### PR TITLE
Make tbb memory allocator optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,7 @@ if(NOT WIN32)
 endif()
 
 option ( TBB_PARALLEL "Use tbb::parallel for prarticle and skinning acceleration on SMP." ON )
-
-if(WIN32)
-option ( TBB_ALLOCATOR "Use tbb memory allocation" ON)
-else()
-option ( TBB_ALLOCATOR "Use tbb memory allocation" OFF)
-endif()
+option ( NO_TBB_MALLOC "Use standard memory allocation instead of tbbmalloc" ON )
 
 include(cotire)
 
@@ -91,8 +86,8 @@ if( TBB_PARALLEL )
   add_definitions ( -DUSE_TBB_PARALLEL )
 endif()
 
-if( TBB_ALLOCATOR )
-  add_definitions ( -DUSE_TBB_ALLOCATOR )
+if( NO_TBB_MALLOC )
+  add_definitions ( -DNO_TBB_MALLOC )
 endif()
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ endif()
 
 option ( TBB_PARALLEL "Use tbb::parallel for prarticle and skinning acceleration on SMP." ON )
 
+if(WIN32)
+option ( TBB_ALLOCATOR "Use tbb memory allocation" ON)
+else()
+option ( TBB_ALLOCATOR "Use tbb memory allocation" OFF)
+endif()
+
 include(cotire)
 
 function(xr_install tgt)
@@ -83,6 +89,10 @@ endif()
 
 if( TBB_PARALLEL )
   add_definitions ( -DUSE_TBB_PARALLEL )
+endif()
+
+if( TBB_ALLOCATOR )
+  add_definitions ( -DUSE_TBB_ALLOCATOR )
 endif()
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")

--- a/src/xrCommon/xr_deque.h
+++ b/src/xrCommon/xr_deque.h
@@ -2,7 +2,7 @@
 #include <deque>
 #include "xrCore/xrMemory.h"
 
-template <typename T, typename allocator = tbb::tbb_allocator<T>>
+template <typename T, typename allocator = xr_allocator<T>>
 using xr_deque = std::deque<T, allocator>;
 
 #define DEF_DEQUE(N, T)\

--- a/src/xrCommon/xr_list.h
+++ b/src/xrCommon/xr_list.h
@@ -2,7 +2,7 @@
 #include <list>
 #include "xrCore/xrMemory.h"
 
-template <typename T, typename allocator = tbb::tbb_allocator<T>>
+template <typename T, typename allocator = xr_allocator<T>>
 using xr_list = std::list<T, allocator>;
 
 #define DEF_LIST(N, T)\

--- a/src/xrCommon/xr_map.h
+++ b/src/xrCommon/xr_map.h
@@ -2,10 +2,10 @@
 #include <map>
 #include "xrCore/xrMemory.h"
 
-template <typename K, class V, class P = std::less<K>, typename allocator = tbb::tbb_allocator<std::pair<const K, V>>>
+template <typename K, class V, class P = std::less<K>, typename allocator = xr_allocator<std::pair<const K, V>>>
 using xr_map = std::map<K, V, P, allocator>;
 
-template <typename K, class V, class P = std::less<K>, typename allocator = tbb::tbb_allocator<std::pair<const K, V>>>
+template <typename K, class V, class P = std::less<K>, typename allocator = xr_allocator<std::pair<const K, V>>>
 using xr_multimap = std::multimap<K, V, P, allocator>;
 
 #define DEF_MAP(N, K, T)\

--- a/src/xrCommon/xr_set.h
+++ b/src/xrCommon/xr_set.h
@@ -2,10 +2,10 @@
 #include <set>
 #include "xrCore/xrMemory.h"
 
-template <typename K, class P = std::less<K>, typename allocator = tbb::tbb_allocator<K>>
+template <typename K, class P = std::less<K>, typename allocator = xr_allocator<K>>
 using xr_set = std::set<K, P, allocator>;
 
-template <typename K, class P = std::less<K>, typename allocator = tbb::tbb_allocator<K>>
+template <typename K, class P = std::less<K>, typename allocator = xr_allocator<K>>
 using xr_multiset = std::multiset<K, P, allocator>;
 
 #define DEFINE_SET(T, N, I)\

--- a/src/xrCommon/xr_string.h
+++ b/src/xrCommon/xr_string.h
@@ -3,7 +3,7 @@
 #include "xrCore/xrMemory.h"
 
 // string(char)
-using xr_string = std::basic_string<char, std::char_traits<char>, tbb::tbb_allocator<char>>;
+using xr_string = std::basic_string<char, std::char_traits<char>, xr_allocator<char>>;
 
 inline void xr_strlwr(xr_string& src)
 {

--- a/src/xrCommon/xr_unordered_map.h
+++ b/src/xrCommon/xr_unordered_map.h
@@ -3,5 +3,5 @@
 #include "xrCore/xrMemory.h"
 
 template <typename K, class V, class Hasher = std::hash<K>, class Traits = std::equal_to<K>,
-          typename allocator = tbb::tbb_allocator<std::pair<const K, V>>>
+          typename allocator = xr_allocator<std::pair<const K, V>>>
 using xr_unordered_map = std::unordered_map<K, V, Hasher, Traits, allocator>;

--- a/src/xrCommon/xr_vector.h
+++ b/src/xrCommon/xr_vector.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include "xrCore/xrMemory.h"
 
-template <typename T, typename allocator = tbb::tbb_allocator<T>>
+template <typename T, typename allocator = xr_allocator<T>>
 using xr_vector = std::vector<T, allocator>;
 
 #define DEF_VECTOR(N, T)\

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -96,7 +96,7 @@ void xrMemory::mem_compact()
     которые требуют большие свободные области памяти.
     Но всё-же чистку tbb, возможно, стоит оставить. Но и это под большим вопросом.
     */
-    scalable_allocation_command(TBBMALLOC_CLEAN_ALL_BUFFERS, nullptr);
+    // scalable_allocation_command(TBBMALLOC_CLEAN_ALL_BUFFERS, nullptr);
     //HeapCompact(GetProcessHeap(), 0);
     if (g_pStringContainer)
         g_pStringContainer->clean();

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -96,7 +96,9 @@ void xrMemory::mem_compact()
     которые требуют большие свободные области памяти.
     Но всё-же чистку tbb, возможно, стоит оставить. Но и это под большим вопросом.
     */
-    // scalable_allocation_command(TBBMALLOC_CLEAN_ALL_BUFFERS, nullptr);
+#ifndef NO_TBB_MALLOC
+    scalable_allocation_command(TBBMALLOC_CLEAN_ALL_BUFFERS, nullptr);
+#endif
     //HeapCompact(GetProcessHeap(), 0);
     if (g_pStringContainer)
         g_pStringContainer->clean();

--- a/src/xrCore/xrMemory.h
+++ b/src/xrCore/xrMemory.h
@@ -20,6 +20,7 @@ using xr_allocator = std::allocator<T>;
 #define xr_internal_free free
 
 #else
+#include <tbb/tbb_allocator.h>
 #include <tbb/scalable_allocator.h>
 
 template <typename T>

--- a/src/xrCore/xrMemory.h
+++ b/src/xrCore/xrMemory.h
@@ -2,9 +2,6 @@
 
 #include "_types.h"
 
-#include <tbb/tbb_allocator.h>
-#include <tbb/scalable_allocator.h>
-
 /*
 Можно заключить - прокси перехватывает не всегда и/или не всё используемые функции.
 И в очень малом количестве случаев это приводит к странностям при работе с памятью.
@@ -14,6 +11,24 @@
 #if defined(WINDOWS) // I have not idea how it works on Windows, but Linux build fails with error 'multiple declaration of __TBB_malloc_proxy_helper_object'
 //#include "tbb/tbbmalloc_proxy.h" // Xottab_DUTY: works bad, disabled it..
 #endif
+
+#ifdef USE_TBB_ALLOCATOR
+#include <tbb/scalable_allocator.h>
+
+template <typename T>
+using xr_allocator = tbb::scalable_allocator<T>;
+#define xr_internal_malloc scalable_malloc
+#define xr_internal_realloc scalable_realloc
+#define xr_internal_free scalable_free
+
+#else
+template <typename T>
+using xr_allocator = std::allocator<T>;
+#define xr_internal_malloc malloc
+#define xr_internal_realloc realloc
+#define xr_internal_free free
+#endif
+
 
 class XRCORE_API xrMemory
 {
@@ -35,9 +50,26 @@ public:
 public:
     size_t mem_usage();
     void   mem_compact();
-    inline void* mem_alloc             (size_t size) { stat_calls++; return scalable_malloc (     size + reserved); }
-    inline void* mem_realloc(void* ptr, size_t size) { stat_calls++; return scalable_realloc(ptr, size + reserved); }
-    inline void  mem_free   (void* ptr)              { stat_calls++;        scalable_free   (ptr);                  }
+
+    inline void* mem_alloc(size_t size)
+    {
+        stat_calls++;
+        return xr_internal_malloc(size);
+    }
+
+    inline void* mem_realloc(void* ptr, size_t new_size)
+    // reallocation is seldom used in the engine
+    // so I don't think this poor algo will significantly decrease performance
+    {
+        stat_calls++;
+        return xr_internal_realloc(ptr, new_size);
+    }
+
+    inline void mem_free(void* ptr)
+    {
+        stat_calls++;
+        xr_internal_free(ptr);
+    }
 };
 
 extern XRCORE_API xrMemory Memory;


### PR DESCRIPTION
`tbb memoty allocator` causes errors on Linux systems with opensource GPU drivers.
Made it optional. Turned off by default on Linux. Windows will build *with* tbb allocator.
This PR doesn't change tbb's parallel_for etc.

Hopefully it will fix #295 for everyone.