### PR TITLE
Resources \ UI: Improved FOV tracker in Settings

### DIFF
--- a/res/gamedata/configs/ui/ui_mm_opt.xml
+++ b/res/gamedata/configs/ui/ui_mm_opt.xml
@@ -587,8 +587,11 @@
 		<cap_fov x="20" y="3" width="135" height="24">
 			<text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_fov</text>
 		</cap_fov>
-		<track_fov x="180" y="5" width="235" height="20" min="55.0" max="115.0">
+		<track_fov x="180" y="5" width="205" height="20" min="55.0" max="115.0" step="1.0">
 			<options_item entry="fov" group="mm_opt_gameplay" />
+			<output_wnd x="215" y="0" width="20" height="20" format="%.0f">
+				<text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">0</text>
+			</output_wnd>
 		</track_fov>
 
         <cap_check_crosshair x="20" y="3" width="135" height="24">

--- a/res/gamedata/configs/ui/ui_mm_opt_16.xml
+++ b/res/gamedata/configs/ui/ui_mm_opt_16.xml
@@ -590,8 +590,11 @@
 		<cap_fov x="16" y="3" width="108" height="24">
 			<text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_fov</text>
 		</cap_fov>
-		<track_fov x="144" y="5" width="188" height="20" min="55.0" max="115.0">
+		<track_fov x="144" y="5" width="160" height="20" min="55.0" max="115.0" step="1.0">
 			<options_item entry="fov" group="mm_opt_gameplay"/>
+			<output_wnd x="165" y="0" width="20" height="20" format="%.0f">
+				<text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">0</text>
+			</output_wnd>
 		</track_fov>
 
         <cap_check_crosshair x="16" y="3" width="108" height="24">

--- a/src/xrUICore/TrackBar/UITrackBar.cpp
+++ b/src/xrUICore/TrackBar/UITrackBar.cpp
@@ -13,6 +13,12 @@ CUITrackBar::CUITrackBar()
     m_pSlider = new CUI3tButton();
     AttachChild(m_pSlider);
     m_pSlider->SetAutoDelete(true);
+
+    m_static = new CUIStatic();
+    m_static->Enable(false);
+    AttachChild(m_static);
+    m_static->SetAutoDelete(true);
+
     m_b_mouse_capturer = false;
 }
 
@@ -106,6 +112,7 @@ void CUITrackBar::Draw()
 {
     CUI_IB_FrameLineWnd::Draw();
     m_pSlider->Draw();
+    m_static->Draw();
 }
 
 void CUITrackBar::Update()
@@ -290,6 +297,20 @@ void CUITrackBar::UpdatePos()
         pos.x = free_space - pos.x;
 
     m_pSlider->SetWndPos(pos);
+
+    if (m_static->IsEnabled())
+    {
+        string256 buff;      
+        if (m_b_is_float)
+        {
+            xr_sprintf(buff, (m_static_format == nullptr ? "%.1f" : m_static_format.c_str()), m_f_val);
+        }
+        else
+        {
+            xr_sprintf(buff, (m_static_format == nullptr ? "%d" : m_static_format.c_str()), m_i_val);
+        }
+        m_static->TextItemControl()->SetTextST(buff);
+    }
 }
 
 void CUITrackBar::OnMessage(LPCSTR message)

--- a/src/xrUICore/TrackBar/UITrackBar.h
+++ b/src/xrUICore/TrackBar/UITrackBar.h
@@ -34,6 +34,9 @@ public:
     void SetOptIBounds(int imin, int imax);
     void SetOptFBounds(float fmin, float fmax);
 
+    CUIStatic* m_static;
+    shared_str m_static_format;
+
 protected:
     void UpdatePos();
     void UpdatePosRelativeToMouse();

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -1167,6 +1167,15 @@ bool CUIXmlInitBase::InitTrackBar(CUIXml& xml_doc, LPCSTR path, int index, CUITr
         }
     }
 
+    string512 buf;
+    strconcat(sizeof(buf), buf, path, ":output_wnd");
+    if (xml_doc.NavigateToNode(buf, index))
+    {
+        InitStatic(xml_doc, buf, index, pWnd->m_static);
+        pWnd->m_static_format = xml_doc.ReadAttrib(buf, index, "format", nullptr);
+        pWnd->m_static->Enable(true);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
1) Step is set to 1.0
2) Show numeric fov value

![image](https://user-images.githubusercontent.com/17707013/51092961-db269d00-17ae-11e9-97a2-0ee9e6cb2ad4.png)
