### PR TITLE
xrEngine: Console: Use SDL text input mode only when console is active

### DIFF
--- a/src/xrEngine/IInputReceiver.h
+++ b/src/xrEngine/IInputReceiver.h
@@ -26,8 +26,8 @@ public:
     static void IR_GetMousePosIndependentCrop(Fvector2& f);
     BOOL IR_GetKeyState(int dik);
     BOOL IR_GetBtnState(int btn);
-    void IR_Capture(void);
-    void IR_Release(void);
+    virtual void IR_Capture(void);
+    virtual void IR_Release(void);
 
     virtual void IR_OnDeactivate(void);
     virtual void IR_OnActivate(void);

--- a/src/xrEngine/IInputReceiver.h
+++ b/src/xrEngine/IInputReceiver.h
@@ -42,6 +42,7 @@ public:
     virtual void IR_OnKeyboardPress(int /*dik*/) {}
     virtual void IR_OnKeyboardRelease(int /*dik*/) {}
     virtual void IR_OnKeyboardHold(int /*dik*/) {}
+    virtual void IR_OnTextInput(const char *) {}
 
     virtual void IR_OnJoystickMove(int /*axis*/, int /*value*/) {}
     virtual void IR_OnJoystickPress(int /*dik*/) {}

--- a/src/xrEngine/edit_actions.cpp
+++ b/src/xrEngine/edit_actions.cpp
@@ -9,7 +9,6 @@
 #include "edit_actions.h"
 #include "line_edit_control.h"
 #include "xr_input.h"
-#include "xrCore/Text/StringConversion.hpp"
 
 namespace text_editor
 {
@@ -57,46 +56,15 @@ void type_pair::init(int dik, char c, char c_shift, bool b_translate)
 
 void type_pair::on_key_press(line_edit_control* const control)
 {
-    char c = 0;
-    if (m_translate)
+    if (!m_translate)
     {
-        c = m_char;
-        char c_shift = m_char_shift;
-
-        SDL_Event event;
-        while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_TEXTINPUT, SDL_TEXTINPUT))
-        {
-            switch (event.type)
-            {
-            case SDL_TEXTINPUT:
-            {
-                static std::locale locale("");
-                auto str = StringFromUTF8(event.text.text, locale);
-
-                if (std::isalpha(str[0], locale) || str[0] == char(-1)) // "я" = -1
-                {
-                    c = std::tolower(str[0], locale);
-                    c_shift = std::toupper(str[0], locale);
-                }
-                break;
-            }
-            }
-        }
-
-        if (control->get_key_state(ks_Shift) != control->get_key_state(ks_CapsLock))
-        {
-            c = c_shift;
-        }
-    }
-    else
-    {
-        c = m_char;
+        char c = m_char;
         if (control->get_key_state(ks_Shift) != control->get_key_state(ks_CapsLock))
         {
             c = m_char_shift;
         }
+        control->insert_character(c);
     }
-    control->insert_character(c);
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -124,6 +124,7 @@ void line_edit_control::clear_states()
     m_buf3[0] = 0;
 
     m_cur_pos = 0;
+    m_inserted_pos = 0;
     m_select_start = 0;
     m_p1 = 0;
     m_p2 = 0;
@@ -365,9 +366,16 @@ void line_edit_control::assign_callback(int const dik, key_state state, Callback
     m_actions[dik]->on_assign(prev_action);
 }
 
-void line_edit_control::insert_character(char c) { m_inserted[0] = c; } // FIXME: increment index or use vector-like container instead
-void line_edit_control::clear_inserted() { m_inserted[0] = m_inserted[1] = 0; }
-bool line_edit_control::empty_inserted() { return (m_inserted[0] == 0); }
+void line_edit_control::insert_character(char c)
+{
+    VERIFY(m_inserted_pos < (m_buffer_size - 1 /*trailing zero*/));
+    m_inserted[m_inserted_pos    ] = c;
+    m_inserted[m_inserted_pos + 1] = 0;
+    m_inserted_pos++;
+}
+
+void line_edit_control::clear_inserted() { m_inserted[0] = m_inserted[1] = 0; m_inserted_pos = 0; }
+bool line_edit_control::empty_inserted() const { return m_inserted_pos == 0; }
 void line_edit_control::set_edit(pcstr str)
 {
     u32 str_size = xr_strlen(str);

--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -10,6 +10,7 @@
 
 #include "xrCore/os_clipboard.h"
 #include "xrCore/buffer_vector.h"
+#include "xrCore/Text/StringConversion.hpp"
 #include "Common/object_broker.h"
 #include "xr_input.h"
 #include "SDL.h"
@@ -364,7 +365,7 @@ void line_edit_control::assign_callback(int const dik, key_state state, Callback
     m_actions[dik]->on_assign(prev_action);
 }
 
-void line_edit_control::insert_character(char c) { m_inserted[0] = c; }
+void line_edit_control::insert_character(char c) { m_inserted[0] = c; } // FIXME: increment index or use vector-like container instead
 void line_edit_control::clear_inserted() { m_inserted[0] = m_inserted[1] = 0; }
 bool line_edit_control::empty_inserted() { return (m_inserted[0] == 0); }
 void line_edit_control::set_edit(pcstr str)
@@ -423,6 +424,33 @@ void line_edit_control::on_key_press(int dik)
     m_rep_time = 0.0f;
 
     update_key_states();
+    update_bufs();
+}
+
+// -------------------------------------------------------------------------------------------------
+
+void line_edit_control::on_text_input(const char *text)
+{
+    clamp_cur_pos();
+    clear_inserted();
+    compute_positions();
+
+    static std::locale locale("");
+    const auto str = StringFromUTF8(text, locale);
+
+    for (const auto c : str)
+    {
+        if (c == '`' || c == '~') // FIXME: console control key. Dunno how to handle properly
+        {
+            continue;
+        }
+        insert_character(c);
+    }
+    add_inserted_text();
+
+    m_edit_str[m_buffer_size - 1] = 0;
+    m_select_start = m_cur_pos;
+
     update_bufs();
 }
 

--- a/src/xrEngine/line_edit_control.h
+++ b/src/xrEngine/line_edit_control.h
@@ -111,7 +111,7 @@ private:
     void create_char_pair(int const dik, char c, char c_shift, bool translate = false);
 
     void clear_inserted();
-    bool empty_inserted();
+    bool empty_inserted() const;
 
     void add_inserted_text();
 
@@ -138,6 +138,7 @@ private:
     int m_buffer_size;
 
     int m_cur_pos;
+    int m_inserted_pos;
     int m_select_start;
     int m_p1;
     int m_p2;

--- a/src/xrEngine/line_edit_control.h
+++ b/src/xrEngine/line_edit_control.h
@@ -58,6 +58,7 @@ public:
     void on_key_press(int dik);
     void on_key_hold(int dik);
     void on_key_release(int dik);
+    void on_text_input(const char *text);
     void on_frame();
 
     void assign_callback(int const dik, key_state state, Callback const& callback);

--- a/src/xrEngine/line_editor.cpp
+++ b/src/xrEngine/line_editor.cpp
@@ -12,15 +12,22 @@ namespace text_editor
 {
 line_editor::line_editor(u32 str_buffer_size) : m_control(str_buffer_size)
 {
-    SDL_StartTextInput();
-}
-line_editor::~line_editor()
-{
-    SDL_StopTextInput();
 }
 
 void line_editor::on_frame() { m_control.on_frame(); }
 void line_editor::IR_OnKeyboardPress(int dik) { m_control.on_key_press(dik); }
 void line_editor::IR_OnKeyboardHold(int dik) { m_control.on_key_hold(dik); }
 void line_editor::IR_OnKeyboardRelease(int dik) { m_control.on_key_release(dik); }
+
+void line_editor::IR_Capture()
+{
+    IInputReceiver::IR_Capture();
+    SDL_StartTextInput();
+}
+
+void line_editor::IR_Release()
+{
+    SDL_StopTextInput();
+    IInputReceiver::IR_Release();
+}
 } // namespace text_editor

--- a/src/xrEngine/line_editor.cpp
+++ b/src/xrEngine/line_editor.cpp
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////
+﻿////////////////////////////////////////////////////////////////////////////
 // Module : line_editor.cpp
 // Created : 22.02.2008
 // Author : Evgeniy Sokolov
@@ -18,6 +18,7 @@ void line_editor::on_frame() { m_control.on_frame(); }
 void line_editor::IR_OnKeyboardPress(int dik) { m_control.on_key_press(dik); }
 void line_editor::IR_OnKeyboardHold(int dik) { m_control.on_key_hold(dik); }
 void line_editor::IR_OnKeyboardRelease(int dik) { m_control.on_key_release(dik); }
+void line_editor::IR_OnTextInput(const char *text) { m_control.on_text_input(text); }
 
 void line_editor::IR_Capture()
 {

--- a/src/xrEngine/line_editor.h
+++ b/src/xrEngine/line_editor.h
@@ -17,10 +17,13 @@ class line_editor : public IInputReceiver
 {
 public:
     line_editor(u32 str_buffer_size);
-    virtual ~line_editor();
+    virtual ~line_editor() = default;
 
     IC line_edit_control& control() { return m_control; }
     void on_frame();
+
+    void IR_Capture() final;
+    void IR_Release() final;
 
 protected:
     virtual void IR_OnKeyboardPress(int dik);

--- a/src/xrEngine/line_editor.h
+++ b/src/xrEngine/line_editor.h
@@ -26,9 +26,10 @@ public:
     void IR_Release() final;
 
 protected:
-    virtual void IR_OnKeyboardPress(int dik);
-    virtual void IR_OnKeyboardHold(int dik);
-    virtual void IR_OnKeyboardRelease(int dik);
+    void IR_OnKeyboardPress(int dik) final;
+    void IR_OnKeyboardHold(int dik) final;
+    void IR_OnKeyboardRelease(int dik) final;
+    void IR_OnTextInput(const char *text) final;
 
 private:
     line_edit_control m_control;

--- a/src/xrEngine/xr_input.cpp
+++ b/src/xrEngine/xr_input.cpp
@@ -142,7 +142,7 @@ void CInput::KeyUpdate()
 
     SDL_Event events[MAX_KEYBOARD_EVENTS];
     const auto count = SDL_PeepEvents(events, MAX_KEYBOARD_EVENTS,
-        SDL_GETEVENT, SDL_KEYDOWN, SDL_KEYUP);
+        SDL_GETEVENT, SDL_KEYDOWN, SDL_TEXTINPUT);
 
     for (int i = 0; i < count; ++i)
     {
@@ -160,6 +160,14 @@ void CInput::KeyUpdate()
         case SDL_KEYUP:
             keyboardState[event.key.keysym.scancode] = false;
             cbStack.back()->IR_OnKeyboardRelease(event.key.keysym.scancode);
+            break;
+
+        case SDL_TEXTINPUT:
+            cbStack.back()->IR_OnTextInput(event.text.text);
+            break;
+
+        default:
+            // Nothing here
             break;
         }
     }


### PR DESCRIPTION
This fixes #355