### PR TITLE
Numerous improvements for command line renderer selection

### DIFF
--- a/res/gamedata/scripts/ui_mm_opt_video.script
+++ b/res/gamedata/scripts/ui_mm_opt_video.script
@@ -40,4 +40,8 @@ function opt_video:InitControls(x, y, xml, handler)
 
 	btn		= xml:Init3tButton		("tab_video:btn_advanced",	self)
 	handler:Register				(btn, "btn_advanced_graphic")
+
+	-- Disable `combo_renderer` combobox control if `renderer` command locked
+	local _enable = renderer_allow_override()
+	handler.combo_renderer:Enable(_enable)
 end

--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -50,8 +50,7 @@ void CRenderDevice::Initialize()
 
   
 #if !defined(LINUX)
-        // xxx: need to fix getting rsRGL flag, it doesn't work now
-        if (strstr(Core.Params, "-gl") || psDeviceFlags.test(rsRGL))
+        if (psDeviceFlags.test(rsRGL))
 #endif
         {
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -48,10 +48,7 @@ void CRenderDevice::Initialize()
         const Uint32 flags = SDL_WINDOW_BORDERLESS | SDL_WINDOW_HIDDEN |
             SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL;
 
-  
-#if !defined(LINUX)
         if (psDeviceFlags.test(rsRGL))
-#endif
         {
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -292,7 +292,7 @@ ENGINE_API int RunApplication()
         {
             CCC_LoadCFG_custom cmd("renderer ");
             cmd.Execute(Console->ConfigFile);
-            renderer_allow_override = TRUE;
+            renderer_allow_override = true;
         }
     }
     else

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -262,11 +262,12 @@ ENGINE_API int RunApplication()
         xr_strcpy(Core.CompName, sizeof(Core.CompName), "Computer");
     }
 
+    Engine.External.CreateRendererList();
+
     FPU::m24r();
     InitEngine();
     InitInput();
     InitConsole();
-    Engine.External.CreateRendererList();
 
     if (CheckBenchmark())
         return 0;
@@ -291,6 +292,7 @@ ENGINE_API int RunApplication()
         {
             CCC_LoadCFG_custom cmd("renderer ");
             cmd.Execute(Console->ConfigFile);
+            renderer_allow_override = TRUE;
         }
     }
     else

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -563,12 +563,7 @@ public:
              * Since the Engine doesn't support switches between renderers
              * in runtime, it's safe to disable this command until restart.
              */
-
-            // keep only actual value
-            const auto& it = std::remove_if(VidQualityToken.begin(), VidQualityToken.end(),
-                [&](const auto& renderer) { return renderer.id != renderer_value; });
-
-            VidQualityToken[1].name = '\0';
+            Msg("Renderer is overrided by command line argument");
             return;
         }
 

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -536,21 +536,21 @@ virtual void Save (IWriter *F) {};
 
 ENGINE_API BOOL r2_sun_static = TRUE;
 ENGINE_API BOOL r2_advanced_pp = FALSE; // advanced post process and effects
-ENGINE_API BOOL renderer_allow_override = FALSE;
+ENGINE_API bool renderer_allow_override = false;
 
 class CCC_renderer : public CCC_Token
 {
     typedef CCC_Token inherited;
 
     u32 renderer_value = 3;
-    static BOOL cmd_lock;
+    static bool cmd_lock;
 
 public:
     CCC_renderer(LPCSTR N) : inherited(N, &renderer_value, NULL) {};
-    virtual ~CCC_renderer() {}
-    virtual void Execute(LPCSTR args)
+    ~CCC_renderer() override {}
+    void Execute(LPCSTR args) override
     {
-        if ((renderer_allow_override == FALSE) && (cmd_lock == TRUE))
+        if ((renderer_allow_override == false) && (cmd_lock == true))
         {
             /*
              * It is a case when the renderer type was specified as
@@ -581,16 +581,11 @@ public:
 
         r2_advanced_pp = (renderer_value >= 3);
     
-        cmd_lock = TRUE;
+        cmd_lock = true;
     }
 
-    virtual void Save(IWriter* F)
+    void Save(IWriter* F) override
     {
-        if (renderer_allow_override == FALSE)
-        {   // Do not save forced value
-            return;
-        }
-
         tokens = VidQualityToken.data();
         inherited::Save(F);
     }
@@ -601,7 +596,7 @@ public:
         return inherited::GetToken();
     }
 };
-BOOL CCC_renderer::cmd_lock = FALSE;
+bool CCC_renderer::cmd_lock = false;
 
 class CCC_soundDevice : public CCC_Token
 {

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -590,6 +590,11 @@ public:
 
     void Save(IWriter* F) override
     {
+        if (renderer_allow_override == false)
+        {   // Do not save forced value
+            return;
+        }
+
         tokens = VidQualityToken.data();
         inherited::Save(F);
     }

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -1,7 +1,4 @@
 #include "stdafx.h"
-
-#include <algorithm>
-
 #include "IGame_Level.h"
 
 #include "x_ray.h"

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -1,4 +1,7 @@
 #include "stdafx.h"
+
+#include <algorithm>
+
 #include "IGame_Level.h"
 
 #include "x_ray.h"
@@ -560,6 +563,12 @@ public:
              * Since the Engine doesn't support switches between renderers
              * in runtime, it's safe to disable this command until restart.
              */
+
+            // keep only actual value
+            const auto& it = std::remove_if(VidQualityToken.begin(), VidQualityToken.end(),
+                [&](const auto& renderer) { return renderer.id != renderer_value; });
+
+            VidQualityToken[1].name = '\0';
             return;
         }
 

--- a/src/xrEngine/xr_ioc_cmd.h
+++ b/src/xrEngine/xr_ioc_cmd.h
@@ -29,7 +29,7 @@
 #include "xrCore/xrCore_benchmark_macros.h"
 #include "xrCore/xr_token.h"
 
-extern ENGINE_API BOOL renderer_allow_override; // allows to change renderer setting
+extern ENGINE_API bool renderer_allow_override; // allows to change renderer setting
 
 class ENGINE_API IConsole_Command
 {

--- a/src/xrEngine/xr_ioc_cmd.h
+++ b/src/xrEngine/xr_ioc_cmd.h
@@ -29,6 +29,8 @@
 #include "xrCore/xrCore_benchmark_macros.h"
 #include "xrCore/xr_token.h"
 
+extern ENGINE_API BOOL renderer_allow_override; // allows to change renderer setting
+
 class ENGINE_API IConsole_Command
 {
 public:

--- a/src/xrGame/console_registrator_script.cpp
+++ b/src/xrGame/console_registrator_script.cpp
@@ -1,10 +1,17 @@
 #include "pch_script.h"
 #include "xrEngine/XR_IOConsole.h"
+#include "xrEngine/xr_ioc_cmd.h"
 #include "xrScriptEngine/ScriptExporter.hpp"
 
 using namespace luabind;
 
 CConsole* console() { return Console; }
+
+bool get_renderer_command_state(void)
+{
+    return renderer_allow_override;
+}
+
 int get_console_integer(CConsole* c, LPCSTR cmd)
 {
     int min = 0, max = 0;
@@ -39,5 +46,7 @@ SCRIPT_EXPORT(CConsole, (), {
             .def("get_bool", &get_console_bool)
             .def("get_float", &get_console_float)
             .def("get_token", &CConsole::GetToken)
-            .def("execute_deferred", &execute_console_command_deferred)];
+            .def("execute_deferred", &execute_console_command_deferred),
+            
+        def("renderer_allow_override", &get_renderer_command_state)];
 });


### PR DESCRIPTION
* Fixed a bug when renderer setting was overrided by `user.ltx`
* Fixed `rsXX` device flags updating
* `CCC_r2` renamed to `CCC_renderer`