### PR TITLE
More user-friendly report of missing keys

### DIFF
--- a/src/xrEngine/xr_input.cpp
+++ b/src/xrEngine/xr_input.cpp
@@ -207,10 +207,7 @@ bool CInput::get_dik_name(int dik, LPSTR dest_str, int dest_sz)
         if (dik == SDL_SCANCODE_UNKNOWN)
             keyname = "Unknown";
         else
-        {
-            Msg("! Can't convert dik_name for dik[%d]", dik);
             return false;
-        }
     }
 
     xr_strcpy(dest_str, dest_sz, keyname.c_str());

--- a/src/xrGame/xr_level_controller.cpp
+++ b/src/xrGame/xr_level_controller.cpp
@@ -37,15 +37,13 @@ void initialize_bindings()
 
 void remap_keys()
 {
-    int idx = 0;
     string128 buff;
     // Log("Keys remap:");
-    while (keyboards[idx].key_name)
+    for (int idx = 0; keyboards[idx].key_name; ++idx)
     {
         buff[0] = 0;
         _keyboard& kb = keyboards[idx];
-        const bool res = pInput->get_dik_name(kb.dik, buff, sizeof(buff));
-        if (res)
+        if (pInput->get_dik_name(kb.dik, buff, sizeof(buff)))
             kb.key_local_name = buff;
         else
         {
@@ -55,7 +53,6 @@ void remap_keys()
         }
 
         // Msg("[%s]-[%s]", kb.key_name, kb.key_local_name.c_str());
-        ++idx;
     }
 }
 

--- a/src/xrGame/xr_level_controller.cpp
+++ b/src/xrGame/xr_level_controller.cpp
@@ -47,8 +47,12 @@ void remap_keys()
         const bool res = pInput->get_dik_name(kb.dik, buff, sizeof(buff));
         if (res)
             kb.key_local_name = buff;
-        else if (kb.key_local_name.empty())
-            kb.key_local_name = kb.key_name;
+        else
+        {
+            Msg("! Can't find a key name for %s", kb.key_name);
+            if (kb.key_local_name.empty())
+                kb.key_local_name = kb.key_name;
+        }
 
         // Msg("[%s]-[%s]", kb.key_name, kb.key_local_name.c_str());
         ++idx;


### PR DESCRIPTION
This warning will almost surely show in the log file. This intends to make this warning more readable.

Before:
```
! Can't convert dik_name for dik[47]
! Can't convert dik_name for dik[52]
! Can't convert dik_name for dik[102]
! Can't convert dik_name for dik[104]
! Can't convert dik_name for dik[105]
! Can't convert dik_name for dik[106]
! Can't convert dik_name for dik[107]
! Can't convert dik_name for dik[108]
! Can't convert dik_name for dik[109]
! Can't convert dik_name for dik[110]
! Can't convert dik_name for dik[123]
! Can't convert dik_name for dik[124]
```
After:
```
! Can't find a key for kLBRACKET
! Can't find a key for kAPOSTROPHE
! Can't find a key for kPOWER
! Can't find a key for kF13
! Can't find a key for kF14
! Can't find a key for kF15
! Can't find a key for kF16
! Can't find a key for kF17
! Can't find a key for kF18
! Can't find a key for kF19
! Can't find a key for kCUT
! Can't find a key for kCOPY
```