### PR TITLE
Re-enabled 8x multisample antialiasing

### DIFF
--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -58,8 +58,7 @@ const xr_token qsun_quality_token[] = {{"st_opt_low", 0}, {"st_opt_medium", 1}, 
     {nullptr, 0}};
 
 u32 ps_r3_msaa = 0; // = 0;
-const xr_token qmsaa_token[] = {{"st_opt_off", 0}, {"2x", 1}, {"4x", 2},
-    //{"8x", 3},
+const xr_token qmsaa_token[] = {{"st_opt_off", 0}, {"2x", 1}, {"4x", 2}, {"8x", 3},
     {nullptr, 0}};
 
 u32 ps_r3_msaa_atest = 0; // = 0;


### PR DESCRIPTION
The code and shaders support 8x, but it was commented out in the original source code (probably because GPUs couldn't handle it back then). It provides a nice visual improvement, especially in VR.