### PR TITLE
[LuaJit] Avoid submodule pollution

### DIFF
--- a/Externals/LuaJIT-proj/BuildVm.vcxproj
+++ b/Externals/LuaJIT-proj/BuildVm.vcxproj
@@ -32,7 +32,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
-    <OutDir>$(ProjectDir)..\LuaJIT\bin\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)bin\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/Externals/LuaJIT-proj/minilua.vcxproj
+++ b/Externals/LuaJIT-proj/minilua.vcxproj
@@ -32,7 +32,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
-    <OutDir>$(ProjectDir)..\LuaJIT\bin\$(PlatformShortName)\</OutDir>
+    <OutDir>$(ProjectDir)bin\$(PlatformShortName)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <WholeProgramOptimization>true</WholeProgramOptimization>


### PR DESCRIPTION
 - Change BuildVm\minilua `OutDir` to `$(ProjectDir)bin\$(PlatformShortName)\`