### PR TITLE
CAI_Space improvement

### DIFF
--- a/src/Common/Common.vcxproj
+++ b/src/Common/Common.vcxproj
@@ -180,6 +180,7 @@
     <ClInclude Include="..\xrCommon\xr_list.h" />
     <ClInclude Include="..\xrCommon\xr_map.h" />
     <ClInclude Include="..\xrCommon\xr_set.h" />
+    <ClInclude Include="..\xrCommon\xr_smart_pointers.h" />
     <ClInclude Include="..\xrCommon\xr_stack.h" />
     <ClInclude Include="..\xrCommon\xr_string.h" />
     <ClInclude Include="..\xrCommon\xr_unordered_map.h" />

--- a/src/Common/Common.vcxproj.filters
+++ b/src/Common/Common.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="..\xrCommon\xr_array.h">
       <Filter>xrCommon</Filter>
     </ClInclude>
+    <ClInclude Include="..\xrCommon\xr_smart_pointers.h">
+      <Filter>xrCommon</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="NvMender2003">

--- a/src/editors/ECore/stdafx.h
+++ b/src/editors/ECore/stdafx.h
@@ -108,6 +108,7 @@ typedef TMsgDlgBtn TMsgDlgButtons[mbHelp];
 #include "xrCore/xr_token.h"
 #include "xrCommon/xr_vector.h"
 #include "xrCommon/xr_string.h"
+#include "xrCommon/xr_smart_pointers.h"
 #include "xrCore/Animation/Bone.hpp"
 #include "xrCore/Animation/Motion.hpp"
 

--- a/src/utils/xrSE_Factory/ai_space.cpp
+++ b/src/utils/xrSE_Factory/ai_space.cpp
@@ -11,9 +11,17 @@
 #include "xrScriptEngine/script_engine.hpp"
 #include "xrServerEntities/object_factory.h"
 
-CAI_Space* g_ai_space = nullptr;
+static CAI_Space g_ai_space;
 
-CAI_Space::CAI_Space() { m_script_engine = nullptr; }
+CAI_Space& CAI_Space::GetInstance()
+{
+    auto& instance = g_ai_space;
+    if (!instance.m_inited)
+    {
+        instance.init();
+    }
+    return instance;
+}
 
 void CAI_Space::RegisterScriptClasses()
 {
@@ -49,13 +57,16 @@ void CAI_Space::RegisterScriptClasses()
 
 void CAI_Space::init()
 {
-    VERIFY(!m_script_engine);
+    R_ASSERT(!m_inited);
+
     VERIFY(!GEnv.ScriptEngine);
-    GEnv.ScriptEngine = m_script_engine = new CScriptEngine(true);
+    GEnv.ScriptEngine = new CScriptEngine(true);
     XRay::ScriptExporter::Reset(); // mark all nodes as undone
-    m_script_engine->init(XRay::ScriptExporter::Export, true);
+    GEnv.ScriptEngine->init(XRay::ScriptExporter::Export, true);
     RegisterScriptClasses();
     object_factory().register_script();
+
+    m_inited = true;
 }
 
-CAI_Space::~CAI_Space() { xr_delete(m_script_engine); }
+CAI_Space::~CAI_Space() { xr_delete(GEnv.ScriptEngine); }

--- a/src/utils/xrSE_Factory/ai_space.h
+++ b/src/utils/xrSE_Factory/ai_space.h
@@ -7,6 +7,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+#include "xrCore/Events/Notifier.h"
 
 class CScriptEngine;
 
@@ -26,6 +27,15 @@ public:
     static CAI_Space& GetInstance();
 
     IC CScriptEngine& script_engine() const;
+
+    enum EEventID
+    {
+        EVENT_SCRIPT_ENGINE_STARTED,
+        EVENT_SCRIPT_ENGINE_RESET,
+        EVENT_COUNT,
+    };
+    CEventNotifierCallback::CID Subscribe(CEventNotifierCallback* cb, EEventID event_id) { return 0; }
+    bool Unsubscribe(CEventNotifierCallback::CID cid, EEventID event_id) { return true; }
 };
 
 IC CAI_Space& ai();

--- a/src/utils/xrSE_Factory/ai_space.h
+++ b/src/utils/xrSE_Factory/ai_space.h
@@ -13,18 +13,20 @@ class CScriptEngine;
 class CAI_Space
 {
 private:
-    CScriptEngine* m_script_engine;
+    bool m_inited = false;
 
+    void init();
     void RegisterScriptClasses();
 
 public:
-    CAI_Space();
+    CAI_Space() = default;
+    CAI_Space(const CAI_Space&) = delete;
+    CAI_Space& operator=(const CAI_Space&) = delete;
     virtual ~CAI_Space();
-    void init();
+    static CAI_Space& GetInstance();
+
     IC CScriptEngine& script_engine() const;
 };
-
-extern CAI_Space* g_ai_space;
 
 IC CAI_Space& ai();
 

--- a/src/utils/xrSE_Factory/ai_space_inline.h
+++ b/src/utils/xrSE_Factory/ai_space_inline.h
@@ -10,16 +10,8 @@
 
 IC CScriptEngine& CAI_Space::script_engine() const
 {
-    VERIFY(m_script_engine);
-    return *m_script_engine;
+    VERIFY(GEnv.ScriptEngine);
+    return *GEnv.ScriptEngine;
 }
 
-IC CAI_Space& ai()
-{
-    if (!g_ai_space)
-    {
-        g_ai_space = new CAI_Space();
-        g_ai_space->init();
-    }
-    return *g_ai_space;
-}
+IC CAI_Space& ai() { return CAI_Space::GetInstance(); }

--- a/src/utils/xrSE_Factory/xrSE_Factory.cpp
+++ b/src/utils/xrSE_Factory/xrSE_Factory.cpp
@@ -60,7 +60,6 @@ BOOL APIENTRY DllMain(HANDLE module_handle, DWORD call_reason, LPVOID reserved)
         auto s = (CInifile**)&pSettings;
         xr_delete(*s);
         xr_delete(g_property_list_helper);
-        xr_delete(g_ai_space);
         xr_delete(g_object_factory);
         if (prop_helper_module)
             prop_helper_module = nullptr;

--- a/src/xrCommon/xr_smart_pointers.h
+++ b/src/xrCommon/xr_smart_pointers.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+template <typename T>
+using xr_unique_ptr = std::unique_ptr<T>;
+
+template <typename T>
+using xr_shared_ptr = std::shared_ptr<T>;
+
+template <class T, class... Args>
+inline xr_unique_ptr<T> xr_make_unique(Args&&... args)
+{
+    return std::make_unique<T>(args...);
+}
+
+template <class T, class... Args>
+inline xr_shared_ptr<T> xr_make_shared(Args&&... args)
+{
+    return std::make_shared<T>(args...);
+}

--- a/src/xrCore/Events/Notifier.h
+++ b/src/xrCore/Events/Notifier.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "xrCommon/xr_smart_pointers.h"
+#include "xrCommon/xr_vector.h"
+#include "xrCommon/xr_array.h"
+#include "xrCore/Threading/Lock.hpp"
+#include "xrCore/Threading/ScopeLock.hpp"
+
+class CEventNotifierCallback
+{
+public:
+    using CID = size_t;
+    static const CID INVALID_CID = std::numeric_limits<CID>::max();
+
+    virtual void ProcessEvent() = 0;
+    virtual ~CEventNotifierCallback(){};
+};
+
+template <unsigned int CNT>
+class CEventNotifier
+{
+private:
+    class CCallbackStorage
+    {
+        class CCallbackWrapper
+        {
+        public:
+            xr_unique_ptr<CEventNotifierCallback> callback;
+            bool destroying = false;
+            bool executing = false;
+
+            CCallbackWrapper(CEventNotifierCallback* cb) : callback(cb){};
+            bool operator==(const CEventNotifierCallback* cb) { return cb == callback.get(); }
+            void Reset()
+            {
+                callback.reset(nullptr);
+                destroying = false;
+                executing = false;
+            }
+        };
+        xr_vector<CCallbackWrapper> m_callbacks;
+        Lock m_lock;
+
+    public:
+        CEventNotifierCallback::CID RegisterCallback(CEventNotifierCallback* cb)
+        {
+            ScopeLock lock(&m_lock);
+            auto it = std::find(m_callbacks.begin(), m_callbacks.end(), nullptr);
+            return (it == m_callbacks.end()) ? (m_callbacks.emplace_back(cb), m_callbacks.size() - 1) :
+                                               (it->callback.reset(cb), std::distance(m_callbacks.begin(), it));
+        }
+
+        bool UnregisterCallback(CEventNotifierCallback::CID cid)
+        {
+            bool result = false;
+            ScopeLock lock(&m_lock);
+            if (cid < m_callbacks.size() && m_callbacks[cid].callback != nullptr)
+            {
+                if (!m_callbacks[cid].destroying)
+                {
+                    result = true;
+                    m_callbacks[cid].destroying = true;
+                }
+
+                if (!m_callbacks[cid].executing)
+                {
+                    m_callbacks[cid].Reset();
+                }
+            }
+            return result;
+        }
+
+        void ExecuteCallbacks()
+        {
+            ScopeLock lock(&m_lock);
+            for (CEventNotifierCallback::CID i = 0; i < m_callbacks.size(); ++i)
+            {
+                auto& cb = m_callbacks[i];
+                if (cb.callback != nullptr && !cb.destroying)
+                {
+                    cb.executing = true;
+                    cb.callback->ProcessEvent();
+                    cb.executing = false;
+
+                    if (cb.destroying)
+                    {
+                        UnregisterCallback(i);
+                    }
+                }
+            }
+        }
+    };
+
+    xr_array<CCallbackStorage, CNT> m_callbacks;
+
+public:
+    CEventNotifierCallback::CID RegisterCallback(CEventNotifierCallback* cb, unsigned int event_id)
+    {
+        R_ASSERT(event_id < CNT);
+        return m_callbacks[event_id].RegisterCallback(cb);
+    }
+
+    bool UnregisterCallback(CEventNotifierCallback::CID cid, unsigned int event_id)
+    {
+        R_ASSERT(event_id < CNT);
+        return m_callbacks[event_id].UnregisterCallback(cid);
+    }
+
+    void FireEvent(unsigned int event_id)
+    {
+        R_ASSERT(event_id < CNT);
+        m_callbacks[event_id].ExecuteCallbacks();
+    }
+};

--- a/src/xrCore/FileSystem.cpp
+++ b/src/xrCore/FileSystem.cpp
@@ -11,7 +11,7 @@
 #include "vfw.h"
 #endif
 
-std::unique_ptr<EFS_Utils> xr_EFS;
+xr_unique_ptr<EFS_Utils> xr_EFS;
 //----------------------------------------------------
 EFS_Utils::EFS_Utils() {}
 EFS_Utils::~EFS_Utils() {}

--- a/src/xrCore/FileSystem.h
+++ b/src/xrCore/FileSystem.h
@@ -42,7 +42,7 @@ public:
     static xr_string ExtractFileExt(LPCSTR src);
     static xr_string ExcludeBasePath(LPCSTR full_path, LPCSTR excl_path);
 };
-extern XRCORE_API std::unique_ptr<EFS_Utils> xr_EFS;
+extern XRCORE_API xr_unique_ptr<EFS_Utils> xr_EFS;
 #define EFS (*xr_EFS)
 
 #endif /*_INCDEF_FileSystem_H_*/

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -26,7 +26,7 @@
 
 const u32 BIG_FILE_READER_WINDOW_SIZE = 1024 * 1024;
 
-std::unique_ptr<CLocatorAPI> xr_FS;
+xr_unique_ptr<CLocatorAPI> xr_FS;
 
 #ifdef _EDITOR
 static constexpr pcstr FSLTX = "fs.ltx"

--- a/src/xrCore/LocatorAPI.h
+++ b/src/xrCore/LocatorAPI.h
@@ -10,6 +10,7 @@
 #include "LocatorAPI_defs.h"
 //#include "xrCore/Threading/Lock.hpp"
 #include "xrCommon/xr_map.h"
+#include "xrCommon/xr_smart_pointers.h"
 #include "xrCommon/predicates.h"
 #include "Common/Noncopyable.hpp"
 
@@ -255,5 +256,5 @@ public:
     void unlock_rescan();
 };
 
-extern XRCORE_API std::unique_ptr<CLocatorAPI> xr_FS;
+extern XRCORE_API xr_unique_ptr<CLocatorAPI> xr_FS;
 #define FS (*xr_FS)

--- a/src/xrCore/ModuleLookup.hpp
+++ b/src/xrCore/ModuleLookup.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <memory>
+#include "xrCommon/xr_smart_pointers.h"
 
 namespace XRay
 {
@@ -23,15 +23,15 @@ public:
     void* GetProcAddress(pcstr procName) const;
 };
 
-using Module = std::unique_ptr<ModuleHandle>;
+using Module = xr_unique_ptr<ModuleHandle>;
 
 inline auto LoadModule(bool dontUnload = false)
 {
-    return std::make_unique<ModuleHandle>(dontUnload);
+    return xr_make_unique<ModuleHandle>(dontUnload);
 }
 
 inline auto LoadModule(pcstr moduleName, bool dontUnload = false)
 {
-    return std::make_unique<ModuleHandle>(moduleName, dontUnload);
+    return xr_make_unique<ModuleHandle>(moduleName, dontUnload);
 }
 }

--- a/src/xrCore/Threading/ThreadPool.hpp
+++ b/src/xrCore/Threading/ThreadPool.hpp
@@ -15,7 +15,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <functional>
-#include <memory>
+#include "xrCommon/xr_smart_pointers.h"
 
 class XRCORE_API Thread
 {
@@ -42,7 +42,7 @@ public:
 class ThreadPool
 {
 public:
-    xr_vector<std::unique_ptr<Thread>> threads;
+    xr_vector<xr_unique_ptr<Thread>> threads;
 
     void initialize()
     {

--- a/src/xrCore/cpuid.cpp
+++ b/src/xrCore/cpuid.cpp
@@ -175,7 +175,7 @@ unsigned int query_processor_info(processor_info* pinfo)
     DWORD byteOffset = 0;
     GetLogicalProcessorInformation(nullptr, &returnedLength);
 
-    auto buffer = std::make_unique<u8[]>(returnedLength);
+    auto buffer = xr_make_unique<u8[]>(returnedLength);
     auto ptr = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION>(buffer.get());
     GetLogicalProcessorInformation(ptr, &returnedLength);
 

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -253,9 +253,9 @@ void xrCore::Initialize(pcstr _ApplicationName, pcstr commandLine, LogCallback c
 
         rtc_initialize();
 
-        xr_FS = std::make_unique<CLocatorAPI>();
+        xr_FS = xr_make_unique<CLocatorAPI>();
 
-        xr_EFS = std::make_unique<EFS_Utils>();
+        xr_EFS = xr_make_unique<EFS_Utils>();
         //. R_ASSERT (co_res==S_OK);
     }
     if (init_fs)

--- a/src/xrCore/xrCore.vcxproj
+++ b/src/xrCore/xrCore.vcxproj
@@ -364,6 +364,7 @@ call .GitInfo.cmd</Command>
     </ClInclude>
     <ClInclude Include="Debug\MiniDump.h" />
     <ClInclude Include="dump_string.h" />
+    <ClInclude Include="Events\Notifier.h" />
     <ClInclude Include="fastdelegate.h" />
     <CustomBuild Include="FileSystem.h" />
     <ClInclude Include="FileCRC32.h" />

--- a/src/xrCore/xrCore.vcxproj.filters
+++ b/src/xrCore/xrCore.vcxproj.filters
@@ -115,6 +115,9 @@
     <Filter Include="xrDelegate">
       <UniqueIdentifier>{b54073c2-213d-456f-b88d-8eeb0dd440b0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Events">
+      <UniqueIdentifier>{f17d865f-a3fd-41ac-b217-d7d34ed591f5}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FTimer.cpp">
@@ -685,6 +688,9 @@
     </ClInclude>
     <ClInclude Include="FileCRC32.h">
       <Filter>FS</Filter>
+    </ClInclude>
+    <ClInclude Include="Events\Notifier.h">
+      <Filter>Events</Filter>
     </ClInclude>
     <ClInclude Include="xrDelegate\xrDelegate.h">
       <Filter>xrDelegate</Filter>

--- a/src/xrGame/Level.cpp
+++ b/src/xrGame/Level.cpp
@@ -110,8 +110,6 @@ CLevel::CLevel()
     Msg("%s", Core.Params);
 }
 
-extern CAI_Space* g_ai_space;
-
 CLevel::~CLevel()
 {
     xr_delete(g_player_hud);

--- a/src/xrGame/MainMenu.cpp
+++ b/src/xrGame/MainMenu.cpp
@@ -67,6 +67,20 @@ CMainMenu* MainMenu() { return (CMainMenu*)g_pGamePersistent->m_pMainMenu; };
 
 CMainMenu::CMainMenu()
 {
+    class CResetEventCb : public CAI_Space::CEventCallback
+    {
+        CMainMenu* m_mainmenu;
+
+    public:
+        CResetEventCb(CMainMenu* mm) : m_mainmenu(mm) {}
+        void ProcessEvent() override
+        {
+            m_mainmenu->DestroyInternal(true);
+        }
+    };
+
+    m_script_reset_event_cid = ai().Subscribe(new CResetEventCb(this), CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
+
     m_Flags.zero();
     m_startDialog = NULL;
     m_screenshotFrame = u32(-1);
@@ -156,6 +170,8 @@ CMainMenu::~CMainMenu()
 
     xr_delete(m_demo_info_loader);
     delete_data(m_pMB_ErrDlgs);
+
+    ai().Unsubscribe(m_script_reset_event_cid, CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
 }
 
 void CMainMenu::ReadTextureInfo()

--- a/src/xrGame/MainMenu.cpp
+++ b/src/xrGame/MainMenu.cpp
@@ -67,19 +67,16 @@ CMainMenu* MainMenu() { return (CMainMenu*)g_pGamePersistent->m_pMainMenu; };
 
 CMainMenu::CMainMenu()
 {
-    class CResetEventCb : public CAI_Space::CEventCallback
+    class CResetEventCb : public CEventNotifierCallback
     {
         CMainMenu* m_mainmenu;
 
     public:
         CResetEventCb(CMainMenu* mm) : m_mainmenu(mm) {}
-        void ProcessEvent() override
-        {
-            m_mainmenu->DestroyInternal(true);
-        }
+        void ProcessEvent() override { m_mainmenu->DestroyInternal(true); }
     };
 
-    m_script_reset_event_cid = ai().Subscribe(new CResetEventCb(this), CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
+    m_script_reset_event_cid = ai().Subscribe(new CResetEventCb(this), CAI_Space::EVENT_SCRIPT_ENGINE_RESET);
 
     m_Flags.zero();
     m_startDialog = NULL;
@@ -171,7 +168,7 @@ CMainMenu::~CMainMenu()
     xr_delete(m_demo_info_loader);
     delete_data(m_pMB_ErrDlgs);
 
-    ai().Unsubscribe(m_script_reset_event_cid, CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
+    ai().Unsubscribe(m_script_reset_event_cid, CAI_Space::EVENT_SCRIPT_ENGINE_RESET);
 }
 
 void CMainMenu::ReadTextureInfo()

--- a/src/xrGame/MainMenu.h
+++ b/src/xrGame/MainMenu.h
@@ -198,7 +198,7 @@ public:
 
     demo_info const* GetDemoInfo(LPCSTR file_name);
 
-    CAI_Space::CEventCallback::CID m_script_reset_event_cid;
+    CEventNotifierCallback::CID m_script_reset_event_cid;
 };
 
 extern CMainMenu* MainMenu();

--- a/src/xrGame/MainMenu.h
+++ b/src/xrGame/MainMenu.h
@@ -15,6 +15,7 @@ class demo_info_loader;
 #include "xrUICore/Callbacks/UIWndCallback.h"
 #include "xrUICore/ui_base.h"
 #include "DemoInfo.h"
+#include "ai_space.h"
 
 namespace gamespy_gp
 {
@@ -196,6 +197,8 @@ public:
     LPCSTR GetCDKeyFromRegistry();
 
     demo_info const* GetDemoInfo(LPCSTR file_name);
+
+    CAI_Space::CEventCallback::CID m_script_reset_event_cid;
 };
 
 extern CMainMenu* MainMenu();

--- a/src/xrGame/ai_space.cpp
+++ b/src/xrGame/ai_space.cpp
@@ -118,9 +118,9 @@ void CAI_Space::init()
     {
         AISpaceBase::Initialize();
 
-        m_ef_storage = std::make_unique<CEF_Storage>();
-        m_cover_manager = std::make_unique<CCoverManager>();
-        m_moving_objects = std::make_unique<::moving_objects>();
+        m_ef_storage = xr_make_unique<CEF_Storage>();
+        m_cover_manager = xr_make_unique<CCoverManager>();
+        m_moving_objects = xr_make_unique<::moving_objects>();
 
         VERIFY(!GEnv.ScriptEngine);
         GEnv.ScriptEngine = new CScriptEngine();

--- a/src/xrGame/ai_space.h
+++ b/src/xrGame/ai_space.h
@@ -10,8 +10,8 @@
 
 #include "xrAICore/AISpaceBase.hpp"
 #include "xrCommon/xr_array.h"
+#include "xrCommon/xr_smart_pointers.h"
 
-#include <memory>
 #include <mutex>
 
 class CGameGraph;
@@ -45,7 +45,7 @@ public:
 
     class CEventCallbackStorage
     {
-        xr_vector<std::unique_ptr<CEventCallback>> m_callbacks;
+        xr_vector<xr_unique_ptr<CEventCallback>> m_callbacks;
         std::mutex m_lock;
 
     public:
@@ -84,10 +84,10 @@ private:
     bool m_inited = false;
     CNotifier m_events_notifier;
 
-    std::unique_ptr<CEF_Storage> m_ef_storage;
-    std::unique_ptr<CCoverManager> m_cover_manager;
-    std::unique_ptr<moving_objects> m_moving_objects;
-    std::unique_ptr<doors::manager> m_doors_manager;
+    xr_unique_ptr<CEF_Storage> m_ef_storage;
+    xr_unique_ptr<CCoverManager> m_cover_manager;
+    xr_unique_ptr<moving_objects> m_moving_objects;
+    xr_unique_ptr<doors::manager> m_doors_manager;
 
     CALifeSimulator* m_alife_simulator = nullptr;
 

--- a/src/xrGame/ai_space.h
+++ b/src/xrGame/ai_space.h
@@ -10,6 +10,8 @@
 
 #include "xrAICore/AISpaceBase.hpp"
 
+#include <memory>
+
 class CGameGraph;
 class CGameLevelCrossTable;
 class CLevelGraph;
@@ -36,13 +38,17 @@ private:
     friend class CLevel;
 
 private:
-    CEF_Storage* m_ef_storage;
-    CALifeSimulator* m_alife_simulator;
-    CCoverManager* m_cover_manager;
-    moving_objects* m_moving_objects;
-    doors::manager* m_doors_manager;
+    bool m_inited = false;
+
+    std::unique_ptr<CEF_Storage> m_ef_storage;
+    std::unique_ptr<CCoverManager> m_cover_manager;
+    std::unique_ptr<moving_objects> m_moving_objects;
+    std::unique_ptr<doors::manager> m_doors_manager;
+
+    CALifeSimulator* m_alife_simulator = nullptr;
 
 private:
+    void init();
     void load(LPCSTR level_name);
     void unload(bool reload = false);
     void set_alife(CALifeSimulator* alife_simulator);
@@ -50,9 +56,12 @@ private:
     void RegisterScriptClasses();
 
 public:
-    CAI_Space();
+    CAI_Space() = default;
+    CAI_Space(const CAI_Space&) = delete;
+    CAI_Space& operator=(const CAI_Space&) = delete;
     virtual ~CAI_Space();
-    void init();
+    static CAI_Space& GetInstance();
+
     void SetupScriptEngine();
     IC CEF_Storage& ef_storage() const;
 
@@ -64,7 +73,5 @@ public:
 };
 
 IC CAI_Space& ai();
-
-extern CAI_Space* g_ai_space;
 
 #include "ai_space_inline.h"

--- a/src/xrGame/ai_space_inline.h
+++ b/src/xrGame/ai_space_inline.h
@@ -39,12 +39,4 @@ IC doors::manager& CAI_Space::doors() const
     return (*m_doors_manager);
 }
 
-IC CAI_Space& ai()
-{
-    if (!g_ai_space)
-    {
-        g_ai_space = new CAI_Space();
-        g_ai_space->init();
-    }
-    return (*g_ai_space);
-}
+IC CAI_Space& ai() { return CAI_Space::GetInstance(); }

--- a/src/xrGame/alife_simulator.cpp
+++ b/src/xrGame/alife_simulator.cpp
@@ -23,7 +23,6 @@
 
 LPCSTR alife_section = "alife";
 
-extern void destroy_lua_wpn_params();
 
 CALifeSimulator::CALifeSimulator(IPureServer* server, shared_str* command_line)
     : CALifeUpdateManager(server, alife_section), CALifeInteractionManager(server, alife_section),
@@ -32,13 +31,7 @@ CALifeSimulator::CALifeSimulator(IPureServer* server, shared_str* command_line)
     // XXX: why do we need to reinitialize script engine?
     if (!strstr(Core.Params, "-keep_lua"))
     {
-        destroy_lua_wpn_params();
-        MainMenu()->DestroyInternal(true);
-        xr_delete(g_object_factory);
-        ai().SetupScriptEngine();
-#ifdef DEBUG
-        ai().get_moving_objects().clear();
-#endif // DEBUG
+        ai().RestartScriptEngine();
     }
 
     ai().set_alife(this);

--- a/src/xrGame/xrgame_dll_detach.cpp
+++ b/src/xrGame/xrgame_dll_detach.cpp
@@ -58,11 +58,9 @@ void init_game_globals()
 extern CUIXml* g_uiSpotXml;
 extern CUIXml* pWpnScopeXml;
 
-extern void destroy_lua_wpn_params();
 
 void clean_game_globals()
 {
-    destroy_lua_wpn_params();
     // destroy object factory
     xr_delete(g_object_factory);
     // destroy monster squad global var

--- a/src/xrGame/xrgame_dll_detach.cpp
+++ b/src/xrGame/xrgame_dll_detach.cpp
@@ -63,8 +63,6 @@ extern void destroy_lua_wpn_params();
 void clean_game_globals()
 {
     destroy_lua_wpn_params();
-    // destroy ai space
-    xr_delete(g_ai_space);
     // destroy object factory
     xr_delete(g_object_factory);
     // destroy monster squad global var

--- a/src/xrServerEntities/object_factory.h
+++ b/src/xrServerEntities/object_factory.h
@@ -6,9 +6,6 @@
 //	Description : Object factory
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef object_factoryH
-#define object_factoryH
-
 #pragma once
 
 #include "object_item_abstract.h"
@@ -91,4 +88,3 @@ extern CObjectFactory* g_object_factory;
 IC const CObjectFactory& object_factory();
 
 #include "object_factory_inline.h"
-#endif

--- a/src/xrServerEntities/object_factory_inline.h
+++ b/src/xrServerEntities/object_factory_inline.h
@@ -8,6 +8,8 @@
 
 #pragma once
 #include <algorithm>
+#include "ai_space.h"
+#include "xrCore/Events/Notifier.h"
 
 IC const CObjectFactory& object_factory()
 {
@@ -16,26 +18,20 @@ IC const CObjectFactory& object_factory()
         g_object_factory = new CObjectFactory();
         g_object_factory->init();
 
-        class CResetEventCb : public CAI_Space::CEventCallback
+        class CResetEventCb : public CEventNotifierCallback
         {
-            CAI_Space::CEventCallback::CID m_cid;
-
         public:
-            CResetEventCb() {}
-            void SetCid(CAI_Space::CEventCallback::CID cid) { m_cid = cid; }
+            CID m_cid;
+
             void ProcessEvent() override
             {
                 xr_delete(g_object_factory);
+                ai().Unsubscribe(m_cid, CAI_Space::EVENT_SCRIPT_ENGINE_RESET);
             }
         };
 
-        static CAI_Space::CEventCallback::CID cid = CAI_Space::CEventCallback::INVALID_CID;
-        if (cid == CAI_Space::CEventCallback::INVALID_CID)
-        {
-            CResetEventCb* e = new CResetEventCb();
-            cid = ai().Subscribe(e, CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
-            e->SetCid(cid);
-        }
+        CResetEventCb* e = new CResetEventCb();
+        e->m_cid = ai().Subscribe(e, CAI_Space::EVENT_SCRIPT_ENGINE_RESET);
     }
     return (*g_object_factory);
 }

--- a/src/xrServerEntities/object_factory_inline.h
+++ b/src/xrServerEntities/object_factory_inline.h
@@ -7,8 +7,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#ifndef object_factory_inlineH
-#define object_factory_inlineH
 #include <algorithm>
 
 IC const CObjectFactory& object_factory()
@@ -17,6 +15,27 @@ IC const CObjectFactory& object_factory()
     {
         g_object_factory = new CObjectFactory();
         g_object_factory->init();
+
+        class CResetEventCb : public CAI_Space::CEventCallback
+        {
+            CAI_Space::CEventCallback::CID m_cid;
+
+        public:
+            CResetEventCb() {}
+            void SetCid(CAI_Space::CEventCallback::CID cid) { m_cid = cid; }
+            void ProcessEvent() override
+            {
+                xr_delete(g_object_factory);
+            }
+        };
+
+        static CAI_Space::CEventCallback::CID cid = CAI_Space::CEventCallback::INVALID_CID;
+        if (cid == CAI_Space::CEventCallback::INVALID_CID)
+        {
+            CResetEventCb* e = new CResetEventCb();
+            cid = ai().Subscribe(e, CAI_Space::CNotifier::EVENT_SCRIPT_ENGINE_RESET);
+            e->SetCid(cid);
+        }
     }
     return (*g_object_factory);
 }
@@ -125,5 +144,3 @@ IC void CObjectFactory::actualize() const
     m_actual = true;
     std::sort(m_clsids.begin(), m_clsids.end(), CObjectItemPredicate());
 }
-
-#endif


### PR DESCRIPTION

    Get rid of raw pointers in CAI_Space, use smart pointers instead
    Make instance of CAI_Space static object (instead of maintaining global raw pointer to it)
    Add CEventNotifier class to xrCore
    Add events for script engine restarting in CAI_Space
    Get rid of hack in CALifeSimulator constructor
    Add wrapper classes xr_unique_ptr and xr_shared_ptr (will be useful in case of returning xr_new)
    Replace usage of std::unique_ptr to xr_unique_ptr
