### PR TITLE
README

### DIFF
--- a/CONTRIBUTE
+++ b/CONTRIBUTE
@@ -1,0 +1,5 @@
+CONTRIBUTING
+============
+Guidelines and conventions
+--------------------------
+Please see https://github.com/OpenXRay/xray-16/tree/xd_dev/doc/procedure

--- a/DEBUG.linux
+++ b/DEBUG.linux
@@ -1,0 +1,9 @@
+DEBUGGING
+=========
+First, build with debugging enabled (see INSTALL.linux)
+
+Then run it like this:
+DEBUGGER="gdb --ex=r --args" ./xr_3da.sh -fsltx ../fsgame.ltx
+
+Disable input grabbing:
+setxkbmap -option grab:break_actions 

--- a/INSTALL.linux
+++ b/INSTALL.linux
@@ -1,0 +1,69 @@
+1. PREREQUISITES
+================
+Utils
+-----
+CMake     - cmake.org (open-source build system generator)
+
+Libraries
+---------
+BugTrap   - https://github.com/Xottab-DUTY/BugTrap
+CryptoPP  - https://github.com/weidai11/cryptopp
+FreeImage - http://freeimage.sourceforge.net
+FreeMagic - https://github.com/OpenXRay/FreeMagic
+GameSpy   - https://github.com/nitrocaster/GameSpy
+libjpeg   - https://github.com/OpenXRay/libjpeg
+libogg    - http://xiph.org/downloads
+libtheora - http://xiph.org/downloads
+libvorbis - http://xiph.org/downloads
+Lightwave - https://github.com/OpenXRay/LightWave
+Luabind   - https://github.com/Xottab-DUTY/luabind-deboostified
+LuaJIT    - https://github.com/Xottab-DUTY/LuaJIT
+lzo       - https://github.com/alexgdi/lzo
+NVAPI     - https://developer.nvidia.com/nvapi
+pugixml   - https://github.com/zeux/pugixml/
+zlib      - http://zlib.net
+OpenAutomate - https://developer.nvidia.com/openautomate
+Autodesk Maya 2008/2009 SDK - https://github.com/OpenXRay/maya
+Autodesk 3DS Max 6.0 SDK - https://github.com/OpenXRay/3dsmax
+
+Distro packages
+---------------
+* Ubuntu Bionic 18.04
+cmake libglew-dev libfreeimage-dev liblockfile-dev libopenal-dev libtbb-dev libcrypto++-dev libpugixml-dev libogg-dev libtheora-dev libvorbis-dev libsdl2-dev liblzo2-dev libjpeg-dev libncurses5-dev libreadline-dev
+
+* Fedora 2?
+cmake glew-devel freeimage-devel liblockfile-devel openal-devel tbb-devel cryptopp-devel pugixml-devel libogg-devel libtheora-devel libvorbis-devel SDL2-devel lzo-devel libjpeg-turbo-devel
+
+Getting the source
+------------------
+cd
+git clone https://github.com/OpenXRay/xray-16.git --recurse-submodules
+
+2. BUILD
+========
+cd xray-16
+mkdir build
+cd build
+cmake ..
+make -jX #where X is the number of build host CPU cores
+
+Build options
+-------------
+* Enable debugging:
+cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+* Compile with clang:
+CC=clang CXX=clang++ cmake ..
+
+* Optimize for the host CPU:
+CFLAGS="-march=native" CXXFLAGS="-march=native" cmake ..
+
+3. INSTALL
+==========
+mkdir -p ~/scop/linux
+make DESTDIR=~/scop/linux install
+cp -r ../res/* ~/scop/
+
+4. SETUP AND RUN
+================
+For setting up and launching instructions, please see SETUP.linux and USAGE.linux

--- a/INSTALL.linux
+++ b/INSTALL.linux
@@ -49,6 +49,9 @@ make -jX
 
 Build options
 -------------
+# Generate compile DB (for code analysis)
+cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+
 # Enable debugging
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
 

--- a/INSTALL.linux
+++ b/INSTALL.linux
@@ -28,15 +28,14 @@ Autodesk 3DS Max 6.0 SDK - https://github.com/OpenXRay/3dsmax
 
 Distro packages
 ---------------
-* Ubuntu Bionic 18.04
+# Ubuntu Bionic 18.04
 cmake libglew-dev libfreeimage-dev liblockfile-dev libopenal-dev libtbb-dev libcrypto++-dev libpugixml-dev libogg-dev libtheora-dev libvorbis-dev libsdl2-dev liblzo2-dev libjpeg-dev libncurses5-dev libreadline-dev
 
-* Fedora 2?
+# Fedora 2?
 cmake glew-devel freeimage-devel liblockfile-devel openal-devel tbb-devel cryptopp-devel pugixml-devel libogg-devel libtheora-devel libvorbis-devel SDL2-devel lzo-devel libjpeg-turbo-devel
 
 Getting the source
 ------------------
-cd
 git clone https://github.com/OpenXRay/xray-16.git --recurse-submodules
 
 2. BUILD
@@ -45,23 +44,26 @@ cd xray-16
 mkdir build
 cd build
 cmake ..
-make -jX #where X is the number of build host CPU cores
+# X - max simultaneous jobs make will invoke
+make -jX
 
 Build options
 -------------
-* Enable debugging:
+# Enable debugging
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-* Compile with clang:
+# Compile with clang
 CC=clang CXX=clang++ cmake ..
 
-* Optimize for the host CPU:
+# Optimize for the host CPU
 CFLAGS="-march=native" CXXFLAGS="-march=native" cmake ..
 
 3. INSTALL
 ==========
+# Directory to hold the binaries
 mkdir -p ~/scop/linux
 make DESTDIR=~/scop/linux install
+# Some configs & resources distributed with xray-16
 cp -r ../res/* ~/scop/
 
 4. SETUP AND RUN

--- a/README
+++ b/README
@@ -1,0 +1,43 @@
+WELCOME TO THE XRAY-16 PROJECT!
+===============================
+This README file is for the xray-16 computer game engine.
+
+xray-16 is a development of the engine used in STALKER: Call of Pripyat game
+originally developed by GSC Game World and released in 2009.
+
+It's an effort to get the code into a better shape by fixing bugs and
+refactoring the code.
+It is collectively developed by the OpenXRay community (github.com/OpenXRay).
+It supports GNU/Linux and MS Windows™ on x86/x64 platforms.
+
+LICENSING NOTES
+===============
+Be advised that at the time of writing, this project is NOT endorsed by GSC
+Game World in any way – GSC remains the copyright holder for the original
+source code.
+
+System requirements
+===================
+Supported OSes
+--------------
+* GNU/Linux
+* BSD (?)
+* MS Windows™
+
+Supported platforms
+-------------------
+* x86
+* x64
+
+Hardware requirements
+---------------------
+???
+
+Manifest
+========
+README        - this file
+INSTALL.linux - build instructions
+SETUP.linux   - setting up game files for xray-16
+USAGE.linux   - launching the game and other options
+DEBUG.linux   - debugging instructions
+CONTRIBUTE    - contributing guidelines

--- a/SETUP.linux
+++ b/SETUP.linux
@@ -1,0 +1,51 @@
+1. RUNTIME REQUIREMENTS
+=======================
+Libraries
+---------
+GLEW      - glew.sourceforge.net (open-source C/C++ extension loading library)
+FreeImage - freeimage.sourceforge.net (Open Source library to support popular graphics image formats)
+lockfile  - github.com/miquels/liblockfile (create, manage and remove generic lockfiles)
+OpenAL    - www.openal.org (cross-platform 3D audio API)
+TBB       - www.threadingbuildingblocks.org (C++ template library for task parallelism)
+Crypto++  - www.cryptopp.com (free C++ class library of cryptographic schemes)
+pugixml   - pugixml.org (C++ XML processing library)
+Theora    - www.theora.org (free and open video compression format)
+OGG       - xiph.org/ogg (multimedia container format, and the native file and stream format)
+SDL2      - www.libsdl.org (low level access to audio, keyboard, mouse, joystick, and graphics hardware)
+LZO       - www.oberhumer.com/opensource/lzo (portable lossless data compression library written in ANSI C)
+libjpeg   - libjpeg-turbo.org (JPEG runtime library)
+
+Utils
+-----
+innoextract - constexpr.org/innoextract (used to extract files from the GOG installer)
+
+Distro packages
+---------------
+* Ubuntu Bionic 18.04
+innoextract libglew2.0 libfreeimage3 liblockfile1 libopenal1 libtbb2 libcrypto++6 libpugixml1v5 libtheora0 libogg0 libsdl2-2.0-0 liblzo2-2 libjpeg8
+
+* Fedora
+???
+
+2. GAME FILES
+=============
+From GOG installer
+------------------
+* Extract game files (note the -g switch)
+innoextract -g 'setup_stalker_cop_2.1.0.17.exe'
+
+* Move the files to the desired directory
+# should already be there if you've followed INSTALL
+mkdir ~/scop
+mv game/* ~/scop
+cd ~/scop
+
+-OR-
+
+From retail release
+-------------------
+* Extract
+* RUSSIAN RELEASE ONLY - Install patch 1.6.02
+http://cop.stalker-game.ru/?page=patches#2
+wget 'http://files.gsc-game.com/st/cop/setup-cop-rp-any-02.exe'
+* ???

--- a/SETUP.linux
+++ b/SETUP.linux
@@ -1,5 +1,8 @@
+If compiling from source, please see INSTALL.linux
+
 1. RUNTIME REQUIREMENTS
 =======================
+
 Libraries
 ---------
 GLEW      - glew.sourceforge.net (open-source C/C++ extension loading library)
@@ -18,34 +21,32 @@ libjpeg   - libjpeg-turbo.org (JPEG runtime library)
 Utils
 -----
 innoextract - constexpr.org/innoextract (used to extract files from the GOG installer)
+unrar - www.rarlabs.com (needed by innoextract to unpack additional *.bin archives)
 
 Distro packages
 ---------------
-* Ubuntu Bionic 18.04
-innoextract libglew2.0 libfreeimage3 liblockfile1 libopenal1 libtbb2 libcrypto++6 libpugixml1v5 libtheora0 libogg0 libsdl2-2.0-0 liblzo2-2 libjpeg8
+# Ubuntu Bionic 18.04
+innoextract unrar libglew2.0 libfreeimage3 liblockfile1 libopenal1 libtbb2 libcrypto++6 libpugixml1v5 libtheora0 libogg0 libsdl2-2.0-0 liblzo2-2 libjpeg8
 
-* Fedora
+# Fedora
 ???
 
 2. GAME FILES
 =============
 From GOG installer
 ------------------
-* Extract game files (note the -g switch)
+# Extract game files (note the -g switch)
 innoextract -g 'setup_stalker_cop_2.1.0.17.exe'
 
-* Move the files to the desired directory
-# should already be there if you've followed INSTALL
-mkdir ~/scop
+# Move the files to the desired directory
 mv game/* ~/scop
-cd ~/scop
 
 -OR-
 
 From retail release
 -------------------
-* Extract
-* RUSSIAN RELEASE ONLY - Install patch 1.6.02
+# Extract
+# RUSSIAN RELEASE ONLY - Install patch 1.6.02
 http://cop.stalker-game.ru/?page=patches#2
 wget 'http://files.gsc-game.com/st/cop/setup-cop-rp-any-02.exe'
-* ???
+# ???

--- a/USAGE.linux
+++ b/USAGE.linux
@@ -1,0 +1,8 @@
+LAUNCH
+======
+
+# cd where you have put the binaries
+cd ~/scop/linux
+
+# fsgame.ltx comes from the res/ dir
+./xr_3da.sh -fsltx ../fsgame.ltx

--- a/USAGE.linux
+++ b/USAGE.linux
@@ -1,8 +1,8 @@
 LAUNCH
 ======
 
-# cd where you have put the binaries
+# cd to where you have put the binaries
 cd ~/scop/linux
 
-# fsgame.ltx comes from the res/ dir
+# 'fsgame.ltx' can be found in the xray-16 res/ dir
 ./xr_3da.sh -fsltx ../fsgame.ltx

--- a/USAGE.linux
+++ b/USAGE.linux
@@ -6,3 +6,10 @@ cd ~/scop/linux
 
 # 'fsgame.ltx' can be found in the xray-16 res/ dir
 ./xr_3da.sh -fsltx ../fsgame.ltx
+
+# Options
+-fsltx		mandatory if fsgame.ltx not in the same directory as 
+-use_gl_4.1	[removed] use OpenGL profile 4.1
+-nosplash	disable splash screen
+-splashnotop???
+-dedicated	launch dedicated server


### PR DESCRIPTION
Documentation rehash.
What's there now is hopelessly convoluted and outdated.

Mostly build / setup instructions for Linux, but extensible to other platforms.

Notably instructions are now split into different files.
Also does away with mentioning wine (tho it probably still needed if installing from retail release - section about which is unfinished)