### PR TITLE
Travis CI linux build fixes

### DIFF
--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -1785,7 +1785,7 @@ pcstr CLocatorAPI::update_path(string_path& dest, pcstr initial, pcstr src, bool
     FS_Path* path;
     if (!get_path(initial, &path))
     {
-        R_ASSERT(!crashOnNotFound, "Failed to find FS path", initial);
+        R_ASSERT3(!crashOnNotFound, "Failed to find FS path", initial);
         return nullptr;
     }
 

--- a/src/xrScriptEngine/LuaStudio/Defines.hpp
+++ b/src/xrScriptEngine/LuaStudio/Defines.hpp
@@ -33,7 +33,5 @@ STATIC_CHECK(false, CS_MAKE_STRING_or_CS_MAKE_STRING_HELPER_macro_already_define
 #define CS_MAKE_STRING_HELPER(a) #a
 #define CS_MAKE_STRING(a) CS_MAKE_STRING_HELPER(a)
 
-#define CS_LIBRARY_NAME(library, extension)                                                                       \
-    CS_MAKE_STRING(CS_STRING_CONCAT(CS_LIBRARY_PREFIX,                                                            \
-        CS_STRING_CONCAT(library, CS_STRING_CONCAT(CS_PLATFORM_ID, CS_STRING_CONCAT(CS_SOLUTION_CONFIGURATION_ID, \
-                                                                       CS_STRING_CONCAT(., extension))))))
+#define CS_LIBRARY_NAME(library, extension) \
+   CS_MAKE_STRING(CS_LIBRARY_PREFIX) CS_MAKE_STRING(library) CS_MAKE_STRING(CS_PLATFORM_ID) CS_MAKE_STRING(CS_SOLUTION_CONFIGURATION_ID) "." CS_MAKE_STRING(extension)


### PR DESCRIPTION
Replaced R_ASSERT with R_ASSERT3 as there're 3 arguments.
Changed CS_LIBRARY_NAME macro to use auto concatenated static strings (it's the same fix as in #370 but I found that later)