### PR TITLE
xrEngine: Stats: Separate FPS counter (Closes #171)

### DIFF
--- a/src/xrEngine/Stats.cpp
+++ b/src/xrEngine/Stats.cpp
@@ -173,6 +173,13 @@ void CStats::Show()
     }
 #endif
     font.OnRender();
+
+    if (psDeviceFlags.test(rsShowFPS))
+    {
+        const auto fps = u32(Device.GetStats().fFPS);
+        fpsFont->Out(Device.dwWidth - 40, 5, "%3d", fps);
+        fpsFont->OnRender();
+    }
 }
 
 void CStats::OnDeviceCreate()
@@ -180,7 +187,12 @@ void CStats::OnDeviceCreate()
     g_bDisableRedText = !!strstr(Core.Params, "-xclsx");
 
     if (!GEnv.isDedicatedServer)
+    {
         statsFont = new CGameFont("stat_font", CGameFont::fsDeviceIndependent);
+        fpsFont = new CGameFont("hud_font_di", CGameFont::fsDeviceIndependent);
+        fpsFont->SetHeightI(0.025f);
+        fpsFont->SetColor(color_rgba(250, 250, 15, 180));
+    }
 
 #ifdef DEBUG
     if (!g_bDisableRedText)
@@ -198,6 +210,7 @@ void CStats::OnDeviceDestroy()
 {
     SetLogCB(nullptr);
     xr_delete(statsFont);
+    xr_delete(fpsFont);
 }
 
 void CStats::FilteredLog(const char* s)

--- a/src/xrEngine/Stats.h
+++ b/src/xrEngine/Stats.h
@@ -15,6 +15,7 @@ class ENGINE_API CStats : public pureRender
 {
 private:
     CGameFont* statsFont;
+    CGameFont* fpsFont;
     float fMem_calls;
     xr_vector<shared_str> errors;
 

--- a/src/xrEngine/defines.h
+++ b/src/xrEngine/defines.h
@@ -40,7 +40,8 @@ enum
     rsR3 = (1ul << 21ul),
     rsR4 = (1ul << 22ul), // 22 was reserved for editor
     rsRGL = (1ul << 23ul), // 23 was reserved for editor
-    // 24-32 bit - reserved to Editor
+    rsShowFPS = (1ul << 24ul), // 24 was reserved for editor
+    // 25-32 bit - reserved to Editor
 };
 
 //. ENGINE_API extern u32 psCurrentMode ;

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -819,6 +819,7 @@ void CCC_Register()
     CMD3(CCC_Mask, "rs_fullscreen", &psDeviceFlags, rsFullscreen);
     CMD3(CCC_Mask, "rs_refresh_60hz", &psDeviceFlags, rsRefresh60hz);
     CMD3(CCC_Mask, "rs_stats", &psDeviceFlags, rsStatistic);
+    CMD3(CCC_Mask, "rs_fps", &psDeviceFlags, rsShowFPS);
     CMD4(CCC_Float, "rs_vis_distance", &psVisDistance, 0.4f, 1.5f);
 
     CMD3(CCC_Mask, "rs_cam_pos", &psDeviceFlags, rsCameraPos);


### PR DESCRIPTION
May disappear when:
+ Load screen is active (`CApplication` uses own draw loop while level is loading)
+ Level debug output is enabled (seems related to lost render target when `bDebug` is set)