### PR TITLE
MP: Fixed crash during client connection to server (Fixes #233)

### DIFF
--- a/src/xrNetServer/NET_Client.cpp
+++ b/src/xrNetServer/NET_Client.cpp
@@ -809,7 +809,6 @@ bool IPureClient::Connect(pcstr options)
                         {
                             // This host session is not in the list then so insert it.
                             HOST_NODE NODE;
-                            ZeroMemory(&NODE, sizeof(HOST_NODE));
 
                             // Copy the Host Address
                             R_CHK(pEnumHostsResponseMsg->pAddressSender->Duplicate(&NODE.pHostAddress));


### PR DESCRIPTION
Fix for first crash in #233 .

Initialization performes in default structure constructor and ZeroMemory makes fields invalid, filling them with NULL values.
