### PR TITLE
Editorconfig: UTF-8 w\b is set as the default encoding

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 # 4 space indentation
 [*.{cpp,h,hpp}]
+charset = utf-8
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
Should force Visual Studio to save all files as UTF-8 (without BOM) by default. At least it work for me.