### PR TITLE
Fix corrupted game saves

### DIFF
--- a/src/xrGame/alife_registry_container.cpp
+++ b/src/xrGame/alife_registry_container.cpp
@@ -30,16 +30,16 @@ struct RegistryHelper<TContainer, Loki::Typelist<Head, Tail>>
 
     static void Save(TContainer* self, IWriter& writer)
     {
+        RegistryHelper<TContainer, Tail>::Save(self, writer);
         if constexpr (isSerializable)
             self->Head::save(writer);
-        RegistryHelper<TContainer, Tail>::Save(self, writer);
     };
 
     static void Load(TContainer* self, IReader& reader)
     {
+        RegistryHelper<TContainer, Tail>::Load(self, reader);
         if constexpr (isSerializable)
             self->Head::load(reader);
-        RegistryHelper<TContainer, Tail>::Load(self, reader);
     }
 };
 


### PR DESCRIPTION
After refactoring the registry container the registries are saving and loading in incorrect (reverse) order. It leads to loading game tasks registry before map locations registry. But game tasks registry requires data from the map locations registry (map spots, for example) and the game crashes when it can't find the required data.