### PR TITLE
FixedMAP comeback

### DIFF
--- a/src/Layers/xrRender/D3DXRenderBase.h
+++ b/src/Layers/xrRender/D3DXRenderBase.h
@@ -68,6 +68,7 @@ public:
     xr_vector<R_dsgraph::mapMatrixStates::value_type *> matStates;
     xr_vector<R_dsgraph::mapMatrixTextures::value_type *> matTextures;
     xr_vector<R_dsgraph::mapMatrixTextures::value_type *> matTexturesTemp;
+    xr_vector<R_dsgraph::_LodItem> lstLODs;
     xr_vector<int> lstLODgroups;
     xr_vector<ISpatial*> lstRenderables;
     xr_vector<ISpatial*> lstSpatial;
@@ -128,6 +129,7 @@ public:
         matTextures.clear();
         matTexturesTemp.clear();
 
+        lstLODs.clear();
         lstLODgroups.clear();
         lstRenderables.clear();
         lstSpatial.clear();
@@ -135,16 +137,16 @@ public:
 
         for (int i = 0; i < SHADER_PASSES_MAX; ++i)
         {
-            mapNormalPasses[0][i].clear();
-            mapNormalPasses[1][i].clear();
-            mapMatrixPasses[0][i].clear();
-            mapMatrixPasses[1][i].clear();
+            mapNormalPasses[0][i].destroy();
+            mapNormalPasses[1][i].destroy();
+            mapMatrixPasses[0][i].destroy();
+            mapMatrixPasses[1][i].destroy();
         }
-        mapSorted.clear();
-        mapHUD.clear();
-        mapLOD.clear();
-        mapDistort.clear();
-        mapHUDSorted.clear();
+        mapSorted.destroy();
+        mapHUD.destroy();
+        mapLOD.destroy();
+        mapDistort.destroy();
+        mapHUDSorted.destroy();
 
 #if RENDER != R_R1
         mapWmark.clear();

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -60,7 +60,7 @@ void D3DXRenderBase::r_dsgraph_insert_dynamic(dxRender_Visual* pVisual, Fvector&
     ShaderElement* sh_d = &*pVisual->shader->E[4]; // 4=L_special
     if (RImplementation.o.distortion && sh_d && sh_d->flags.bDistort && pmask[sh_d->flags.iPriority / 2])
     {
-        mapDistort.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d }))); // sh_d -> L_special
+        mapDistort.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d })); // sh_d -> L_special
     }
 
     // Select shader
@@ -74,13 +74,13 @@ void D3DXRenderBase::r_dsgraph_insert_dynamic(dxRender_Visual* pVisual, Fvector&
     if (RI.val_bHUD)
     {
         if (sh->flags.bStrictB2F)
-            mapHUDSorted.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh })));
+            mapHUDSorted.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh }));
         else
-            mapHUD      .emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh })));
+            mapHUD      .insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh }));
 
 #if RENDER != R_R1
         if (sh->flags.bEmissive)
-            mapHUDEmissive.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d }))); // sh_d -> L_special
+            mapHUDEmissive.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d })); // sh_d -> L_special
 #endif
         return;
     }
@@ -95,7 +95,7 @@ void D3DXRenderBase::r_dsgraph_insert_dynamic(dxRender_Visual* pVisual, Fvector&
     // strict-sorting selection
     if (sh->flags.bStrictB2F)
     {
-        mapSorted.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh })));
+        mapSorted.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh }));
         return;
     }
 
@@ -107,11 +107,11 @@ void D3DXRenderBase::r_dsgraph_insert_dynamic(dxRender_Visual* pVisual, Fvector&
     // d) Should be rendered to accumulation buffer in the second pass
     if (sh->flags.bEmissive)
     {
-        mapEmissive.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d }))); // sh_d -> L_special
+        mapEmissive.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh_d })); // sh_d -> L_special
     }
     if (sh->flags.bWmark && pmask_wmark)
     {
-        mapWmark.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh })));
+        mapWmark.insert_anyway(distSQ, _MatrixItemS({ SSA, RI.val_pObject, pVisual, *RI.val_pTransform, sh }));
         return;
     }
 #endif
@@ -224,7 +224,7 @@ void D3DXRenderBase::r_dsgraph_insert_static(dxRender_Visual* pVisual)
     ShaderElement* sh_d = &*pVisual->shader->E[4]; // 4=L_special
     if (RImplementation.o.distortion && sh_d && sh_d->flags.bDistort && pmask[sh_d->flags.iPriority / 2])
     {
-        mapDistort.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh_d }))); // sh_d -> L_special
+        mapDistort.insert_anyway(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh_d })); // sh_d -> L_special
     }
 
     // Select shader
@@ -239,7 +239,7 @@ void D3DXRenderBase::r_dsgraph_insert_static(dxRender_Visual* pVisual)
     {
         // TODO: Выяснить, почему в единственном месте параметр ssa не используется
         // Визуально различий не замечено
-        mapSorted.emplace_back(std::make_pair(distSQ, _MatrixItemS({ /*0*/SSA, nullptr, pVisual, Fidentity, sh })));
+        mapSorted.insert_anyway(distSQ, _MatrixItemS({ /*0*/SSA, nullptr, pVisual, Fidentity, sh }));
         return;
     }
 
@@ -251,11 +251,11 @@ void D3DXRenderBase::r_dsgraph_insert_static(dxRender_Visual* pVisual)
     // d) Should be rendered to accumulation buffer in the second pass
     if (sh->flags.bEmissive)
     {
-        mapEmissive.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh_d }))); // sh_d -> L_special
+        mapEmissive.insert_anyway(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh_d })); // sh_d -> L_special
     }
     if (sh->flags.bWmark && pmask_wmark)
     {
-        mapWmark.emplace_back(std::make_pair(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh })));
+        mapWmark.insert_anyway(distSQ, _MatrixItemS({ SSA, nullptr, pVisual, Fidentity, sh }));
         return;
     }
 #endif
@@ -486,7 +486,7 @@ void CRender::add_leafs_Static(dxRender_Visual* pVisual)
         {
             if (ssa < r_ssaDISCARD)
                 return;
-            mapLOD.emplace_back(std::make_pair(D, _LodItem({ ssa, pVisual })));
+            mapLOD.insert_anyway(D, _LodItem({ ssa, pVisual }));
         }
 #if RENDER != R_R1
         if (ssa > r_ssaLOD_B || phase == PHASE_SMAP)
@@ -706,7 +706,7 @@ void CRender::add_Static(dxRender_Visual* pVisual, u32 planes)
         {
             if (ssa < r_ssaDISCARD)
                 return;
-            mapLOD.emplace_back(std::make_pair(D, _LodItem({ ssa, pVisual })));
+            mapLOD.insert_anyway(D, _LodItem({ ssa, pVisual }));
         }
 #if RENDER != R_R1
         if (ssa > r_ssaLOD_B || phase == PHASE_SMAP)

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -64,9 +64,8 @@ template <class T> void sort_tlist(xr_vector<typename T::value_type*>& lst, xr_v
     if (amount <= 1)
     {
         // Just sort by SSA
-        lst.reserve(textures.size());
-        for (auto &i : textures) lst.push_back(&i);
-        std::sort(lst.begin(), lst.end(), cmp_second_ssa<typename T::value_type *>);
+        textures.get_any_p(lst);
+        std::sort(lst.begin(), lst.end(), cmp_second_ssa<typename T::value_type*>);
     }
     else
     {
@@ -109,9 +108,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
         {
             mapNormalVS& vs = mapNormalPasses[_priority][iPass];
 
-            nrmVS.reserve(vs.size());
-            for (auto &i : vs) nrmVS.push_back(&i);
-            std::sort(nrmVS.begin(), nrmVS.end(), cmp_second_ssa<mapNormalVS::value_type *>);
+            vs.get_any_p(nrmVS);
+            std::sort(nrmVS.begin(), nrmVS.end(), cmp_second_ssa<mapNormalVS::value_type*>);
             for (auto & vs_it : nrmVS)
             {
                 RCache.set_VS(vs_it->first);
@@ -121,9 +119,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
                 mapNormalGS& gs = vs_it->second;
                 gs.ssa = 0;
 
-                nrmGS.reserve(gs.size());
-                for (auto &i : gs) nrmGS.push_back(&i);
-                std::sort(nrmGS.begin(), nrmGS.end(), cmp_second_ssa<mapNormalGS::value_type *>);
+                gs.get_any_p(nrmGS);
+                std::sort(nrmGS.begin(), nrmGS.end(), cmp_second_ssa<mapNormalGS::value_type*>);
                 for (auto & gs_it : nrmGS)
                 {
                     RCache.set_GS(gs_it->first);
@@ -134,9 +131,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
 #endif
                     ps.ssa = 0;
 
-                    nrmPS.reserve(ps.size());
-                    for (auto &i : ps) nrmPS.push_back(&i);
-                    std::sort(nrmPS.begin(), nrmPS.end(), cmp_ps_second_ssa<mapNormalPS::value_type *>);
+                    ps.get_any_p(nrmPS);
+                    std::sort(nrmPS.begin(), nrmPS.end(), cmp_ps_second_ssa<mapNormalPS::value_type*>);
                     for (auto &ps_it : nrmPS)
                     {
                         RCache.set_PS(ps_it->first);
@@ -150,9 +146,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
 #endif
                         cs.ssa = 0;
 
-                        nrmCS.reserve(cs.size());
-                        for (auto &i : cs) nrmCS.push_back(&i);
-                        std::sort(nrmCS.begin(), nrmCS.end(), cmp_second_ssa<mapNormalCS::value_type *>);
+                        cs.get_any_p(nrmCS);
+                        std::sort(nrmCS.begin(), nrmCS.end(), cmp_second_ssa<mapNormalCS::value_type*>);
                         for (auto &cs_it : nrmCS)
                         {
                             RCache.set_Constants(cs_it->first);
@@ -160,9 +155,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
                             mapNormalStates& states = cs_it->second;
                             states.ssa = 0;
 
-                            nrmStates.reserve(states.size());
-                            for (auto &i : states) nrmStates.push_back(&i);
-                            std::sort(nrmStates.begin(), nrmStates.end(), cmp_second_ssa<mapNormalStates::value_type *>);
+                            states.get_any_p(nrmStates);
+                            std::sort(nrmStates.begin(), nrmStates.end(), cmp_second_ssa<mapNormalStates::value_type*>);
                             for (auto &state_it : nrmStates)
                             {
                                 RCache.set_States(state_it->first);
@@ -224,9 +218,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
     {
         mapMatrixVS& vs = mapMatrixPasses[_priority][iPass];
 
-        matVS.reserve(vs.size());
-        for (auto &i : vs) matVS.push_back(&i);
-        std::sort(matVS.begin(), matVS.end(), cmp_second_ssa<mapMatrixVS::value_type *>);
+        vs.get_any_p(matVS);
+        std::sort(matVS.begin(), matVS.end(), cmp_second_ssa<mapMatrixVS::value_type*>);
         for (auto &vs_id : matVS)
         {
             RCache.set_VS(vs_id->first);
@@ -235,9 +228,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
             mapMatrixGS& gs = vs_id->second;
             gs.ssa = 0;
 
-            matGS.reserve(gs.size());
-            for (auto &i : gs) matGS.push_back(&i);
-            std::sort(matGS.begin(), matGS.end(), cmp_second_ssa<mapMatrixGS::value_type *>);
+            gs.get_any_p(matGS);
+            std::sort(matGS.begin(), matGS.end(), cmp_second_ssa<mapMatrixGS::value_type*>);
             for (auto &gs_it : matGS)
             {
                 RCache.set_GS(gs_it->first);
@@ -248,8 +240,7 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
 #endif
                 ps.ssa = 0;
 
-                matPS.reserve(ps.size());
-                for (auto &i : ps) matPS.push_back(&i);
+                ps.get_any_p(matPS);
                 std::sort(matPS.begin(), matPS.end(), cmp_ps_second_ssa<mapMatrixPS::value_type *>);
                 for (auto &ps_it : matPS)
                 {
@@ -264,9 +255,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
 #endif
                     cs.ssa = 0;
 
-                    matCS.reserve(cs.size());
-                    for (auto &i : cs) matCS.push_back(&i);
-                    std::sort(matCS.begin(), matCS.end(), cmp_second_ssa<mapMatrixCS::value_type *>);
+                    cs.get_any_p(matCS);
+                    std::sort(matCS.begin(), matCS.end(), cmp_second_ssa<mapMatrixCS::value_type*>);
                     for (auto &cs_it : matCS)
                     {
                         RCache.set_Constants(cs_it->first);
@@ -274,9 +264,8 @@ void D3DXRenderBase::r_dsgraph_render_graph(u32 _priority)
                         mapMatrixStates& states = cs_it->second;
                         states.ssa = 0;
 
-                        matStates.reserve(states.size());
-                        for (auto &i : states) matStates.push_back(&i);
-                        std::sort(matStates.begin(), matStates.end(), cmp_second_ssa<mapMatrixStates::value_type *>);
+                        states.get_any_p(matStates);
+                        std::sort(matStates.begin(), matStates.end(), cmp_second_ssa<mapMatrixStates::value_type*>);
                         for (auto &state_it : matStates)
                         {
                             RCache.set_States(state_it->first);

--- a/src/Layers/xrRender/r__dsgraph_types.h
+++ b/src/Layers/xrRender/r__dsgraph_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "xrCore/Containers/FixedMap.h"
 
 class dxRender_Visual;
 
@@ -65,17 +66,17 @@ struct mapNormalItems : public mapNormalDirect
     float ssa;
 };
 
-struct mapNormalTextures : public xr_unordered_map<STextureList*, mapNormalItems>
+struct mapNormalTextures : public xr_fixed_map<STextureList*, mapNormalItems>
 {
     float ssa;
 };
 
-struct mapNormalStates : public xr_unordered_map<state_type, mapNormalTextures>
+struct mapNormalStates : public xr_fixed_map<state_type, mapNormalTextures>
 {
     float ssa;
 };
 
-struct mapNormalCS : public xr_unordered_map<R_constant_table*, mapNormalStates>
+struct mapNormalCS : public xr_fixed_map<R_constant_table*, mapNormalStates>
 {
     float ssa;
 };
@@ -88,26 +89,26 @@ struct mapNormalAdvStages
     mapNormalCS mapCS;
 };
 
-struct mapNormalPS : public xr_unordered_map<ps_type, mapNormalAdvStages>
+struct mapNormalPS : public xr_fixed_map<ps_type, mapNormalAdvStages>
 {
     float ssa;
 };
 #else
-struct mapNormalPS : public xr_unordered_map<ps_type, mapNormalCS>
+struct mapNormalPS : public xr_fixed_map<ps_type, mapNormalCS>
 {
     float ssa;
 };
 #endif
 
 #ifndef USE_DX9
-struct mapNormalGS : public xr_unordered_map<gs_type, mapNormalPS>
+struct mapNormalGS : public xr_fixed_map<gs_type, mapNormalPS>
 {
     float ssa;
 };
 
-struct mapNormalVS : public xr_unordered_map<vs_type, mapNormalGS> {};
+struct mapNormalVS : public xr_fixed_map<vs_type, mapNormalGS> {};
 #else
-struct mapNormalVS : public xr_unordered_map<vs_type, mapNormalPS> {};
+struct mapNormalVS : public xr_fixed_map<vs_type, mapNormalPS> {};
 #endif
 
 using mapNormal_T = mapNormalVS;
@@ -121,17 +122,17 @@ struct mapMatrixItems : public mapMatrixDirect
     float ssa;
 };
 
-struct mapMatrixTextures : public xr_unordered_map<STextureList*, mapMatrixItems>
+struct mapMatrixTextures : public xr_fixed_map<STextureList*, mapMatrixItems>
 {
     float ssa;
 };
 
-struct mapMatrixStates : public xr_unordered_map<state_type, mapMatrixTextures>
+struct mapMatrixStates : public xr_fixed_map<state_type, mapMatrixTextures>
 {
     float ssa;
 };
 
-struct mapMatrixCS : public xr_unordered_map<R_constant_table*, mapMatrixStates>
+struct mapMatrixCS : public xr_fixed_map<R_constant_table*, mapMatrixStates>
 {
     float ssa;
 };
@@ -144,33 +145,33 @@ struct mapMatrixAdvStages
     mapMatrixCS mapCS;
 };
 
-struct mapMatrixPS : public xr_unordered_map<ps_type, mapMatrixAdvStages>
+struct mapMatrixPS : public xr_fixed_map<ps_type, mapMatrixAdvStages>
 {
     float ssa;
 };
 #else
-struct mapMatrixPS : public xr_unordered_map<ps_type, mapMatrixCS>
+struct mapMatrixPS : public xr_fixed_map<ps_type, mapMatrixCS>
 {
     float ssa;
 };
 #endif
 
 #ifndef USE_DX9
-struct mapMatrixGS : public xr_unordered_map<gs_type, mapMatrixPS>
+struct mapMatrixGS : public xr_fixed_map<gs_type, mapMatrixPS>
 {
     float ssa;
 };
 
-struct mapMatrixVS : public xr_unordered_map<vs_type, mapMatrixGS> {};
+struct mapMatrixVS : public xr_fixed_map<vs_type, mapMatrixGS> {};
 #else
-struct mapMatrixVS : public xr_unordered_map<vs_type, mapMatrixPS> {};
+struct mapMatrixVS : public xr_fixed_map<vs_type, mapMatrixPS> {};
 #endif
 
 using mapMatrix_T = mapMatrixVS;
 using mapMatrixPasses_T = mapMatrix_T[SHADER_PASSES_MAX];
 
 // Top level
-using mapSorted_T = xr_vector<std::pair<float, _MatrixItemS>>;
-using mapHUD_T    = xr_vector<std::pair<float, _MatrixItemS>>;
-using mapLOD_T    = xr_vector<std::pair<float, _LodItem>>;
+using mapSorted_T = xr_fixed_map<float, _MatrixItemS>;
+using mapHUD_T    = xr_fixed_map<float, _MatrixItemS>;
+using mapLOD_T    = xr_fixed_map<float, _LodItem>;
 }

--- a/src/Layers/xrRenderPC_R2/r2_loader.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_loader.cpp
@@ -102,6 +102,7 @@ void CRender::level_Load(IReader* fs)
     pApp->LoadEnd();
 
     // sanity-clear
+    lstLODs.clear();
     lstLODgroups.clear();
     mapLOD.clear();
 

--- a/src/Layers/xrRenderPC_R3/r3_loader.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_loader.cpp
@@ -108,6 +108,7 @@ void CRender::level_Load(IReader* fs)
     pApp->LoadEnd();
 
     // sanity-clear
+    lstLODs.clear();
     lstLODgroups.clear();
     mapLOD.clear();
 

--- a/src/Layers/xrRenderPC_R4/r4_loader.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_loader.cpp
@@ -108,6 +108,7 @@ void CRender::level_Load(IReader* fs)
     pApp->LoadEnd();
 
     // sanity-clear
+    lstLODs.clear();
     lstLODgroups.clear();
     mapLOD.clear();
 

--- a/src/xrCore/Containers/FixedMap.h
+++ b/src/xrCore/Containers/FixedMap.h
@@ -1,0 +1,425 @@
+#pragma once
+
+#include "xrCommon/xr_allocator.h"
+
+template <class K, class T>
+struct xr_fixed_map_node
+{
+    K first;
+    T second;
+
+    xr_fixed_map_node<K, T> *left, *right;
+
+    xr_fixed_map_node()
+        : first(), second(),
+          left(nullptr),
+          right(nullptr) {}
+
+    ~xr_fixed_map_node()
+    {
+        left = nullptr;
+        right = nullptr;
+    }
+
+    xr_fixed_map_node(xr_fixed_map_node&& other) noexcept
+    {
+        first = std::move(other.first);
+        second = std::move(other.second);
+        left = other.left;
+        right = other.right;
+        other.left = nullptr;
+        other.right = nullptr;
+    }
+
+    xr_fixed_map_node(const xr_fixed_map_node& other) noexcept
+    {
+        first = other.first;
+        second = other.second;
+        left = other.left;
+        right = other.right;
+    }
+
+    xr_fixed_map_node& operator=(const xr_fixed_map_node& other) noexcept
+    {
+        first = other.first;
+        second = other.second;
+        left = other.left;
+        right = other.right;
+        return *this;
+    }
+};
+
+namespace std
+{
+template <class K, class T>
+void swap(const xr_fixed_map_node<K, T>& left, const xr_fixed_map_node<K, T>& right)
+{
+    xr_fixed_map_node<K, T> temp(left);
+    left = right;
+    right = temp;
+}
+} // namespace std
+
+template <class K, class T, size_t TGrowMultiplier = 2, class allocator = xr_allocator<xr_fixed_map_node<K, T>>>
+class xr_fixed_map
+{
+    static constexpr size_t SG_REALLOC_ADVANCE = 64;
+
+public:
+    using key_type = K;
+    using mapped_type = T;
+    using value_type = xr_fixed_map_node<K, T>;
+
+    using callback = void __fastcall(value_type*);
+    using callback_cmp = bool __fastcall(value_type& N1, value_type& N2);
+
+    static_assert(TGrowMultiplier >= 1, "Grow multiplier can't be less than 1");
+    static_assert(std::is_same_v<value_type, typename allocator::value_type>,
+        "xr_fixed_map<K, T, allocator> allocator mismatch");
+
+private:
+    value_type* nodes;
+    size_t pool;
+    size_t limit;
+
+    void resize()
+    {
+        size_t newLimit;
+
+        if constexpr (TGrowMultiplier > 1)
+        {
+            if (limit == 0) // first allocation
+                newLimit = SG_REALLOC_ADVANCE;
+            else
+                newLimit = limit * TGrowMultiplier;
+        }
+        else
+        {
+            newLimit = limit + SG_REALLOC_ADVANCE;
+            VERIFY(newLimit % SG_REALLOC_ADVANCE == 0);
+        }
+
+        value_type* newNodes = allocator::allocate(newLimit);
+        R_ASSERT(newNodes);
+
+        if constexpr (std::is_pod<T>::value)
+        {
+            ZeroMemory(newNodes, sizeof(value_type) * newLimit);
+            if (limit)
+                std::copy(nodes, nodes + limit, newNodes);
+        }
+        else
+        {
+            std::move(nodes, nodes + limit, newNodes);
+            for (value_type* cur = newNodes + limit; cur != newNodes + newLimit; ++cur)
+                allocator::construct(cur);
+        }
+
+        for (size_t i = 0; i < pool; ++i)
+        {
+            VERIFY(nodes);
+            value_type* nodeOld = nodes + i;
+            value_type* nodeNew = newNodes + i;
+
+            if (nodeOld->left)
+            {
+                size_t leftId = nodeOld->left - nodes;
+                nodeNew->left = newNodes + leftId;
+            }
+            if (nodeOld->right)
+            {
+                size_t rightId = nodeOld->right - nodes;
+                nodeNew->right = newNodes + rightId;
+            }
+        }
+
+        if (nodes)
+            allocator::deallocate(nodes, limit);
+
+        nodes = newNodes;
+        limit = newLimit;
+    }
+
+    value_type* add(const K& key)
+    {
+        if (pool == limit)
+            resize();
+
+        value_type* node = nodes + pool;
+        node->first = key;
+        node->left = nullptr;
+        node->right = nullptr;
+        ++pool;
+
+        return node;
+    }
+
+    value_type* create_child(value_type*& parent, const K& key)
+    {
+        size_t PID = size_t(parent - nodes);
+        value_type* N = add(key);
+        parent = nodes + PID;
+        return N;
+    }
+
+    void recurse_left_right(value_type* N, callback CB)
+    {
+        if (N->left)
+            recurse_left_right(N->left, CB);
+        CB(N);
+        if (N->right)
+            recurse_left_right(N->right, CB);
+    }
+
+    void recurse_right_left(value_type* N, callback CB)
+    {
+        if (N->right)
+            recurse_right_left(N->right, CB);
+        CB(N);
+        if (N->left)
+            recurse_right_left(N->left, CB);
+    }
+
+    void get_left_right(value_type* N, xr_vector<T, xr_allocator<T>>& D)
+    {
+        if (N->left)
+            get_left_right(N->left, D);
+        D.push_back(N->second);
+        if (N->right)
+            get_left_right(N->right, D);
+    }
+
+    void get_right_left(value_type* N, xr_vector<T, xr_allocator<T>>& D)
+    {
+        if (N->right)
+            get_right_left(N->right, D);
+        D.push_back(N->second);
+        if (N->left)
+            get_right_left(N->left, D);
+    }
+
+    void get_left_right_p(value_type* N, xr_vector<value_type*, xr_allocator<value_type*>>& D)
+    {
+        if (N->left)
+            get_left_right_p(N->left, D);
+        D.push_back(N);
+        if (N->right)
+            get_left_right_p(N->right, D);
+    }
+
+    void get_right_left_p(value_type* N, xr_vector<value_type*, xr_allocator<value_type*>>& D)
+    {
+        if (N->right)
+            get_right_left_p(N->right, D);
+        D.push_back(N);
+        if (N->left)
+            get_right_left_p(N->left, D);
+    }
+
+public:
+    xr_fixed_map()
+    {
+        pool = 0;
+        limit = 0;
+        nodes = 0;
+    }
+
+    ~xr_fixed_map()
+    {
+        destroy();
+    }
+
+    void destroy()
+    {
+        if (nodes)
+        {
+            for (value_type* cur = begin(); cur != last(); ++cur)
+                cur->~value_type();
+            allocator::deallocate(nodes, limit);
+        }
+        nodes = 0;
+        pool = 0;
+        limit = 0;
+    }
+
+    value_type* insert(const K& key)
+    {
+        if (!pool)
+            return add(key);
+
+        value_type* node = nodes;
+
+    once_more:
+        if (key < node->first)
+        {
+            if (node->left)
+            {
+                node = node->left;
+                goto once_more;
+            }
+            else
+            {
+                value_type* N = create_child(node, key);
+                node->left = N;
+                return N;
+            }
+        }
+        else if (key > node->first)
+        {
+            if (node->right)
+            {
+                node = node->right;
+                goto once_more;
+            }
+            else
+            {
+                value_type* N = create_child(node, key);
+                node->right = N;
+                return N;
+            }
+        }
+        else
+            return node;
+    }
+
+    value_type* insert_anyway(const K& key)
+    {
+        if (!pool)
+            return add(key);
+
+        value_type* node = nodes;
+
+    once_more:
+        if (key <= node->first)
+        {
+            if (node->left)
+            {
+                node = node->left;
+                goto once_more;
+            }
+            else
+            {
+                value_type* N = create_child(node, key);
+                node->left = N;
+                return N;
+            }
+        }
+        else
+        {
+            if (node->right)
+            {
+                node = node->right;
+                goto once_more;
+            }
+            else
+            {
+                value_type* N = create_child(node, key);
+                node->right = N;
+                return N;
+            }
+        }
+    }
+
+    value_type* insert(const K& key, const T& value)
+    {
+        value_type* N = insert(key);
+        N->second = value;
+        return N;
+    }
+
+    value_type* insert_anyway(const K& key, const T& value)
+    {
+        value_type* N = insert_anyway(key);
+        N->second = value;
+        return N;
+    }
+
+    value_type* insert(K&& key, T&& value)
+    {
+        value_type* N = insert(key);
+        N->second = value;
+        return N;
+    }
+
+    value_type* insert_anyway(K&& key, T&& value)
+    {
+        value_type* N = insert_anyway(key);
+        N->second = value;
+        return N;
+    }
+
+    size_t allocated() const { return limit; }
+
+    bool empty() const { return pool == 0 ; }
+    void clear() { pool = 0; }
+
+    value_type* begin() { return nodes; }
+    value_type* end() { return nodes + pool; }
+
+    value_type* first() { return nodes; }
+    value_type* last() { return nodes + limit; } // for setup only
+
+    size_t size() const { return pool; }
+
+    value_type& at_index(size_t v) { return nodes[v]; }
+
+    mapped_type& at(const key_type& key) { return insert(key)->second; }
+    mapped_type& operator[](const key_type& key) { return insert(key)->second; }
+
+    void traverse_left_right(callback CB)
+    {
+        if (pool)
+            recurse_left_right(nodes, CB);
+    }
+
+    void traverse_right_left(callback CB)
+    {
+        if (pool)
+            recurse_right_left(nodes, CB);
+    }
+
+    void traverse_any(callback CB)
+    {
+        value_type* _end = end();
+        for (value_type* cur = begin(); cur != _end; ++cur)
+            CB(cur);
+    }
+
+    void get_left_right(xr_vector<T, xr_allocator<T>>& D)
+    {
+        if (pool)
+            get_left_right(nodes, D);
+    }
+
+    void get_left_right_p(xr_vector<value_type*, xr_allocator<value_type*>>& D)
+    {
+        if (pool)
+            get_left_right_p(nodes, D);
+    }
+
+    void get_right_left(xr_vector<T, xr_allocator<T>>& D)
+    {
+        if (pool)
+            get_right_left(nodes, D);
+    }
+
+    void get_right_left_p(xr_vector<value_type*, xr_allocator<value_type*>>& D)
+    {
+        if (pool)
+            get_right_left_p(nodes, D);
+    }
+
+    void get_any_p(xr_vector<value_type*, xr_allocator<value_type*>>& D)
+    {
+        D.reserve(size());
+        value_type* _end = end();
+        for (value_type* cur = begin(); cur != _end; ++cur)
+            D.push_back(cur);
+    }
+
+    void setup(callback CB)
+    {
+        for (size_t i = 0; i < limit; i++)
+            CB(nodes + i);
+    }
+};

--- a/src/xrCore/xrCore.vcxproj
+++ b/src/xrCore/xrCore.vcxproj
@@ -380,6 +380,7 @@ if not exist "$(OutDir)tbbmalloc_proxy.dll" copy /y "$(xrSdkDir)binaries\$(Platf
     <ClInclude Include="Compression\SubAlloc.hpp" />
     <ClInclude Include="Containers\AssociativeVector.hpp" />
     <ClInclude Include="Containers\AssociativeVectorComparer.hpp" />
+    <ClInclude Include="Containers\FixedMap.h" />
     <ClInclude Include="cpuid.h" />
     <ClInclude Include="Crypto\xr_dsa.h" />
     <ClInclude Include="Crypto\xr_dsa_signer.h" />

--- a/src/xrCore/xrCore.vcxproj.filters
+++ b/src/xrCore/xrCore.vcxproj.filters
@@ -719,6 +719,9 @@
     <ClInclude Include="Memory\xrMemory_align.h">
       <Filter>Memory</Filter>
     </ClInclude>
+    <ClInclude Include="Containers\FixedMap.h">
+      <Filter>Containers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="xrCore.rc">


### PR DESCRIPTION
Returned FixedMap usage to xrRender. This container was used before and it is proven to be faster than xr_vector and xr_unordered_map.