### PR TITLE
Fix LuaStudio module compiling with ISO C++ strict compilers

### DIFF
--- a/src/xrScriptEngine/LuaStudio/Defines.hpp
+++ b/src/xrScriptEngine/LuaStudio/Defines.hpp
@@ -33,7 +33,6 @@ STATIC_CHECK(false, CS_MAKE_STRING_or_CS_MAKE_STRING_HELPER_macro_already_define
 #define CS_MAKE_STRING_HELPER(a) #a
 #define CS_MAKE_STRING(a) CS_MAKE_STRING_HELPER(a)
 
-#define CS_LIBRARY_NAME(library, extension)                                                                       \
-    CS_MAKE_STRING(CS_STRING_CONCAT(CS_LIBRARY_PREFIX,                                                            \
-        CS_STRING_CONCAT(library, CS_STRING_CONCAT(CS_PLATFORM_ID, CS_STRING_CONCAT(CS_SOLUTION_CONFIGURATION_ID, \
-                                                                       CS_STRING_CONCAT(., extension))))))
+#define CS_LIBRARY_NAME(library, extension) \
+    CS_MAKE_STRING(CS_LIBRARY_PREFIX) CS_MAKE_STRING(library) CS_MAKE_STRING(CS_PLATFORM_ID) \
+        CS_MAKE_STRING(CS_SOLUTION_CONFIGURATION_ID) CS_MAKE_STRING(.) CS_MAKE_STRING(extension)


### PR DESCRIPTION
Hi!

Currently (or, at least, few days ago) dev builds was failing (https://travis-ci.org/OpenXRay/xray-16/jobs/506720869) because of LuaStudio macro CS_LIBRARY_NAME, which is uses invalid tokens according to ISO C++ standard.
Original developer was using Visual C++ compiler, which is shipping with Visual Studio. Such compiler is tolerant for that kind of tokens. In our case, it was tokens with dot symbol inside.

I was wondering about how I could change this macro without touching everything else. Unfortunately, after several attempts to make it looks good enough, I decided to change macro behavior:

 - WAS: CS_LIBRARY_NAME was concatenating several tokens first, with nested CS_STRING_CONCAT usage. Then, it was creating single C string from freshly-made big token.
 - NOW: CS_STRING_CONCAT is creating several C strings from available tokens. Then, it is concatenating these strings to big one.

I also made this small program for testing purposes:
```C
#include <stdlib.h>
#include <stdio.h>

#define CS_STRING_CONCAT_HELPER(a, b) a##b
#define CS_STRING_CONCAT(a, b) CS_STRING_CONCAT_HELPER(a, b)
#define CS_MAKE_STRING_HELPER(a) #a
#define CS_MAKE_STRING(a) CS_MAKE_STRING_HELPER(a)

#define CS_LIBRARY_NAME(library, extension) \
    CS_MAKE_STRING(CS_LIBRARY_PREFIX) CS_MAKE_STRING(library) CS_MAKE_STRING(CS_PLATFORM_ID) \
        CS_MAKE_STRING(CS_SOLUTION_CONFIGURATION_ID) CS_MAKE_STRING(.) CS_MAKE_STRING(extension)

#define CS_LIBRARY_PREFIX cs.
#define CS_PLATFORM_ID
#define CS_SOLUTION_CONFIGURATION_ID

int main() {
	printf("%s\n", CS_MAKE_STRING(CS_STRING_CONCAT(hello, world)));
	//printf("%s\n", CS_MAKE_STRING(CS_STRING_CONCAT(., world)));
	printf("%s\n", CS_LIBRARY_NAME(lua_studio_backend, dll));
	return EXIT_SUCCESS;
}
```
Compiling and executing:
```$ cc test.c -o test
$ ./test
helloworld
cs.lua_studio_backend.dll
$
```

You may check out here:

1) How CS_STRING_CONCAT works (actually I have no idea what original developer was thinking because it is actually making one token from two, and it's widely knows as "token concatenation", not string!)
2) How CS_STRING_CONCAT works with dot as one of the operands (it's not working under gcc/clang and working under Visual C++ compiler)
3) What CS_LIBRARY_NAME returns, as in original `src/xrScriptEngine/LuaStudio/Defines.hpp` file

References:

0) https://travis-ci.org/OpenXRay/xray-16/jobs/506720869
1) https://stackoverflow.com/questions/1206624/differences-in-macro-concatenation-operator-between-visual-c-and-gcc?rq=1
2) https://gcc.gnu.org/onlinedocs/gcc-4.3.3/cpp/Concatenation.html#Concatenation
3) https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35610