### PR TITLE
Xrcore refactor

### DIFF
--- a/src/xrCore/Animation/Motion.hpp
+++ b/src/xrCore/Animation/Motion.hpp
@@ -40,7 +40,7 @@ struct st_BoneMotion
         m_Flags.zero();
         ZeroMemory(envs, sizeof(CEnvelope*) * ctMaxChannel);
     }
-    void SetName(LPCSTR nm) { name = nm; }
+    void SetName(pcstr nm) { name = nm; }
 };
 // vector по костям
 using BoneMotionVec = xr_vector<st_BoneMotion>;
@@ -77,7 +77,7 @@ public:
         }
         name = tmp;
     }
-    LPCSTR Name() { return name.c_str(); }
+    pcstr Name() { return name.c_str(); }
     int FrameStart() { return iFrameStart; }
     int FrameEnd() { return iFrameEnd; }
     float FPS() { return fFPS; }

--- a/src/xrCore/Animation/SkeletonMotions.cpp
+++ b/src/xrCore/Animation/SkeletonMotions.cpp
@@ -22,7 +22,7 @@ u16 CPartition::part_id(const shared_str& name) const
     return u16(-1);
 }
 
-void CPartition::load(IKinematics* V, LPCSTR model_name)
+void CPartition::load(IKinematics* V, pcstr model_name)
 {
     string_path fn, fn_full;
     xr_strcpy(fn, sizeof(fn), model_name);
@@ -74,7 +74,7 @@ u16 find_bone_id(vecBones* bones, shared_str nm)
 }
 
 //-----------------------------------------------------------------------
-BOOL motions_value::load(LPCSTR N, IReader* data, vecBones* bones)
+BOOL motions_value::load(pcstr N, IReader* data, vecBones* bones)
 {
     m_id = N;
 

--- a/src/xrCore/Animation/SkeletonMotions.hpp
+++ b/src/xrCore/Animation/SkeletonMotions.hpp
@@ -179,7 +179,7 @@ public:
     IC const CPartDef& part(u16 id) const { return P[id]; }
     u16 part_id(const shared_str& name) const;
     u32 mem_usage() { return P[0].mem_usage() * MAX_PARTS; }
-    void load(IKinematics* V, LPCSTR model_name);
+    void load(IKinematics* V, pcstr model_name);
     u8 count() const
     {
         u8 ret = 0;
@@ -203,7 +203,7 @@ struct XRCORE_API motions_value
 
     shared_str m_id;
 
-    BOOL load(LPCSTR N, IReader* data, vecBones* bones);
+    BOOL load(pcstr N, IReader* data, vecBones* bones);
     MotionVec* bone_motions(shared_str bone_name);
 
     u32 mem_usage()

--- a/src/xrCore/ChooseTypes.H
+++ b/src/xrCore/ChooseTypes.H
@@ -44,7 +44,7 @@ struct SChooseItem
 {
     shared_str name;
     shared_str hint;
-    SChooseItem(LPCSTR nm, LPCSTR ht) : name(nm), hint(ht) {}
+    SChooseItem(pcstr nm, pcstr ht) : name(nm), hint(ht) {}
 };
 
 using ChooseItemVec = xr_vector<SChooseItem>;
@@ -52,7 +52,7 @@ using ChooseItemVec = xr_vector<SChooseItem>;
 // typedef
 typedef fastdelegate::FastDelegate2<ChooseItemVec&, void*> TOnChooseFillItems;
 typedef fastdelegate::FastDelegate2<SChooseItem*, PropItemVec&> TOnChooseSelectItem;
-typedef fastdelegate::FastDelegate3<LPCSTR, HDC, const Irect&> TOnDrawThumbnail;
+typedef fastdelegate::FastDelegate3<pcstr, HDC, const Irect&> TOnDrawThumbnail;
 typedef fastdelegate::FastDelegate0<> TOnChooseClose;
 
 typedef void (*TOnChooseFillEvents)();
@@ -75,11 +75,11 @@ struct SChooseEvents
         flags.zero();
     }
     SChooseEvents(
-    LPCSTR capt, TOnChooseFillItems f, TOnChooseSelectItem s, TOnDrawThumbnail t, TOnChooseClose c, u32 fl)
+    pcstr capt, TOnChooseFillItems f, TOnChooseSelectItem s, TOnDrawThumbnail t, TOnChooseClose c, u32 fl)
     {
         Set(capt, f, s, t, c, fl);
     }
-    void Set(LPCSTR capt, TOnChooseFillItems f, TOnChooseSelectItem s, TOnDrawThumbnail t, TOnChooseClose c, u32 fl)
+    void Set(pcstr capt, TOnChooseFillItems f, TOnChooseSelectItem s, TOnDrawThumbnail t, TOnChooseClose c, u32 fl)
     {
         caption = capt;
         on_fill = f;

--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -338,7 +338,7 @@ IReader* IReader::open_chunk(u32 ID)
     }
     else
         return 0;
-};
+}
 void IReader::close()
 {
     IReader* self = this;
@@ -406,9 +406,9 @@ void IReader::r(void* p, int cnt)
         FS.dwOpenCounter++;
     }
 #endif
-};
+}
 
-IC BOOL is_term(char a) { return (a == 13) || (a == 10); };
+IC BOOL is_term(char a) { return (a == 13) || (a == 10); }
 IC u32 IReader::advance_term_string()
 {
     u32 sz = 0;
@@ -467,7 +467,7 @@ void IReader::r_stringZ(xr_string& dest)
 {
     dest = (char*)(data + Pos);
     Pos += int(dest.size() + 1);
-};
+}
 
 void IReader::skip_stringZ()
 {
@@ -475,11 +475,11 @@ void IReader::skip_stringZ()
     while ((src[Pos] != 0) && (!eof()))
         Pos++;
     Pos++;
-};
+}
 
 //---------------------------------------------------
 // temp stream
-CTempReader::~CTempReader() { xr_free(data); };
+CTempReader::~CTempReader() { xr_free(data); }
 //---------------------------------------------------
 // pack stream
 CPackReader::~CPackReader()
@@ -492,15 +492,15 @@ CPackReader::~CPackReader()
 #elif defined(LINUX)
     ::munmap(base_address, Size);
 #endif
-};
+}
 //---------------------------------------------------
 // file stream
 CFileReader::CFileReader(pcstr name)
 {
     data = (char*)FileDownload(name, (u32*)&Size);
     Pos = 0;
-};
-CFileReader::~CFileReader() { xr_free(data); };
+}
+CFileReader::~CFileReader() { xr_free(data); }
 //---------------------------------------------------
 // compressed stream
 CCompressedReader::CCompressedReader(const char* name, const char* sign)
@@ -508,7 +508,7 @@ CCompressedReader::CCompressedReader(const char* name, const char* sign)
     data = (char*)FileDecompress(name, sign, (u32*)&Size);
     Pos = 0;
 }
-CCompressedReader::~CCompressedReader() { xr_free(data); };
+CCompressedReader::~CCompressedReader() { xr_free(data); }
 CVirtualFileRW::CVirtualFileRW(pcstr cFileName)
 {
 #if defined(WINDOWS)

--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -26,7 +26,7 @@ u32 g_file_mapped_count = 0;
 typedef xr_map<u32, std::pair<u32, shared_str>> FILE_MAPPINGS;
 FILE_MAPPINGS g_file_mappings;
 
-void register_file_mapping(void* address, const u32& size, LPCSTR file_name)
+void register_file_mapping(void* address, const u32& size, pcstr file_name)
 {
     FILE_MAPPINGS::const_iterator I = g_file_mappings.find(*(u32*)&address);
     VERIFY(I == g_file_mappings.end());
@@ -135,7 +135,7 @@ bool file_handle_internal(pcstr file_name, u32& size, int& file_handle)
 }
 #endif // EDITOR
 
-void* FileDownload(LPCSTR file_name, const int& file_handle, u32& file_size)
+void* FileDownload(pcstr file_name, const int& file_handle, u32& file_size)
 {
     void* buffer = xr_malloc(file_size + 1); // IDK why need +1 for file size, but without this caused invalid write size 1 for this buffer
 
@@ -152,7 +152,7 @@ void* FileDownload(LPCSTR file_name, const int& file_handle, u32& file_size)
     return (buffer);
 }
 
-void* FileDownload(LPCSTR file_name, u32* buffer_size)
+void* FileDownload(pcstr file_name, u32* buffer_size)
 {
     int file_handle;
     R_ASSERT3(file_handle_internal(file_name, *buffer_size, file_handle), "can't open file : ", file_name);
@@ -225,7 +225,7 @@ void CMemoryWriter::w(const void* ptr, u32 count)
 }
 
 // static const u32 mb_sz = 0x1000000;
-bool CMemoryWriter::save_to(LPCSTR fn)
+bool CMemoryWriter::save_to(pcstr fn)
 {
     IWriter* F = FS.w_open(fn);
     if (F)

--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -137,7 +137,7 @@ bool file_handle_internal(pcstr file_name, u32& size, int& file_handle)
 
 void* FileDownload(LPCSTR file_name, const int& file_handle, u32& file_size)
 {
-    void* buffer = xr_malloc(file_size);
+    void* buffer = xr_malloc(file_size + 1); // IDK why need +1 for file size, but without this caused invalid write size 1 for this buffer
 
     int r_bytes = _read(file_handle, buffer, file_size);
     R_ASSERT3(

--- a/src/xrCore/FS.h
+++ b/src/xrCore/FS.h
@@ -26,7 +26,7 @@ XRCORE_API void VerifyPath(pcstr path);
 XRCORE_API extern u32 g_file_mapped_memory;
 XRCORE_API extern u32 g_file_mapped_count;
 XRCORE_API void dump_file_mappings();
-extern void register_file_mapping(void* address, const u32& size, LPCSTR file_name);
+extern void register_file_mapping(void* address, const u32& size, pcstr file_name);
 extern void unregister_file_mapping(void* address, const u32& size);
 #endif // DEBUG
 
@@ -160,7 +160,7 @@ public:
         xr_free(data);
     }
 #pragma warning(pop)
-    bool save_to(LPCSTR fn);
+    bool save_to(pcstr fn);
     virtual void flush(){};
 };
 

--- a/src/xrCore/FS_internal.h
+++ b/src/xrCore/FS_internal.h
@@ -12,7 +12,7 @@
 #include <share.h>
 #endif
 
-void* FileDownload(LPCSTR fn, u32* pdwSize = NULL);
+void* FileDownload(pcstr fn, u32* pdwSize = NULL);
 void FileCompress(const char* fn, const char* sign, void* data, u32 size);
 void* FileDecompress(const char* fn, const char* sign, u32* size = NULL);
 

--- a/src/xrCore/FileCRC32.cpp
+++ b/src/xrCore/FileCRC32.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "FileCRC32.h"
 
-void getFileCrc32(IReader* F, LPCSTR filePath, u32& outCrc, bool parseIncludes)
+void getFileCrc32(IReader* F, pcstr filePath, u32& outCrc, bool parseIncludes)
 {
     outCrc = crc32(F->pointer(), F->length(), outCrc);
     string4096 str;

--- a/src/xrCore/FileCRC32.h
+++ b/src/xrCore/FileCRC32.h
@@ -1,3 +1,3 @@
 #pragma once
 
-XRCORE_API void getFileCrc32(IReader* F, LPCSTR filePath, u32& outCrc, bool parseIncludes = true);
+XRCORE_API void getFileCrc32(IReader* F, pcstr filePath, u32& outCrc, bool parseIncludes = true);

--- a/src/xrCore/FileSystem.cpp
+++ b/src/xrCore/FileSystem.cpp
@@ -15,37 +15,37 @@ xr_unique_ptr<EFS_Utils> xr_EFS;
 //----------------------------------------------------
 EFS_Utils::EFS_Utils() {}
 EFS_Utils::~EFS_Utils() {}
-xr_string EFS_Utils::ExtractFileName(LPCSTR src)
+xr_string EFS_Utils::ExtractFileName(pcstr src)
 {
     string_path name;
     _splitpath(src, 0, 0, name, 0);
     return xr_string(name);
 }
 
-xr_string EFS_Utils::ExtractFileExt(LPCSTR src)
+xr_string EFS_Utils::ExtractFileExt(pcstr src)
 {
     string_path ext;
     _splitpath(src, 0, 0, 0, ext);
     return xr_string(ext);
 }
 
-xr_string EFS_Utils::ExtractFilePath(LPCSTR src)
+xr_string EFS_Utils::ExtractFilePath(pcstr src)
 {
     string_path drive, dir;
     _splitpath(src, drive, dir, 0, 0);
     return xr_string(drive) + dir;
 }
 
-xr_string EFS_Utils::ExcludeBasePath(LPCSTR full_path, LPCSTR excl_path)
+xr_string EFS_Utils::ExcludeBasePath(pcstr full_path, pcstr excl_path)
 {
-    LPCSTR sub = strstr(full_path, excl_path);
+    pcstr sub = strstr(full_path, excl_path);
     if (0 != sub)
         return xr_string(sub + xr_strlen(excl_path));
     else
         return xr_string(full_path);
 }
 
-xr_string EFS_Utils::ChangeFileExt(LPCSTR src, LPCSTR ext)
+xr_string EFS_Utils::ChangeFileExt(pcstr src, pcstr ext)
 {
     xr_string tmp;
     LPSTR src_ext = strext(src);
@@ -62,9 +62,9 @@ xr_string EFS_Utils::ChangeFileExt(LPCSTR src, LPCSTR ext)
     return tmp;
 }
 
-xr_string EFS_Utils::ChangeFileExt(const xr_string& src, LPCSTR ext) { return ChangeFileExt(src.c_str(), ext); }
+xr_string EFS_Utils::ChangeFileExt(const xr_string& src, pcstr ext) { return ChangeFileExt(src.c_str(), ext); }
 //----------------------------------------------------
-void MakeFilter(string1024& dest, LPCSTR info, LPCSTR ext)
+void MakeFilter(string1024& dest, pcstr info, pcstr ext)
 {
     std::string res;
 
@@ -122,7 +122,7 @@ UINT_PTR CALLBACK OFNHookProcOldStyle(HWND, UINT, WPARAM, LPARAM)
 #endif
 
 bool EFS_Utils::GetOpenNameInternal(
-    LPCSTR initial, LPSTR buffer, int sz_buf, bool bMulti, LPCSTR offset, int start_flt_ext)
+    pcstr initial, LPSTR buffer, int sz_buf, bool bMulti, pcstr offset, int start_flt_ext)
 {
     VERIFY(buffer && (sz_buf > 0));
 #if defined(WINDOWS)
@@ -216,7 +216,7 @@ bool EFS_Utils::GetOpenNameInternal(
 #endif
 }
 
-bool EFS_Utils::GetSaveName(LPCSTR initial, string_path& buffer, LPCSTR offset, int start_flt_ext)
+bool EFS_Utils::GetSaveName(pcstr initial, string_path& buffer, pcstr offset, int start_flt_ext)
 {
     // unsigned int dwVersion = GetVersion();
     // unsigned int dwWindowsMajorVersion = (DWORD)(LOBYTE(LOWORD(dwVersion)));
@@ -224,7 +224,7 @@ bool EFS_Utils::GetSaveName(LPCSTR initial, string_path& buffer, LPCSTR offset, 
     FS_Path& P = *FS.get_path(initial);
     string1024 flt;
 
-    LPCSTR def_ext = P.m_DefExt;
+    pcstr def_ext = P.m_DefExt;
     if (false) //&& dwWindowsMajorVersion == 6 )
     {
         if (strstr(P.m_DefExt, "*."))
@@ -282,18 +282,18 @@ bool EFS_Utils::GetSaveName(LPCSTR initial, string_path& buffer, LPCSTR offset, 
 #endif
 }
 //----------------------------------------------------
-LPCSTR EFS_Utils::AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name)
+pcstr EFS_Utils::AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name)
 {
     string256 _fn;
     xr_strcpy(tex_name, tex_name_size, AppendFolderToName(tex_name, _fn, sizeof(_fn), depth, full_name));
     return tex_name;
 }
 
-LPCSTR EFS_Utils::AppendFolderToName(
-    LPCSTR src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name)
+pcstr EFS_Utils::AppendFolderToName(
+    pcstr src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name)
 {
     shared_str tmp = src_name;
-    LPCSTR s = src_name;
+    pcstr s = src_name;
     LPSTR d = dest_name;
     int sv_depth = depth;
     for (; *s && depth; s++, d++)
@@ -323,8 +323,8 @@ LPCSTR EFS_Utils::AppendFolderToName(
     return dest_name;
 }
 
-LPCSTR EFS_Utils::GenerateName(
-    LPCSTR base_path, LPCSTR base_name, LPCSTR def_ext, LPSTR out_name, u32 const out_name_size)
+pcstr EFS_Utils::GenerateName(
+    pcstr base_path, pcstr base_name, pcstr def_ext, LPSTR out_name, u32 const out_name_size)
 {
     int cnt = 0;
     string_path fn;

--- a/src/xrCore/FileSystem.cpp
+++ b/src/xrCore/FileSystem.cpp
@@ -48,7 +48,7 @@ xr_string EFS_Utils::ExcludeBasePath(pcstr full_path, pcstr excl_path)
 xr_string EFS_Utils::ChangeFileExt(pcstr src, pcstr ext)
 {
     xr_string tmp;
-    LPSTR src_ext = strext(src);
+    pstr src_ext = strext(src);
     if (src_ext)
     {
         size_t ext_pos = src_ext - src;
@@ -122,7 +122,7 @@ UINT_PTR CALLBACK OFNHookProcOldStyle(HWND, UINT, WPARAM, LPARAM)
 #endif
 
 bool EFS_Utils::GetOpenNameInternal(
-    pcstr initial, LPSTR buffer, int sz_buf, bool bMulti, pcstr offset, int start_flt_ext)
+    pcstr initial, pstr buffer, int sz_buf, bool bMulti, pcstr offset, int start_flt_ext)
 {
     VERIFY(buffer && (sz_buf > 0));
 #if defined(WINDOWS)
@@ -282,7 +282,7 @@ bool EFS_Utils::GetSaveName(pcstr initial, string_path& buffer, pcstr offset, in
 #endif
 }
 //----------------------------------------------------
-pcstr EFS_Utils::AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name)
+pcstr EFS_Utils::AppendFolderToName(pstr tex_name, u32 const tex_name_size, int depth, BOOL full_name)
 {
     string256 _fn;
     xr_strcpy(tex_name, tex_name_size, AppendFolderToName(tex_name, _fn, sizeof(_fn), depth, full_name));
@@ -290,11 +290,11 @@ pcstr EFS_Utils::AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int
 }
 
 pcstr EFS_Utils::AppendFolderToName(
-    pcstr src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name)
+    pcstr src_name, pstr dest_name, u32 const dest_name_size, int depth, BOOL full_name)
 {
     shared_str tmp = src_name;
     pcstr s = src_name;
-    LPSTR d = dest_name;
+    pstr d = dest_name;
     int sv_depth = depth;
     for (; *s && depth; s++, d++)
     {
@@ -324,7 +324,7 @@ pcstr EFS_Utils::AppendFolderToName(
 }
 
 pcstr EFS_Utils::GenerateName(
-    pcstr base_path, pcstr base_name, pcstr def_ext, LPSTR out_name, u32 const out_name_size)
+    pcstr base_path, pcstr base_name, pcstr def_ext, pstr out_name, u32 const out_name_size)
 {
     int cnt = 0;
     string_path fn;

--- a/src/xrCore/FileSystem.h
+++ b/src/xrCore/FileSystem.h
@@ -11,36 +11,36 @@ class XRCORE_API EFS_Utils
 {
 protected:
     bool GetOpenNameInternal(
-        LPCSTR initial, LPSTR buffer, int sz_buf, bool bMulti = false, LPCSTR offset = 0, int start_flt_ext = -1);
+        pcstr initial, LPSTR buffer, int sz_buf, bool bMulti = false, pcstr offset = 0, int start_flt_ext = -1);
 
 public:
     EFS_Utils();
     virtual ~EFS_Utils();
     void _initialize() {}
     void _destroy() {}
-    LPCSTR GenerateName(LPCSTR base_path, LPCSTR base_name, LPCSTR def_ext, LPSTR out_name, u32 const out_name_size);
+    pcstr GenerateName(pcstr base_path, pcstr base_name, pcstr def_ext, LPSTR out_name, u32 const out_name_size);
 
-    bool GetOpenName(LPCSTR initial, string_path& buffer, int sz_buf, bool bMulti = false, LPCSTR offset = 0,
+    bool GetOpenName(pcstr initial, string_path& buffer, int sz_buf, bool bMulti = false, pcstr offset = 0,
         int start_flt_ext = -1);
-    bool GetOpenName(LPCSTR initial, xr_string& buf, bool bMulti = false, LPCSTR offset = 0, int start_flt_ext = -1);
+    bool GetOpenName(pcstr initial, xr_string& buf, bool bMulti = false, pcstr offset = 0, int start_flt_ext = -1);
 
-    bool GetSaveName(LPCSTR initial, string_path& buffer, LPCSTR offset = 0, int start_flt_ext = -1);
-    bool GetSaveName(LPCSTR initial, xr_string& buf, LPCSTR offset = 0, int start_flt_ext = -1);
+    bool GetSaveName(pcstr initial, string_path& buffer, pcstr offset = 0, int start_flt_ext = -1);
+    bool GetSaveName(pcstr initial, xr_string& buf, pcstr offset = 0, int start_flt_ext = -1);
 
-    void MarkFile(LPCSTR fn, bool bDeleteSource);
+    void MarkFile(pcstr fn, bool bDeleteSource);
 
     xr_string AppendFolderToName(xr_string& tex_name, int depth, BOOL full_name);
 
-    LPCSTR AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name);
-    LPCSTR AppendFolderToName(LPCSTR src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name);
+    pcstr AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name);
+    pcstr AppendFolderToName(pcstr src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name);
 
-    xr_string ChangeFileExt(LPCSTR src, LPCSTR ext);
-    xr_string ChangeFileExt(const xr_string& src, LPCSTR ext);
+    xr_string ChangeFileExt(pcstr src, pcstr ext);
+    xr_string ChangeFileExt(const xr_string& src, pcstr ext);
 
-    static xr_string ExtractFileName(LPCSTR src);
-    static xr_string ExtractFilePath(LPCSTR src);
-    static xr_string ExtractFileExt(LPCSTR src);
-    static xr_string ExcludeBasePath(LPCSTR full_path, LPCSTR excl_path);
+    static xr_string ExtractFileName(pcstr src);
+    static xr_string ExtractFilePath(pcstr src);
+    static xr_string ExtractFileExt(pcstr src);
+    static xr_string ExcludeBasePath(pcstr full_path, pcstr excl_path);
 };
 extern XRCORE_API xr_unique_ptr<EFS_Utils> xr_EFS;
 #define EFS (*xr_EFS)

--- a/src/xrCore/FileSystem.h
+++ b/src/xrCore/FileSystem.h
@@ -11,14 +11,14 @@ class XRCORE_API EFS_Utils
 {
 protected:
     bool GetOpenNameInternal(
-        pcstr initial, LPSTR buffer, int sz_buf, bool bMulti = false, pcstr offset = 0, int start_flt_ext = -1);
+        pcstr initial, pstr buffer, int sz_buf, bool bMulti = false, pcstr offset = 0, int start_flt_ext = -1);
 
 public:
     EFS_Utils();
     virtual ~EFS_Utils();
     void _initialize() {}
     void _destroy() {}
-    pcstr GenerateName(pcstr base_path, pcstr base_name, pcstr def_ext, LPSTR out_name, u32 const out_name_size);
+    pcstr GenerateName(pcstr base_path, pcstr base_name, pcstr def_ext, pstr out_name, u32 const out_name_size);
 
     bool GetOpenName(pcstr initial, string_path& buffer, int sz_buf, bool bMulti = false, pcstr offset = 0,
         int start_flt_ext = -1);
@@ -31,8 +31,8 @@ public:
 
     xr_string AppendFolderToName(xr_string& tex_name, int depth, BOOL full_name);
 
-    pcstr AppendFolderToName(LPSTR tex_name, u32 const tex_name_size, int depth, BOOL full_name);
-    pcstr AppendFolderToName(pcstr src_name, LPSTR dest_name, u32 const dest_name_size, int depth, BOOL full_name);
+    pcstr AppendFolderToName(pstr tex_name, u32 const tex_name_size, int depth, BOOL full_name);
+    pcstr AppendFolderToName(pcstr src_name, pstr dest_name, u32 const dest_name_size, int depth, BOOL full_name);
 
     xr_string ChangeFileExt(pcstr src, pcstr ext);
     xr_string ChangeFileExt(const xr_string& src, pcstr ext);

--- a/src/xrCore/FileSystem_borland.cpp
+++ b/src/xrCore/FileSystem_borland.cpp
@@ -21,7 +21,7 @@ int CALLBACK BrowseCallbackProc(HWND hWnd, UINT uMsg, LPARAM lParam, LPARAM lpDa
     return 0;
 }
 
-bool EFS_Utils::GetOpenName(LPCSTR initial, xr_string& buffer, bool bMulti, LPCSTR offset, int start_flt_ext)
+bool EFS_Utils::GetOpenName(pcstr initial, xr_string& buffer, bool bMulti, pcstr offset, int start_flt_ext)
 {
     char buf[255 * 255]; // max files to select
     xr_strcpy(buf, buffer.c_str());
@@ -52,7 +52,7 @@ bool EFS_Utils::GetOpenName(LPCSTR initial, xr_string& buffer, bool bMulti, LPCS
     return bRes;
 }
 
-bool EFS_Utils::GetSaveName(LPCSTR initial, xr_string& buffer, LPCSTR offset, int start_flt_ext)
+bool EFS_Utils::GetSaveName(pcstr initial, xr_string& buffer, pcstr offset, int start_flt_ext)
 {
     string_path buf;
     xr_strcpy(buf, sizeof(buf), buffer.c_str());
@@ -64,7 +64,7 @@ bool EFS_Utils::GetSaveName(LPCSTR initial, xr_string& buffer, LPCSTR offset, in
 }
 //----------------------------------------------------
 
-void EFS_Utils::MarkFile(LPCSTR fn, bool bDeleteSource)
+void EFS_Utils::MarkFile(pcstr fn, bool bDeleteSource)
 {
     xr_string ext = strext(fn);
     ext.insert(1, "~");

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -1127,7 +1127,7 @@ int CLocatorAPI::file_list(FS_FileSet& dest, pcstr path, u32 flags, pcstr mask)
             // file
             if ((flags & FS_ListFiles) == 0)
                 continue;
-            LPCSTR entry_begin = entry.name + base_len;
+            pcstr entry_begin = entry.name + base_len;
             if (flags & FS_RootOnly && strstr(entry_begin, DELIMITER))
                 continue; // folder in folder
             // check extension
@@ -1161,7 +1161,7 @@ int CLocatorAPI::file_list(FS_FileSet& dest, pcstr path, u32 flags, pcstr mask)
             // folder
             if ((flags & FS_ListFolders) == 0)
                 continue;
-            LPCSTR entry_begin = entry.name + base_len;
+            pcstr entry_begin = entry.name + base_len;
 
             if (flags & FS_RootOnly && strstr(entry_begin, DELIMITER) != end_symbol)
                 continue; // folder in folder
@@ -1181,9 +1181,9 @@ void CLocatorAPI::check_cached_files(pstr fname, const u32& fname_size, const fi
     if (!path_exist("$server_root$"))
         return;
 
-    LPCSTR path_base = get_path("$server_root$")->m_Path;
+    pcstr path_base = get_path("$server_root$")->m_Path;
     u32 len_base = xr_strlen(path_base);
-    LPCSTR path_file = fname;
+    pcstr path_file = fname;
     u32 len_file = xr_strlen(path_file);
     if (len_file <= len_base)
         return;

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -1242,7 +1242,7 @@ void CLocatorAPI::check_cached_files(pstr fname, const u32& fname_size, const fi
     xr_strcpy(fname, fname_size, fname_in_cache);
 }
 
-void CLocatorAPI::file_from_cache_impl(IReader*& R, LPSTR fname, const file& desc)
+void CLocatorAPI::file_from_cache_impl(IReader*& R, pstr fname, const file& desc)
 {
     if (desc.size_real < 16 * 1024)
     {
@@ -1253,7 +1253,7 @@ void CLocatorAPI::file_from_cache_impl(IReader*& R, LPSTR fname, const file& des
     R = new CVirtualFileReader(fname);
 }
 
-void CLocatorAPI::file_from_cache_impl(CStreamReader*& R, LPSTR fname, const file& desc)
+void CLocatorAPI::file_from_cache_impl(CStreamReader*& R, pstr fname, const file& desc)
 {
     CFileStreamReader* r = new CFileStreamReader();
     r->construct(fname, BIG_FILE_READER_WINDOW_SIZE);

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -155,12 +155,13 @@ XRCORE_API void _dump_open_files(int mode)
     Log("----total count = ", g_open_files.size());
 }
 
-CLocatorAPI::CLocatorAPI() : bNoRecurse(true), m_auth_code(0),
+CLocatorAPI::CLocatorAPI() : bNoRecurse(true),
 #ifdef CONFIG_PROFILE_LOCKS
-    m_auth_lock(new Lock(MUTEX_PROFILE_ID(CLocatorAPI::m_auth_lock)))
+    m_auth_lock(new Lock(MUTEX_PROFILE_ID(CLocatorAPI::m_auth_lock))),
 #else
-    m_auth_lock(new Lock)
+    m_auth_lock(new Lock),
 #endif // CONFIG_PROFILE_LOCKS
+    m_auth_code(0)
 {
     m_Flags.zero();
 #if defined(WINDOWS)

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -343,7 +343,7 @@ IReader* open_chunk(int fd, u32 ID)
             return nullptr;
     }
     return nullptr;
-};
+}
 #endif
 
 void CLocatorAPI::LoadArchive(archive& A, pcstr entrypoint)

--- a/src/xrCore/LocatorAPI.h
+++ b/src/xrCore/LocatorAPI.h
@@ -60,7 +60,7 @@ enum class FSType
     Any = Virtual | External,
 };
 
-IMPLEMENT_ENUM_FLAG_OPERATORS(FSType, int);
+IMPLEMENT_ENUM_FLAG_OPERATORS(FSType, int)
 
 class FileStatus
 {

--- a/src/xrCore/LocatorAPI.h
+++ b/src/xrCore/LocatorAPI.h
@@ -175,8 +175,8 @@ public:
 private:
     void check_cached_files(pstr fname, const u32& fname_size, const file& desc, pcstr& source_name);
 
-    void file_from_cache_impl(IReader*& R, LPSTR fname, const file& desc);
-    void file_from_cache_impl(CStreamReader*& R, LPSTR fname, const file& desc);
+    void file_from_cache_impl(IReader*& R, pstr fname, const file& desc);
+    void file_from_cache_impl(CStreamReader*& R, pstr fname, const file& desc);
     template <typename T>
     void file_from_cache(T*& R, pstr fname, const u32& fname_size, const file& desc, pcstr& source_name);
 

--- a/src/xrCore/LocatorAPI_defs.cpp
+++ b/src/xrCore/LocatorAPI_defs.cpp
@@ -34,7 +34,7 @@ void FS_File::set(const xr_string& nm, long sz, time_t modif, unsigned attr)
 //////////////////////////////////////////////////////////////////////
 // FS_Path
 //////////////////////////////////////////////////////////////////////
-FS_Path::FS_Path(LPCSTR _Root, LPCSTR _Add, LPCSTR _DefExt, LPCSTR _FilterCaption, u32 flags)
+FS_Path::FS_Path(pcstr _Root, pcstr _Add, pcstr _DefExt, pcstr _FilterCaption, u32 flags)
 {
     // VERIFY (_Root&&_Root[0]);
     string_path temp;
@@ -65,7 +65,7 @@ FS_Path::~FS_Path()
     xr_free(m_FilterCaption);
 }
 
-void FS_Path::_set(LPCSTR add)
+void FS_Path::_set(pcstr add)
 {
     // m_Add
     R_ASSERT(add);
@@ -81,7 +81,7 @@ void FS_Path::_set(LPCSTR add)
     m_Path = xr_strdup(temp);
 }
 
-void FS_Path::_set_root(LPCSTR root)
+void FS_Path::_set_root(pcstr root)
 {
     string_path temp;
     xr_strcpy(temp, root);
@@ -98,7 +98,7 @@ void FS_Path::_set_root(LPCSTR root)
     m_Path = xr_strdup(temp);
 }
 
-LPCSTR FS_Path::_update(string_path& dest, LPCSTR src) const
+pcstr FS_Path::_update(string_path& dest, pcstr src) const
 {
     R_ASSERT(dest);
     R_ASSERT(src);
@@ -109,7 +109,7 @@ LPCSTR FS_Path::_update(string_path& dest, LPCSTR src) const
     return dest;
 }
 /*
-void FS_Path::_update(xr_string& dest, LPCSTR src)const
+void FS_Path::_update(xr_string& dest, pcstr src)const
 {
 R_ASSERT(src);
 dest = xr_string(m_Path)+src;
@@ -121,10 +121,10 @@ void FS_Path::rescan_path_cb()
     FS.m_Flags.set(CLocatorAPI::flNeedRescan, TRUE);
 }
 
-bool XRCORE_API PatternMatch(LPCSTR s, LPCSTR mask)
+bool XRCORE_API PatternMatch(pcstr s, pcstr mask)
 {
-    LPCSTR cp = 0;
-    LPCSTR mp = 0;
+    pcstr cp = 0;
+    pcstr mp = 0;
     for (; *s && *mask != '*'; mask++, s++)
         if (*mask != *s && *mask != '?')
             return false;

--- a/src/xrCore/LocatorAPI_defs.h
+++ b/src/xrCore/LocatorAPI_defs.h
@@ -31,11 +31,11 @@ public:
     Flags32 m_Flags;
 
 public:
-    FS_Path(LPCSTR _Root, LPCSTR _Add, LPCSTR _DefExt = 0, LPCSTR _FilterString = 0, u32 flags = 0);
+    FS_Path(pcstr _Root, pcstr _Add, pcstr _DefExt = 0, pcstr _FilterString = 0, u32 flags = 0);
     ~FS_Path();
-    LPCSTR _update(string_path& dest, LPCSTR src) const;
-    void _set(LPCSTR add);
-    void _set_root(LPCSTR root);
+    pcstr _update(string_path& dest, pcstr src) const;
+    void _set(pcstr add);
+    void _set_root(pcstr root);
 
     void __stdcall rescan_path_cb();
 };
@@ -74,6 +74,6 @@ public:
 };
 using FS_FileSet = xr_set<FS_File>;
 
-extern bool XRCORE_API PatternMatch(LPCSTR s, LPCSTR mask);
+extern bool XRCORE_API PatternMatch(pcstr s, pcstr mask);
 
 #endif // LocatorAPI_defsH

--- a/src/xrCore/LocatorAPI_defs.h
+++ b/src/xrCore/LocatorAPI_defs.h
@@ -23,11 +23,11 @@ public:
     };
 
 public:
-    LPSTR m_Path;
-    LPSTR m_Root;
-    LPSTR m_Add;
-    LPSTR m_DefExt;
-    LPSTR m_FilterCaption;
+    pstr m_Path;
+    pstr m_Root;
+    pstr m_Add;
+    pstr m_DefExt;
+    pstr m_FilterCaption;
     Flags32 m_Flags;
 
 public:

--- a/src/xrCore/Math/MathUtil.cpp
+++ b/src/xrCore/Math/MathUtil.cpp
@@ -42,15 +42,14 @@ void Initialize()
     Skin2W = Skin2W_SSE;
     Skin3W = Skin3W_SSE;
     Skin4W = Skin4W_SSE;
-    PLCCalc = PLCCalc_SSE;
+    
 #else
     Skin1W = Skin1W_CPP;
     Skin2W = Skin2W_CPP;
     Skin3W = Skin3W_CPP;
     Skin4W = Skin4W_CPP;
-    PLCCalc = PLCCalc_SSE;
-    //PLCCalc = PLCCalc_CPP;
 #endif
+    PLCCalc = SDL_HasSSE() ? PLCCalc_SSE : PLCCalc_CPP;
     // XXX: use PLC_energy and iCeil too
     // SSE implementations of this functions is not used.
     // Found duplicate implementation in src\Layers\xrRenderPC_R1\LightShadows.cpp

--- a/src/xrCore/Math/MathUtil.cpp
+++ b/src/xrCore/Math/MathUtil.cpp
@@ -16,8 +16,8 @@
 #include "SkinXW_SSE.hpp"
 #else
 #include "SkinXW_CPP.hpp"
-#include "PLC_CPP.hpp"
 #endif
+#include "PLC_CPP.hpp"
 
 #include "_math.h"
 

--- a/src/xrCore/NET_utils.cpp
+++ b/src/xrCore/NET_utils.cpp
@@ -395,7 +395,7 @@ void NET_Packet::r_stringZ(pstr S)
 {
     if (!inistream)
     {
-        LPCSTR data = LPCSTR(&B.data[r_pos]);
+        pcstr data = pcstr(&B.data[r_pos]);
         size_t len = xr_strlen(data);
         r(S, (u32)len + 1);
     }
@@ -409,7 +409,7 @@ void NET_Packet::r_stringZ(xr_string& dest)
 {
     if (!inistream)
     {
-        dest = LPCSTR(&B.data[r_pos]);
+        dest = pcstr(&B.data[r_pos]);
         r_advance(u32(dest.size() + 1));
     }
     else
@@ -424,7 +424,7 @@ void NET_Packet::r_stringZ(shared_str& dest)
 {
     if (!inistream)
     {
-        dest = LPCSTR(&B.data[r_pos]);
+        dest = pcstr(&B.data[r_pos]);
         r_advance(dest.size() + 1);
     }
     else
@@ -439,7 +439,7 @@ void NET_Packet::skip_stringZ()
 {
     if (!inistream)
     {
-        LPCSTR data = LPCSTR(&B.data[r_pos]);
+        pcstr data = pcstr(&B.data[r_pos]);
         u32 len = xr_strlen(data);
         r_advance(len + 1);
     }
@@ -476,7 +476,7 @@ void NET_Packet::r_stringZ_s(pstr string, u32 const size)
         return;
     }
 
-    LPCSTR data = LPCSTR(B.data + r_pos);
+    pcstr data = pcstr(B.data + r_pos);
     u32 length = xr_strlen(data);
     R_ASSERT2((length + 1) <= size, "buffer overrun");
     r(string, length + 1);

--- a/src/xrCore/PostProcess/PPInfo.cpp
+++ b/src/xrCore/PostProcess/PPInfo.cpp
@@ -58,7 +58,7 @@ SPPInfo::SPPInfo()
     cm_interpolate = 0.0f;
 }
 void SPPInfo::normalize() {}
-void SPPInfo::validate(LPCSTR str)
+void SPPInfo::validate(pcstr str)
 {
     VERIFY2(_valid(duality.h), str);
     VERIFY2(_valid(duality.v), str);

--- a/src/xrCore/PostProcess/PPInfo.hpp
+++ b/src/xrCore/PostProcess/PPInfo.hpp
@@ -80,5 +80,5 @@ struct XRCORE_API SPPInfo
     void normalize();
     SPPInfo();
     SPPInfo& lerp(const SPPInfo& def, const SPPInfo& to, float factor);
-    void validate(LPCSTR str);
+    void validate(pcstr str);
 };

--- a/src/xrCore/PostProcess/PostProcess.cpp
+++ b/src/xrCore/PostProcess/PostProcess.cpp
@@ -32,7 +32,7 @@ void BasicPostProcessAnimator::Clear()
         xr_delete(m_Params[a]);
 }
 
-void BasicPostProcessAnimator::Load(LPCSTR name, bool internalFs /*= true*/)
+void BasicPostProcessAnimator::Load(pcstr name, bool internalFs /*= true*/)
 {
     m_Name = name;
     string_path full_path;
@@ -47,7 +47,7 @@ void BasicPostProcessAnimator::Load(LPCSTR name, bool internalFs /*= true*/)
     else
         xr_strcpy(full_path, name);
 
-    LPCSTR ext = strext(full_path);
+    pcstr ext = strext(full_path);
     if (ext)
     {
         if (!xr_strcmp(ext, POSTPROCESS_FILE_EXTENSION))
@@ -200,7 +200,7 @@ CPostProcessParam* BasicPostProcessAnimator::GetParam(pp_params param)
     return m_Params[param];
 }
 
-void BasicPostProcessAnimator::Save(LPCSTR name)
+void BasicPostProcessAnimator::Save(pcstr name)
 {
     IWriter* W = FS.w_open(name);
     VERIFY(W);

--- a/src/xrCore/PostProcess/PostProcess.cpp
+++ b/src/xrCore/PostProcess/PostProcess.cpp
@@ -133,7 +133,7 @@ void BasicPostProcessAnimator::SetDesiredFactor(float f, float sp)
     m_factor_speed = sp;
     VERIFY(_valid(m_factor));
     VERIFY(_valid(m_dest_factor));
-};
+}
 
 void BasicPostProcessAnimator::SetCurrentFactor(float f)
 {
@@ -141,7 +141,7 @@ void BasicPostProcessAnimator::SetCurrentFactor(float f)
     m_dest_factor = f;
     VERIFY(_valid(m_factor));
     VERIFY(_valid(m_dest_factor));
-};
+}
 
 BOOL BasicPostProcessAnimator::Process(float dt, SPPInfo& PPInfo)
 {

--- a/src/xrCore/PostProcess/PostProcess.hpp
+++ b/src/xrCore/PostProcess/PostProcess.hpp
@@ -132,8 +132,8 @@ public:
     BasicPostProcessAnimator();
     virtual ~BasicPostProcessAnimator();
     void Clear();
-    virtual void Load(LPCSTR name, bool internalFs = true);
-    IC LPCSTR Name() { return *m_Name; }
+    virtual void Load(pcstr name, bool internalFs = true);
+    IC pcstr Name() { return *m_Name; }
     virtual void Stop(float speed);
     void SetDesiredFactor(float f, float sp);
     void SetCurrentFactor(float f);
@@ -144,5 +144,5 @@ public:
     void Create();
     CPostProcessParam* GetParam(pp_params param);
     void ResetParam(pp_params param);
-    void Save(LPCSTR name);
+    void Save(pcstr name);
 };

--- a/src/xrCore/Threading/Lock.cpp
+++ b/src/xrCore/Threading/Lock.cpp
@@ -28,9 +28,9 @@ void set_add_profile_portion(add_profile_portion_callback callback) { add_profil
 struct profiler
 {
     u64 m_time;
-    LPCSTR m_timer_id;
+    pcstr m_timer_id;
 
-    IC profiler::profiler(LPCSTR timer_id)
+    IC profiler::profiler(pcstr timer_id)
     {
         if (!add_profile_portion)
             return;

--- a/src/xrCore/Threading/Lock.hpp
+++ b/src/xrCore/Threading/Lock.hpp
@@ -4,7 +4,7 @@
 #include "Common/Noncopyable.hpp"
 
 #ifdef CONFIG_PROFILE_LOCKS
-typedef void (*add_profile_portion_callback)(LPCSTR id, const u64& time);
+typedef void (*add_profile_portion_callback)(pcstr id, const u64& time);
 void XRCORE_API set_add_profile_portion(add_profile_portion_callback callback);
 
 #define STRINGIZER_HELPER(a) #a

--- a/src/xrCore/_bitwise.h
+++ b/src/xrCore/_bitwise.h
@@ -1,34 +1,17 @@
 #pragma once
-#ifndef _BITWISE_
-#define _BITWISE_
+#ifndef _BITWISE_H
+#define _BITWISE_H
 #include "math_constants.h"
 #include "_types.h"
 
 // float values defines
 #define fdSGN 0x080000000 // mask for sign bit
-#define fdMABS 0x07FFFFFFF // mask for absolute value (~sgn)
-#define fdMANT 0x0007FFFFF // mask for mantissa
-#define fdEXPO 0x07F800000 // mask for exponent
-#define fdONE 0x03F800000 // 1.0f
-#define fdHALF 0x03F000000 // 0.5f
-#define fdTWO 0x040000000 // 2.0
-#define fdOOB 0x000000000 // "out of bounds" value
-#define fdNAN 0x07fffffff // "Not a number" value
-#define fdMAX 0x07F7FFFFF // FLT_MAX
-#define fdRLE10 0x03ede5bdb // 1/ln10
 
 // integer math on floats
-#ifdef _M_AMD64
 IC bool negative(const float f) { return f < 0; }
 IC bool positive(const float f) { return f >= 0; }
 IC void set_negative(float& f) { f = -fabsf(f); }
 IC void set_positive(float& f) { f = fabsf(f); }
-#else
-IC bool negative(const float& f) { return *(unsigned*)&f & fdSGN; }
-IC bool positive(const float& f) { return (*(unsigned*)&f & fdSGN) == 0; }
-IC void set_negative(float& f) { *(unsigned*)&f |= fdSGN; }
-IC void set_positive(float& f) { *(unsigned*)&f &= ~fdSGN; }
-#endif
 
 /*
  * Here are a few nice tricks for 2's complement based machines
@@ -100,20 +83,6 @@ IC int iCeil(float x)
     return std::ceil(x);
 }
 
-// Validity checks
-IC bool fis_gremlin(const float& f)
-{
-    u8 value = u8(((*(int*)&f & 0x7f800000) >> 23) - 0x20);
-    return value > 0xc0;
-}
-IC bool fis_denormal(const float& f) { return !(*(int*)&f & 0x7f800000); }
-// Approximated calculations
-IC float apx_InvSqrt(const float& n)
-{
-    long tmp = long(0xBE800000) - *(long*)&n >> 1;
-    float y = *(float*)&tmp;
-    return y * (1.47f - 0.47f * n * y * y);
-}
 // Only for [0..1] (positive) range
 IC float apx_asin(const float x)
 {

--- a/src/xrCore/_math.cpp
+++ b/src/xrCore/_math.cpp
@@ -176,7 +176,7 @@ void initialize()
     ::Random.seed(u32(CPU::GetCLK() % ((u64)0x1 << 32)));
 #endif
 }
-};
+}
 
 namespace CPU
 {

--- a/src/xrCore/_math.cpp
+++ b/src/xrCore/_math.cpp
@@ -348,7 +348,7 @@ void _initialize_cpu_thread()
 struct THREAD_NAME
 {
     DWORD dwType;
-    LPCSTR szName;
+    pcstr szName;
     DWORD dwThreadID;
     DWORD dwFlags;
 };

--- a/src/xrCore/_std_extensions.h
+++ b/src/xrCore/_std_extensions.h
@@ -166,17 +166,17 @@ IC size_t xr_strlen(const char* S) { return strlen(S); }
 //#ifndef _EDITOR
 #ifndef MASTER_GOLD
 
-inline int xr_strcpy(LPSTR destination, size_t const destination_size, pcstr source)
+inline int xr_strcpy(pstr destination, size_t const destination_size, pcstr source)
 {
     return strcpy_s(destination, destination_size, source);
 }
 
-inline int xr_strcat(LPSTR destination, size_t const buffer_size, pcstr source)
+inline int xr_strcat(pstr destination, size_t const buffer_size, pcstr source)
 {
     return strcat_s(destination, buffer_size, source);
 }
 
-inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, pcstr format_string, ...)
+inline int __cdecl xr_sprintf(pstr destination, size_t const buffer_size, pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);
@@ -196,16 +196,16 @@ inline int __cdecl xr_sprintf(char (&destination)[count], pcstr format_string, .
 }
 #else // #ifndef MASTER_GOLD
 
-inline int xr_strcpy(LPSTR destination, size_t const destination_size, pcstr source)
+inline int xr_strcpy(pstr destination, size_t const destination_size, pcstr source)
 {
     return strncpy_s(destination, destination_size, source, destination_size);
 }
 
-inline int xr_strcat(LPSTR destination, size_t const buffer_size, pcstr source)
+inline int xr_strcat(pstr destination, size_t const buffer_size, pcstr source)
 {
     size_t const destination_length = xr_strlen(destination);
-    LPSTR i = destination + destination_length;
-    LPSTR const e = destination + buffer_size - 1;
+    pstr i = destination + destination_length;
+    pstr const e = destination + buffer_size - 1;
     if (i > e)
         return 0;
 
@@ -216,7 +216,7 @@ inline int xr_strcat(LPSTR destination, size_t const buffer_size, pcstr source)
     return 0;
 }
 
-inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, pcstr format_string, ...)
+inline int __cdecl xr_sprintf(pstr destination, size_t const buffer_size, pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);

--- a/src/xrCore/_std_extensions.h
+++ b/src/xrCore/_std_extensions.h
@@ -178,6 +178,7 @@ inline int xr_strcat(pstr destination, size_t const buffer_size, pcstr source)
 
 inline int __cdecl xr_sprintf(pstr destination, size_t const buffer_size, pcstr format_string, ...)
 {
+    UNUSED(buffer_size);
     va_list args;
     va_start(args, format_string);
     const int result = vsprintf_s(destination, buffer_size, format_string, args);

--- a/src/xrCore/_std_extensions.h
+++ b/src/xrCore/_std_extensions.h
@@ -166,17 +166,17 @@ IC size_t xr_strlen(const char* S) { return strlen(S); }
 //#ifndef _EDITOR
 #ifndef MASTER_GOLD
 
-inline int xr_strcpy(LPSTR destination, size_t const destination_size, LPCSTR source)
+inline int xr_strcpy(LPSTR destination, size_t const destination_size, pcstr source)
 {
     return strcpy_s(destination, destination_size, source);
 }
 
-inline int xr_strcat(LPSTR destination, size_t const buffer_size, LPCSTR source)
+inline int xr_strcat(LPSTR destination, size_t const buffer_size, pcstr source)
 {
     return strcat_s(destination, buffer_size, source);
 }
 
-inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, LPCSTR format_string, ...)
+inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);
@@ -186,7 +186,7 @@ inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, LPCST
 }
 
 template <int count>
-inline int __cdecl xr_sprintf(char (&destination)[count], LPCSTR format_string, ...)
+inline int __cdecl xr_sprintf(char (&destination)[count], pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);
@@ -196,12 +196,12 @@ inline int __cdecl xr_sprintf(char (&destination)[count], LPCSTR format_string, 
 }
 #else // #ifndef MASTER_GOLD
 
-inline int xr_strcpy(LPSTR destination, size_t const destination_size, LPCSTR source)
+inline int xr_strcpy(LPSTR destination, size_t const destination_size, pcstr source)
 {
     return strncpy_s(destination, destination_size, source, destination_size);
 }
 
-inline int xr_strcat(LPSTR destination, size_t const buffer_size, LPCSTR source)
+inline int xr_strcat(LPSTR destination, size_t const buffer_size, pcstr source)
 {
     size_t const destination_length = xr_strlen(destination);
     LPSTR i = destination + destination_length;
@@ -209,14 +209,14 @@ inline int xr_strcat(LPSTR destination, size_t const buffer_size, LPCSTR source)
     if (i > e)
         return 0;
 
-    for (LPCSTR j = source; *j && (i != e); ++i, ++j)
+    for (pcstr j = source; *j && (i != e); ++i, ++j)
         *i = *j;
 
     *i = 0;
     return 0;
 }
 
-inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, LPCSTR format_string, ...)
+inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);
@@ -226,7 +226,7 @@ inline int __cdecl xr_sprintf(LPSTR destination, size_t const buffer_size, LPCST
 }
 
 template <int count>
-inline int __cdecl xr_sprintf(char (&destination)[count], LPCSTR format_string, ...)
+inline int __cdecl xr_sprintf(char (&destination)[count], pcstr format_string, ...)
 {
     va_list args;
     va_start(args, format_string);
@@ -237,13 +237,13 @@ inline int __cdecl xr_sprintf(char (&destination)[count], LPCSTR format_string, 
 #endif // #ifndef MASTER_GOLD
 
 template <int count>
-inline int xr_strcpy(char(&destination)[count], LPCSTR source)
+inline int xr_strcpy(char(&destination)[count], pcstr source)
 {
     return xr_strcpy(destination, count, source);
 }
 
 template <int count>
-inline int xr_strcat(char(&destination)[count], LPCSTR source)
+inline int xr_strcat(char(&destination)[count], pcstr source)
 {
     return xr_strcat(destination, count, source);
 }

--- a/src/xrCore/clsid.cpp
+++ b/src/xrCore/clsid.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #pragma hdrstop
 
-XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, LPSTR text)
+XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, pstr text)
 {
     text[8] = 0;
     for (int i = 7; i >= 0; i--)

--- a/src/xrCore/clsid.cpp
+++ b/src/xrCore/clsid.cpp
@@ -10,7 +10,7 @@ XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, LPSTR text)
         id >>= 8;
     }
 }
-XRCORE_API CLASS_ID __stdcall TEXT2CLSID(LPCSTR text)
+XRCORE_API CLASS_ID __stdcall TEXT2CLSID(pcstr text)
 {
     VERIFY3(xr_strlen(text) <= 8, "Beer from creator CLASS_ID:", text);
     char buf[9];

--- a/src/xrCore/clsid.h
+++ b/src/xrCore/clsid.h
@@ -13,6 +13,6 @@ typedef u64 CLASS_ID;
 #define MK_CLSID_INV(a, b, c, d, e, f, g, h) MK_CLSID(h, g, f, e, d, c, b, a)
 
 extern XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, LPSTR text);
-extern XRCORE_API CLASS_ID __stdcall TEXT2CLSID(LPCSTR text);
+extern XRCORE_API CLASS_ID __stdcall TEXT2CLSID(pcstr text);
 
 #endif

--- a/src/xrCore/clsid.h
+++ b/src/xrCore/clsid.h
@@ -12,7 +12,7 @@ typedef u64 CLASS_ID;
 
 #define MK_CLSID_INV(a, b, c, d, e, f, g, h) MK_CLSID(h, g, f, e, d, c, b, a)
 
-extern XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, LPSTR text);
+extern XRCORE_API void __stdcall CLSID2TEXT(CLASS_ID id, pstr text);
 extern XRCORE_API CLASS_ID __stdcall TEXT2CLSID(pcstr text);
 
 #endif

--- a/src/xrCore/fastdelegate.h
+++ b/src/xrCore/fastdelegate.h
@@ -672,7 +672,7 @@ public:
     inline bool operator<(const DelegateMemento& right) { return IsLess(right); }
     inline bool operator>(const DelegateMemento& right) { return right.IsLess(*this); }
     DelegateMemento(const DelegateMemento& right)
-        : m_pFunction(right.m_pFunction), m_pthis(right.m_pthis)
+        : m_pthis(right.m_pthis), m_pFunction(right.m_pFunction)
 #if !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)
           ,
           m_pStaticFunction(right.m_pStaticFunction)

--- a/src/xrCore/file_stream_reader.cpp
+++ b/src/xrCore/file_stream_reader.cpp
@@ -4,7 +4,7 @@
 #include <fcntl.h>
 #endif
 
-void CFileStreamReader::construct(LPCSTR file_name, const u32& window_size)
+void CFileStreamReader::construct(pcstr file_name, const u32& window_size)
 {
 #if defined(WINDOWS)
     m_file_handle = CreateFile(file_name, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, 0, 0);

--- a/src/xrCore/file_stream_reader.h
+++ b/src/xrCore/file_stream_reader.h
@@ -16,7 +16,7 @@ private:
 #endif
 
 public:
-    virtual void construct(LPCSTR file_name, const u32& window_size);
+    virtual void construct(pcstr file_name, const u32& window_size);
     virtual void destroy();
 };
 

--- a/src/xrCore/log.cpp
+++ b/src/xrCore/log.cpp
@@ -201,7 +201,7 @@ LogCallback SetLogCB(const LogCallback& cb)
     return (result);
 }
 
-LPCSTR log_name() { return (log_file_name); }
+pcstr log_name() { return (log_file_name); }
 
 void CreateLog(BOOL nl)
 {
@@ -234,7 +234,7 @@ void CreateLog(BOOL nl)
 
         for (u32 it = 0; it < LogFile.size(); it++)
         {
-            LPCSTR s = LogFile[it].c_str();
+            pcstr s = LogFile[it].c_str();
             LogWriter->w_printf("%s%s\n", buf, s ? s : "");
         }
         LogWriter->flush();

--- a/src/xrCore/log.h
+++ b/src/xrCore/log.h
@@ -11,17 +11,17 @@ template <class T> struct _matrix; typedef _matrix<float> Fmatrix;
 
 #define VPUSH(a) ((a).x), ((a).y), ((a).z)
 
-void XRCORE_API __cdecl Msg(LPCSTR format, ...);
-void XRCORE_API Log(LPCSTR msg);
-void XRCORE_API Log(LPCSTR msg);
-void XRCORE_API Log(LPCSTR msg, LPCSTR dop);
-void XRCORE_API Log(LPCSTR msg, u32 dop);
-void XRCORE_API Log(LPCSTR msg, u64 dop);
-void XRCORE_API Log(LPCSTR msg, int dop);
-void XRCORE_API Log(LPCSTR msg, float dop);
-void XRCORE_API Log(LPCSTR msg, const Fvector& dop);
-void XRCORE_API Log(LPCSTR msg, const Fmatrix& dop);
-void XRCORE_API LogWinErr(LPCSTR msg, long err_code);
+void XRCORE_API __cdecl Msg(pcstr format, ...);
+void XRCORE_API Log(pcstr msg);
+void XRCORE_API Log(pcstr msg);
+void XRCORE_API Log(pcstr msg, pcstr dop);
+void XRCORE_API Log(pcstr msg, u32 dop);
+void XRCORE_API Log(pcstr msg, u64 dop);
+void XRCORE_API Log(pcstr msg, int dop);
+void XRCORE_API Log(pcstr msg, float dop);
+void XRCORE_API Log(pcstr msg, const Fvector& dop);
+void XRCORE_API Log(pcstr msg, const Fmatrix& dop);
+void XRCORE_API LogWinErr(pcstr msg, long err_code);
 
 struct LogCallback
 {

--- a/src/xrCore/net_utils.h
+++ b/src/xrCore/net_utils.h
@@ -33,7 +33,7 @@ struct XRCORE_API IIniFileStream
     virtual void __stdcall w_s16(s16 a) = 0;
     virtual void __stdcall w_u8(u8 a) = 0;
     virtual void __stdcall w_s8(s8 a) = 0;
-    virtual void __stdcall w_stringZ(LPCSTR S) = 0;
+    virtual void __stdcall w_stringZ(pcstr S) = 0;
 
     virtual void __stdcall r_vec3(Fvector&) = 0;
     virtual void __stdcall r_vec4(Fvector4&) = 0;

--- a/src/xrCore/net_utils.h
+++ b/src/xrCore/net_utils.h
@@ -93,7 +93,7 @@ public:
     bool w_allow;
 
 public:
-    NET_Packet() : inistream(nullptr), r_pos(0), timeReceive(0), w_allow(true), B() {}
+    NET_Packet() : inistream(nullptr), B(), r_pos(0), timeReceive(0), w_allow(true) {}
     // writing - main
     IC void write_start()
     {

--- a/src/xrCore/string_concatenations.cpp
+++ b/src/xrCore/string_concatenations.cpp
@@ -93,7 +93,7 @@ void check_stack_overflow(u32 stack_increment)
 
 void string_tupples::error_process() const
 {
-    LPCSTR strings[6];
+    pcstr strings[6];
 
     u32 part_size = 0;
     u32 overrun_string_index = (u32)-1;

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -564,7 +564,7 @@ void xrDebug::DoExit(const std::string& message)
 #endif
 }
 
-LPCSTR xrDebug::ErrorToString(long code)
+pcstr xrDebug::ErrorToString(long code)
 {
     const char* result = nullptr;
     static string1024 descStorage;
@@ -597,7 +597,7 @@ int out_of_memory_handler(size_t size)
     return 1;
 }
 
-extern LPCSTR log_name();
+extern pcstr log_name();
 
 void WINAPI xrDebug::PreErrorHandler(INT_PTR)
 {

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -688,7 +688,7 @@ void xrDebug::FormatLastError(char* buffer, const size_t& bufferSize)
     }
     void* msg = nullptr;
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, nullptr, lastErr,
-                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&msg, 0, nullptr);
+                  MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (pstr)&msg, 0, nullptr);
     // XXX nitrocaster: check buffer overflow
     xr_sprintf(buffer, bufferSize, "[error][%8d]: %s", lastErr, (char*)msg);
     LocalFree(msg);

--- a/src/xrCore/xr_ini.cpp
+++ b/src/xrCore/xr_ini.cpp
@@ -396,7 +396,7 @@ IC bool is_empty_line_now(IReader* F)
     char* a3 = (char*)F->pointer() - 1;
 
     return *a0 == 13 && *a1 == 10 && *a2 == 13 && *a3 == 10;
-};
+}
 
 void CInifile::Load(IReader* F, pcstr path, allow_include_func_t allow_include_func)
 {

--- a/src/xrCore/xr_trims.cpp
+++ b/src/xrCore/xr_trims.cpp
@@ -3,14 +3,14 @@
 #include "xrCore/xr_token.h"
 #include "xrCore/_std_extensions.h"
 
-LPSTR _TrimLeft(LPSTR str)
+pstr _TrimLeft(pstr str)
 {
-    LPSTR p = str;
+    pstr p = str;
     while (*p && (u8(*p) <= u8(' ')))
         p++;
     if (p != str)
     {
-        LPSTR t = str;
+        pstr t = str;
         for (; *p; t++, p++)
             *t = *p;
         *t = 0;
@@ -18,16 +18,16 @@ LPSTR _TrimLeft(LPSTR str)
     return str;
 }
 
-LPSTR _TrimRight(LPSTR str)
+pstr _TrimRight(pstr str)
 {
-    LPSTR p = str + xr_strlen(str);
+    pstr p = str + xr_strlen(str);
     while ((p != str) && (u8(*p) <= u8(' ')))
         p--;
     *(++p) = 0;
     return str;
 }
 
-LPSTR _Trim(LPSTR str)
+pstr _Trim(pstr str)
 {
     _TrimLeft(str);
     _TrimRight(str);
@@ -46,7 +46,7 @@ pcstr _SetPos(pcstr src, u32 pos, char separator)
     return res;
 }
 
-pcstr _CopyVal(pcstr src, LPSTR dst, char separator)
+pcstr _CopyVal(pcstr src, pstr dst, char separator)
 {
     pcstr p;
     size_t n;
@@ -78,7 +78,7 @@ int _GetItemCount(pcstr src, char separator)
     return cnt;
 }
 
-LPSTR _GetItem(pcstr src, int index, LPSTR dst, u32 const dst_size, char separator, pcstr def, bool trim)
+pstr _GetItem(pcstr src, int index, pstr dst, u32 const dst_size, char separator, pcstr def, bool trim)
 {
     pcstr ptr;
     ptr = _SetPos(src, index, separator);
@@ -91,9 +91,9 @@ LPSTR _GetItem(pcstr src, int index, LPSTR dst, u32 const dst_size, char separat
     return dst;
 }
 
-LPSTR _GetItems(pcstr src, int idx_start, int idx_end, LPSTR dst, char separator)
+pstr _GetItems(pcstr src, int idx_start, int idx_end, pstr dst, char separator)
 {
-    LPSTR n = dst;
+    pstr n = dst;
     int level = 0;
     for (pcstr p = src; *p != 0; p++)
     {
@@ -131,16 +131,16 @@ u32 _ParseItem(pcstr src, xr_token* token_list)
     return u32(-1);
 }
 
-u32 _ParseItem(LPSTR src, int ind, xr_token* token_list)
+u32 _ParseItem(pstr src, int ind, xr_token* token_list)
 {
     char dst[128];
     _GetItem(src, ind, dst);
     return _ParseItem(dst, token_list);
 }
 
-LPSTR _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, LPSTR dst, char separator)
+pstr _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, pstr dst, char separator)
 {
-    LPSTR n = dst;
+    pstr n = dst;
     int level = 0;
     bool bCopy = true;
     for (pcstr p = src; *p != 0; p++)
@@ -195,9 +195,9 @@ xr_string& _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items,
     return dst;
 }
 
-LPSTR _ReplaceItem(pcstr src, int index, pcstr new_item, LPSTR dst, char separator)
+pstr _ReplaceItem(pcstr src, int index, pcstr new_item, pstr dst, char separator)
 {
-    LPSTR n = dst;
+    pstr n = dst;
     int level = 0;
     bool bCopy = true;
     for (pcstr p = src; *p != 0; p++)
@@ -252,7 +252,7 @@ xr_string& _ReplaceItem(pcstr src, int index, pcstr new_item, xr_string& dst, ch
     return dst;
 }
 
-LPSTR _ChangeSymbol(LPSTR name, char src, char dest)
+pstr _ChangeSymbol(pstr name, char src, char dest)
 {
     char* sTmpName = name;
     while (sTmpName[0])
@@ -398,7 +398,7 @@ float StrTimeToFloatTime(pcstr buf, bool _h, bool _m, bool _s, bool _ms)
 }
 #endif
 
-void _SequenceToList(LPSTRVec& lst, pcstr in, char separator)
+void _SequenceToList(pstrVec& lst, pcstr in, char separator)
 {
     int t_cnt = _GetItemCount(in, separator);
     string1024 T;

--- a/src/xrCore/xr_trims.cpp
+++ b/src/xrCore/xr_trims.cpp
@@ -34,9 +34,9 @@ LPSTR _Trim(LPSTR str)
     return str;
 }
 
-LPCSTR _SetPos(LPCSTR src, u32 pos, char separator)
+pcstr _SetPos(pcstr src, u32 pos, char separator)
 {
-    LPCSTR res = src;
+    pcstr res = src;
     u32 p = 0;
     while ((p < pos) && (0 != (res = strchr(res, separator))))
     {
@@ -46,9 +46,9 @@ LPCSTR _SetPos(LPCSTR src, u32 pos, char separator)
     return res;
 }
 
-LPCSTR _CopyVal(LPCSTR src, LPSTR dst, char separator)
+pcstr _CopyVal(pcstr src, LPSTR dst, char separator)
 {
-    LPCSTR p;
+    pcstr p;
     size_t n;
     p = strchr(src, separator);
     n = (p != nullptr) ? (p - src) : xr_strlen(src);
@@ -57,13 +57,13 @@ LPCSTR _CopyVal(LPCSTR src, LPSTR dst, char separator)
     return dst;
 }
 
-int _GetItemCount(LPCSTR src, char separator)
+int _GetItemCount(pcstr src, char separator)
 {
     u32 cnt = 0;
     if (src && src[0])
     {
-        LPCSTR res = src;
-        LPCSTR last_res = res;
+        pcstr res = src;
+        pcstr last_res = res;
         while (0 != (res = strchr(res, separator)))
         {
             res++;
@@ -78,9 +78,9 @@ int _GetItemCount(LPCSTR src, char separator)
     return cnt;
 }
 
-LPSTR _GetItem(LPCSTR src, int index, LPSTR dst, u32 const dst_size, char separator, LPCSTR def, bool trim)
+LPSTR _GetItem(pcstr src, int index, LPSTR dst, u32 const dst_size, char separator, pcstr def, bool trim)
 {
-    LPCSTR ptr;
+    pcstr ptr;
     ptr = _SetPos(src, index, separator);
     if (ptr)
         _CopyVal(ptr, dst, separator);
@@ -91,11 +91,11 @@ LPSTR _GetItem(LPCSTR src, int index, LPSTR dst, u32 const dst_size, char separa
     return dst;
 }
 
-LPSTR _GetItems(LPCSTR src, int idx_start, int idx_end, LPSTR dst, char separator)
+LPSTR _GetItems(pcstr src, int idx_start, int idx_end, LPSTR dst, char separator)
 {
     LPSTR n = dst;
     int level = 0;
-    for (LPCSTR p = src; *p != 0; p++)
+    for (pcstr p = src; *p != 0; p++)
     {
         if ((level >= idx_start) && (level < idx_end))
             *n++ = *p;
@@ -123,7 +123,7 @@ pcstr _GetItems(pcstr src, int idx_start, int idx_end, xr_string& dst, char sepa
     return dst.c_str();
 }
 
-u32 _ParseItem(LPCSTR src, xr_token* token_list)
+u32 _ParseItem(pcstr src, xr_token* token_list)
 {
     for (int i = 0; token_list[i].name; i++)
         if (!xr_stricmp(src, token_list[i].name))
@@ -138,18 +138,18 @@ u32 _ParseItem(LPSTR src, int ind, xr_token* token_list)
     return _ParseItem(dst, token_list);
 }
 
-LPSTR _ReplaceItems(LPCSTR src, int idx_start, int idx_end, LPCSTR new_items, LPSTR dst, char separator)
+LPSTR _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, LPSTR dst, char separator)
 {
     LPSTR n = dst;
     int level = 0;
     bool bCopy = true;
-    for (LPCSTR p = src; *p != 0; p++)
+    for (pcstr p = src; *p != 0; p++)
     {
         if ((level >= idx_start) && (level < idx_end))
         {
             if (bCopy)
             {
-                for (LPCSTR itm = new_items; *itm != 0;)
+                for (pcstr itm = new_items; *itm != 0;)
                     *n++ = *itm++;
                 bCopy = false;
             }
@@ -195,18 +195,18 @@ xr_string& _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items,
     return dst;
 }
 
-LPSTR _ReplaceItem(LPCSTR src, int index, LPCSTR new_item, LPSTR dst, char separator)
+LPSTR _ReplaceItem(pcstr src, int index, pcstr new_item, LPSTR dst, char separator)
 {
     LPSTR n = dst;
     int level = 0;
     bool bCopy = true;
-    for (LPCSTR p = src; *p != 0; p++)
+    for (pcstr p = src; *p != 0; p++)
     {
         if (level == index)
         {
             if (bCopy)
             {
-                for (LPCSTR itm = new_item; *itm != 0;)
+                for (pcstr itm = new_item; *itm != 0;)
                     *n++ = *itm++;
                 bCopy = false;
             }
@@ -274,9 +274,9 @@ xr_string& _ChangeSymbol(xr_string& name, char src, char dest)
 
 #ifdef M_BORLAND
 AnsiString& _Trim(AnsiString& str) { return str = str.Trim(); }
-LPCSTR _CopyVal(LPCSTR src, AnsiString& dst, char separator)
+pcstr _CopyVal(pcstr src, AnsiString& dst, char separator)
 {
-    LPCSTR p;
+    pcstr p;
     u32 n;
     p = strchr(src, separator);
     n = (p != nullptr) ? (p - src) : xr_strlen(src);
@@ -287,9 +287,9 @@ LPCSTR _CopyVal(LPCSTR src, AnsiString& dst, char separator)
 
 
 
-LPCSTR _GetItem(LPCSTR src, int index, AnsiString& dst, char separator, LPCSTR def, bool trim)
+pcstr _GetItem(pcstr src, int index, AnsiString& dst, char separator, pcstr def, bool trim)
 {
-    LPCSTR ptr;
+    pcstr ptr;
     ptr = _SetPos(src, index, separator);
     if (ptr)
         _CopyVal(ptr, dst, separator);
@@ -328,7 +328,7 @@ AnsiString _ListToSequence2(const AStringVec& lst)
     return out;
 }
 
-void _SequenceToList(AStringVec& lst, LPCSTR in, char separator)
+void _SequenceToList(AStringVec& lst, pcstr in, char separator)
 {
     lst.clear();
     int t_cnt = _GetItemCount(in, separator);
@@ -374,7 +374,7 @@ AnsiString FloatTimeToStrTime(float v, bool _h, bool _m, bool _s, bool _ms)
     return buf;
 }
 
-float StrTimeToFloatTime(LPCSTR buf, bool _h, bool _m, bool _s, bool _ms)
+float StrTimeToFloatTime(pcstr buf, bool _h, bool _m, bool _s, bool _ms)
 {
     float t[4] = {0.f, 0.f, 0.f, 0.f};
     int rm[4];
@@ -398,7 +398,7 @@ float StrTimeToFloatTime(LPCSTR buf, bool _h, bool _m, bool _s, bool _ms)
 }
 #endif
 
-void _SequenceToList(LPSTRVec& lst, LPCSTR in, char separator)
+void _SequenceToList(LPSTRVec& lst, pcstr in, char separator)
 {
     int t_cnt = _GetItemCount(in, separator);
     string1024 T;
@@ -411,7 +411,7 @@ void _SequenceToList(LPSTRVec& lst, LPCSTR in, char separator)
     }
 }
 
-void _SequenceToList(xr_vector<shared_str>& lst, LPCSTR in, char separator)
+void _SequenceToList(xr_vector<shared_str>& lst, pcstr in, char separator)
 {
     lst.clear();
     int t_cnt = _GetItemCount(in, separator);
@@ -425,7 +425,7 @@ void _SequenceToList(xr_vector<shared_str>& lst, LPCSTR in, char separator)
     }
 }
 
-void _SequenceToList(SStringVec& lst, LPCSTR in, char separator)
+void _SequenceToList(SStringVec& lst, pcstr in, char separator)
 {
     lst.clear();
     int t_cnt = _GetItemCount(in, separator);
@@ -454,8 +454,8 @@ xr_string _ListToSequence(const SStringVec& lst)
 
 xr_string& _TrimLeft(xr_string& str)
 {
-    LPCSTR b = str.c_str();
-    LPCSTR p = str.c_str();
+    pcstr b = str.c_str();
+    pcstr p = str.c_str();
     while (*p && (u8(*p) <= u8(' ')))
         p++;
     if (p != b)
@@ -465,11 +465,11 @@ xr_string& _TrimLeft(xr_string& str)
 
 xr_string& _TrimRight(xr_string& str)
 {
-    LPCSTR b = str.c_str();
+    pcstr b = str.c_str();
     size_t l = str.length();
     if (l)
     {
-        LPCSTR p = str.c_str() + l - 1;
+        pcstr p = str.c_str() + l - 1;
         while ((p != b) && (u8(*p) <= u8(' ')))
             p--;
         if (p != (str + b))
@@ -485,9 +485,9 @@ xr_string& _Trim(xr_string& str)
     return str;
 }
 
-LPCSTR _CopyVal(LPCSTR src, xr_string& dst, char separator)
+pcstr _CopyVal(pcstr src, xr_string& dst, char separator)
 {
-    LPCSTR p;
+    pcstr p;
     std::ptrdiff_t n;
     p = strchr(src, separator);
     n = (p != nullptr) ? (p - src) : xr_strlen(src);
@@ -496,9 +496,9 @@ LPCSTR _CopyVal(LPCSTR src, xr_string& dst, char separator)
     return dst.c_str();
 }
 
-LPCSTR _GetItem(LPCSTR src, int index, xr_string& dst, char separator, LPCSTR def, bool trim)
+pcstr _GetItem(pcstr src, int index, xr_string& dst, char separator, pcstr def, bool trim)
 {
-    LPCSTR ptr;
+    pcstr ptr;
     ptr = _SetPos(src, index, separator);
     if (ptr)
         _CopyVal(ptr, dst, separator);

--- a/src/xrCore/xr_trims.h
+++ b/src/xrCore/xr_trims.h
@@ -21,30 +21,30 @@ XRCORE_API float StrTimeToFloatTime(pcstr buf, bool h = true, bool m = true, boo
 #endif
 
 XRCORE_API int _GetItemCount(pcstr, char separator = ',');
-XRCORE_API LPSTR _GetItem(pcstr, int, LPSTR, u32 const dst_size, char separator = ',', pcstr = "", bool trim = true);
+XRCORE_API pstr _GetItem(pcstr, int, pstr, u32 const dst_size, char separator = ',', pcstr = "", bool trim = true);
 
 template <int count>
-inline LPSTR _GetItem(
+inline pstr _GetItem(
     pcstr src, int index, char (&dst)[count], char separator = ',', pcstr def = "", bool trim = true)
 {
     return _GetItem(src, index, dst, count, separator, def, trim);
 }
 
-XRCORE_API LPSTR _GetItems(pcstr, int, int, LPSTR, char separator = ',');
+XRCORE_API pstr _GetItems(pcstr, int, int, pstr, char separator = ',');
 XRCORE_API pcstr _GetItems(pcstr, int, int, xr_string&, char);
 XRCORE_API pcstr _SetPos(pcstr src, u32 pos, char separator = ',');
-XRCORE_API pcstr _CopyVal(pcstr src, LPSTR dst, char separator = ',');
-XRCORE_API LPSTR _Trim(LPSTR str);
-XRCORE_API LPSTR _TrimLeft(LPSTR str);
-XRCORE_API LPSTR _TrimRight(LPSTR str);
-XRCORE_API LPSTR _ChangeSymbol(LPSTR name, char src, char dest);
+XRCORE_API pcstr _CopyVal(pcstr src, pstr dst, char separator = ',');
+XRCORE_API pstr _Trim(pstr str);
+XRCORE_API pstr _TrimLeft(pstr str);
+XRCORE_API pstr _TrimRight(pstr str);
+XRCORE_API pstr _ChangeSymbol(pstr name, char src, char dest);
 XRCORE_API u32 _ParseItem(pcstr src, xr_token* token_list);
-XRCORE_API u32 _ParseItem(LPSTR src, int ind, xr_token* token_list);
-XRCORE_API LPSTR _ReplaceItem(pcstr src, int index, pcstr new_item, LPSTR dst, char separator);
+XRCORE_API u32 _ParseItem(pstr src, int ind, xr_token* token_list);
+XRCORE_API pstr _ReplaceItem(pcstr src, int index, pcstr new_item, pstr dst, char separator);
 XRCORE_API xr_string& _ReplaceItem(pcstr src, int index, pcstr new_item, xr_string& dst, char separator);
-XRCORE_API LPSTR _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, LPSTR dst, char separator);
+XRCORE_API pstr _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, pstr dst, char separator);
 XRCORE_API xr_string& _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, xr_string& dst, char separator);
-XRCORE_API void _SequenceToList(LPSTRVec& lst, pcstr in, char separator = ',');
+XRCORE_API void _SequenceToList(pstrVec& lst, pcstr in, char separator = ',');
 XRCORE_API void _SequenceToList(RStringVec& lst, pcstr in, char separator = ',');
 XRCORE_API void _SequenceToList(SStringVec& lst, pcstr in, char separator = ',');
 

--- a/src/xrCore/xr_trims.h
+++ b/src/xrCore/xr_trims.h
@@ -11,49 +11,49 @@ using string64Vec = xr_vector<string64>;
 
 #ifdef __BORLANDC__
 XRCORE_API AnsiString& _Trim(AnsiString& str);
-XRCORE_API LPCSTR _GetItem(LPCSTR src, int, AnsiString& p, char separator = ',', LPCSTR = "", bool trim = true);
-XRCORE_API LPCSTR _CopyVal(LPCSTR src, AnsiString& dst, char separator = ',');
+XRCORE_API pcstr _GetItem(pcstr src, int, AnsiString& p, char separator = ',', pcstr = "", bool trim = true);
+XRCORE_API pcstr _CopyVal(pcstr src, AnsiString& dst, char separator = ',');
 XRCORE_API AnsiString _ListToSequence(const AStringVec& lst);
 XRCORE_API AnsiString _ListToSequence2(const AStringVec& lst);
-XRCORE_API void _SequenceToList(AStringVec& lst, LPCSTR in, char separator = ',');
+XRCORE_API void _SequenceToList(AStringVec& lst, pcstr in, char separator = ',');
 XRCORE_API AnsiString FloatTimeToStrTime(float v, bool h = true, bool m = true, bool s = true, bool ms = false);
-XRCORE_API float StrTimeToFloatTime(LPCSTR buf, bool h = true, bool m = true, bool s = true, bool ms = false);
+XRCORE_API float StrTimeToFloatTime(pcstr buf, bool h = true, bool m = true, bool s = true, bool ms = false);
 #endif
 
-XRCORE_API int _GetItemCount(LPCSTR, char separator = ',');
-XRCORE_API LPSTR _GetItem(LPCSTR, int, LPSTR, u32 const dst_size, char separator = ',', LPCSTR = "", bool trim = true);
+XRCORE_API int _GetItemCount(pcstr, char separator = ',');
+XRCORE_API LPSTR _GetItem(pcstr, int, LPSTR, u32 const dst_size, char separator = ',', pcstr = "", bool trim = true);
 
 template <int count>
 inline LPSTR _GetItem(
-    LPCSTR src, int index, char (&dst)[count], char separator = ',', LPCSTR def = "", bool trim = true)
+    pcstr src, int index, char (&dst)[count], char separator = ',', pcstr def = "", bool trim = true)
 {
     return _GetItem(src, index, dst, count, separator, def, trim);
 }
 
-XRCORE_API LPSTR _GetItems(LPCSTR, int, int, LPSTR, char separator = ',');
+XRCORE_API LPSTR _GetItems(pcstr, int, int, LPSTR, char separator = ',');
 XRCORE_API pcstr _GetItems(pcstr, int, int, xr_string&, char);
-XRCORE_API LPCSTR _SetPos(LPCSTR src, u32 pos, char separator = ',');
-XRCORE_API LPCSTR _CopyVal(LPCSTR src, LPSTR dst, char separator = ',');
+XRCORE_API pcstr _SetPos(pcstr src, u32 pos, char separator = ',');
+XRCORE_API pcstr _CopyVal(pcstr src, LPSTR dst, char separator = ',');
 XRCORE_API LPSTR _Trim(LPSTR str);
 XRCORE_API LPSTR _TrimLeft(LPSTR str);
 XRCORE_API LPSTR _TrimRight(LPSTR str);
 XRCORE_API LPSTR _ChangeSymbol(LPSTR name, char src, char dest);
-XRCORE_API u32 _ParseItem(LPCSTR src, xr_token* token_list);
+XRCORE_API u32 _ParseItem(pcstr src, xr_token* token_list);
 XRCORE_API u32 _ParseItem(LPSTR src, int ind, xr_token* token_list);
-XRCORE_API LPSTR _ReplaceItem(LPCSTR src, int index, LPCSTR new_item, LPSTR dst, char separator);
+XRCORE_API LPSTR _ReplaceItem(pcstr src, int index, pcstr new_item, LPSTR dst, char separator);
 XRCORE_API xr_string& _ReplaceItem(pcstr src, int index, pcstr new_item, xr_string& dst, char separator);
-XRCORE_API LPSTR _ReplaceItems(LPCSTR src, int idx_start, int idx_end, LPCSTR new_items, LPSTR dst, char separator);
+XRCORE_API LPSTR _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, LPSTR dst, char separator);
 XRCORE_API xr_string& _ReplaceItems(pcstr src, int idx_start, int idx_end, pcstr new_items, xr_string& dst, char separator);
-XRCORE_API void _SequenceToList(LPSTRVec& lst, LPCSTR in, char separator = ',');
-XRCORE_API void _SequenceToList(RStringVec& lst, LPCSTR in, char separator = ',');
-XRCORE_API void _SequenceToList(SStringVec& lst, LPCSTR in, char separator = ',');
+XRCORE_API void _SequenceToList(LPSTRVec& lst, pcstr in, char separator = ',');
+XRCORE_API void _SequenceToList(RStringVec& lst, pcstr in, char separator = ',');
+XRCORE_API void _SequenceToList(SStringVec& lst, pcstr in, char separator = ',');
 
 XRCORE_API xr_string& _Trim(xr_string& src);
 XRCORE_API xr_string& _TrimLeft(xr_string& src);
 XRCORE_API xr_string& _TrimRight(xr_string& src);
 XRCORE_API xr_string& _ChangeSymbol(xr_string& name, char src, char dest);
-XRCORE_API LPCSTR _CopyVal(LPCSTR src, xr_string& dst, char separator = ',');
-XRCORE_API LPCSTR _GetItem(LPCSTR src, int, xr_string& p, char separator = ',', LPCSTR = "", bool trim = true);
+XRCORE_API pcstr _CopyVal(pcstr src, xr_string& dst, char separator = ',');
+XRCORE_API pcstr _GetItem(pcstr src, int, xr_string& p, char separator = ',', pcstr = "", bool trim = true);
 XRCORE_API xr_string _ListToSequence(const SStringVec& lst);
 XRCORE_API shared_str _ListToSequence(const RStringVec& lst);
 

--- a/src/xrCore/xr_vector_defs.h
+++ b/src/xrCore/xr_vector_defs.h
@@ -20,7 +20,7 @@ DEFINE_VECTOR(Fvector*, LPFvectorVec, LPFvectorIt);
 DEFINE_VECTOR(Fcolor, FcolorVec, FcolorIt);
 DEFINE_VECTOR(Fcolor*, LPFcolorVec, LPFcolorIt);
 DEFINE_VECTOR(LPSTR, LPSTRVec, LPSTRIt);
-DEFINE_VECTOR(LPCSTR, LPCSTRVec, LPCSTRIt);
+DEFINE_VECTOR(pcstr, pcstrVec, pcstrIt);
 DEFINE_VECTOR(string64, string64Vec, string64It);
 DEFINE_VECTOR(xr_string, SStringVec, SStringVecIt);
 

--- a/src/xrCore/xr_vector_defs.h
+++ b/src/xrCore/xr_vector_defs.h
@@ -19,7 +19,7 @@ DEFINE_VECTOR(Fvector, FvectorVec, FvectorIt);
 DEFINE_VECTOR(Fvector*, LPFvectorVec, LPFvectorIt);
 DEFINE_VECTOR(Fcolor, FcolorVec, FcolorIt);
 DEFINE_VECTOR(Fcolor*, LPFcolorVec, LPFcolorIt);
-DEFINE_VECTOR(LPSTR, LPSTRVec, LPSTRIt);
+DEFINE_VECTOR(pstr, pstrVec, pstrIt);
 DEFINE_VECTOR(pcstr, pcstrVec, pcstrIt);
 DEFINE_VECTOR(string64, string64Vec, string64It);
 DEFINE_VECTOR(xr_string, SStringVec, SStringVecIt);

--- a/src/xrCore/xr_vector_defs.h
+++ b/src/xrCore/xr_vector_defs.h
@@ -8,38 +8,38 @@
 #include "xrCore/_color.h"
 #include "xrCommon/xr_string.h"
 
-DEFINE_VECTOR(bool, boolVec, boolIt);
-DEFINE_VECTOR(BOOL, BOOLVec, BOOLIt);
-DEFINE_VECTOR(BOOL*, LPBOOLVec, LPBOOLIt);
-DEFINE_VECTOR(Frect, FrectVec, FrectIt);
-DEFINE_VECTOR(Irect, IrectVec, IrectIt);
-DEFINE_VECTOR(Fplane, PlaneVec, PlaneIt);
-DEFINE_VECTOR(Fvector2, Fvector2Vec, Fvector2It);
-DEFINE_VECTOR(Fvector, FvectorVec, FvectorIt);
-DEFINE_VECTOR(Fvector*, LPFvectorVec, LPFvectorIt);
-DEFINE_VECTOR(Fcolor, FcolorVec, FcolorIt);
-DEFINE_VECTOR(Fcolor*, LPFcolorVec, LPFcolorIt);
-DEFINE_VECTOR(pstr, pstrVec, pstrIt);
-DEFINE_VECTOR(pcstr, pcstrVec, pcstrIt);
-DEFINE_VECTOR(string64, string64Vec, string64It);
-DEFINE_VECTOR(xr_string, SStringVec, SStringVecIt);
+DEFINE_VECTOR(bool, boolVec, boolIt)
+DEFINE_VECTOR(BOOL, BOOLVec, BOOLIt)
+DEFINE_VECTOR(BOOL*, LPBOOLVec, LPBOOLIt)
+DEFINE_VECTOR(Frect, FrectVec, FrectIt)
+DEFINE_VECTOR(Irect, IrectVec, IrectIt)
+DEFINE_VECTOR(Fplane, PlaneVec, PlaneIt)
+DEFINE_VECTOR(Fvector2, Fvector2Vec, Fvector2It)
+DEFINE_VECTOR(Fvector, FvectorVec, FvectorIt)
+DEFINE_VECTOR(Fvector*, LPFvectorVec, LPFvectorIt)
+DEFINE_VECTOR(Fcolor, FcolorVec, FcolorIt)
+DEFINE_VECTOR(Fcolor*, LPFcolorVec, LPFcolorIt)
+DEFINE_VECTOR(pstr, pstrVec, pstrIt)
+DEFINE_VECTOR(pcstr, pcstrVec, pcstrIt)
+DEFINE_VECTOR(string64, string64Vec, string64It)
+DEFINE_VECTOR(xr_string, SStringVec, SStringVecIt)
 
-DEFINE_VECTOR(s8, S8Vec, S8It);
-DEFINE_VECTOR(s8*, LPS8Vec, LPS8It);
-DEFINE_VECTOR(s16, S16Vec, S16It);
-DEFINE_VECTOR(s16*, LPS16Vec, LPS16It);
-DEFINE_VECTOR(s32, S32Vec, S32It);
-DEFINE_VECTOR(s32*, LPS32Vec, LPS32It);
-DEFINE_VECTOR(u8, U8Vec, U8It);
-DEFINE_VECTOR(u8*, LPU8Vec, LPU8It);
-DEFINE_VECTOR(u16, U16Vec, U16It);
-DEFINE_VECTOR(u16*, LPU16Vec, LPU16It);
-DEFINE_VECTOR(u32, U32Vec, U32It);
-DEFINE_VECTOR(u32*, LPU32Vec, LPU32It);
-DEFINE_VECTOR(float, FloatVec, FloatIt);
-DEFINE_VECTOR(float*, LPFloatVec, LPFloatIt);
-DEFINE_VECTOR(int, IntVec, IntIt);
-DEFINE_VECTOR(int*, LPIntVec, LPIntIt);
+DEFINE_VECTOR(s8, S8Vec, S8It)
+DEFINE_VECTOR(s8*, LPS8Vec, LPS8It)
+DEFINE_VECTOR(s16, S16Vec, S16It)
+DEFINE_VECTOR(s16*, LPS16Vec, LPS16It)
+DEFINE_VECTOR(s32, S32Vec, S32It)
+DEFINE_VECTOR(s32*, LPS32Vec, LPS32It)
+DEFINE_VECTOR(u8, U8Vec, U8It)
+DEFINE_VECTOR(u8*, LPU8Vec, LPU8It)
+DEFINE_VECTOR(u16, U16Vec, U16It)
+DEFINE_VECTOR(u16*, LPU16Vec, LPU16It)
+DEFINE_VECTOR(u32, U32Vec, U32It)
+DEFINE_VECTOR(u32*, LPU32Vec, LPU32It)
+DEFINE_VECTOR(float, FloatVec, FloatIt)
+DEFINE_VECTOR(float*, LPFloatVec, LPFloatIt)
+DEFINE_VECTOR(int, IntVec, IntIt)
+DEFINE_VECTOR(int*, LPIntVec, LPIntIt)
 
 #ifdef __BORLANDC__
 DEFINE_VECTOR(AnsiString, AStringVec, AStringIt);

--- a/src/xrCore/xrsharedmem.h
+++ b/src/xrCore/xrsharedmem.h
@@ -33,7 +33,7 @@ IC bool smem_sort(const smem_value* A, const smem_value* B)
     if (A->dwLength > B->dwLength)
         return false;
     return memcmp(A->value, B->value, A->dwLength) < 0;
-};
+}
 
 // predicate for insertion - just a quick estimate
 IC bool smem_search(const smem_value* A, const smem_value* B)
@@ -43,7 +43,7 @@ IC bool smem_search(const smem_value* A, const smem_value* B)
     if (A->dwCRC > B->dwCRC)
         return false;
     return A->dwLength < B->dwLength;
-};
+}
 
 // predicate for exact (byte level) comparition
 IC bool smem_equal(const smem_value* A, u32 dwCRC, u32 dwLength, u8* ptr)
@@ -53,7 +53,7 @@ IC bool smem_equal(const smem_value* A, u32 dwCRC, u32 dwLength, u8* ptr)
     if (A->dwLength != dwLength)
         return false;
     return 0 == memcmp(A->value, ptr, dwLength);
-};
+}
 #pragma warning(pop)
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The result of clearing compiler warnings for xrCore (options -Wall -Wextra -Wshadow -Wformat=2 -Wfloat-equal -Wlogical-op -Wshift-overflow=2 -Wduplicated-cond -Wcast-qual -Wcast-align -D_FORTIFY_SOURCE=2)