### PR TITLE
xrEngine: fix game crash for window mode

### DIFF
--- a/src/xrEngine/MonitorManager.cpp
+++ b/src/xrEngine/MonitorManager.cpp
@@ -27,8 +27,15 @@ MonitorsManager::ResolutionPair MonitorsManager::GetMinimalResolution()
 MonitorsManager::ResolutionPair MonitorsManager::GetMaximalResolution()
 {
     const ResolutionsMap& resolutions = Monitors[Vid_SelectedMonitor];
-    const auto it = resolutions.crbegin();
-    return it->first;
+    if(!resolutions.empty())
+    {
+        const auto it = resolutions.crbegin();
+        return it->first;
+    }
+    else
+    {
+        return ResolutionPair(640,480);
+    }
 }
 
 

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -433,9 +433,10 @@ public:
 
     void Execute(pcstr args) override
     {
-        int id;
-        sscanf(args, "%d. *", &id);
-        Vid_SelectedMonitor = id;
+        u32 id = 0;
+
+        if(1 == sscanf(args, "%u. *", &id))
+            Vid_SelectedMonitor = id;
     }
 
     void GetStatus(TStatus& S) override

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -435,7 +435,7 @@ public:
     {
         u32 id = 0;
 
-        if(1 == sscanf(args, "%u. *", &id))
+        if (1 == sscanf(args, "%u. *", &id))
             Vid_SelectedMonitor = id;
     }
 


### PR DESCRIPTION
The problem was in the old configuration file, the monitors were numbered from 1, and now from 0. Added processing of this case.