### PR TITLE
Speed up sound source list by using an unordered map

### DIFF
--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -86,8 +86,10 @@ void CSoundRender_Core::_clear()
     env_unload();
 
     // remove sources
-    for (u32 sit = 0; sit < s_sources.size(); sit++)
-        xr_delete(s_sources[sit]);
+    for (auto it = s_sources.begin(); it != s_sources.end(); ++it)
+    {
+        xr_delete(it->second);
+    }
     s_sources.clear();
 
     // remove emitters
@@ -592,9 +594,9 @@ void CSoundRender_Core::refresh_sources()
 {
     for (u32 eit = 0; eit < s_emitters.size(); eit++)
         s_emitters[eit]->stop(false);
-    for (u32 sit = 0; sit < s_sources.size(); sit++)
+    for (auto it = s_sources.begin(); it != s_sources.end(); ++it)
     {
-        CSoundRender_Source* s = s_sources[sit];
+        CSoundRender_Source* s = it->second;
         s->unload();
         s->load(*s->fname);
     }

--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -86,9 +86,9 @@ void CSoundRender_Core::_clear()
     env_unload();
 
     // remove sources
-    for (const auto& kv : s_sources)
+    for (auto& kv : s_sources)
     {
-        delete kv.second;
+        xr_delete(kv.second);
     }
     s_sources.clear();
 

--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -86,9 +86,9 @@ void CSoundRender_Core::_clear()
     env_unload();
 
     // remove sources
-    for (auto it = s_sources.begin(); it != s_sources.end(); ++it)
+    for (const auto& kv : s_sources)
     {
-        xr_delete(it->second);
+        delete kv.second;
     }
     s_sources.clear();
 
@@ -594,9 +594,9 @@ void CSoundRender_Core::refresh_sources()
 {
     for (u32 eit = 0; eit < s_emitters.size(); eit++)
         s_emitters[eit]->stop(false);
-    for (auto it = s_sources.begin(); it != s_sources.end(); ++it)
+    for (const auto& kv : s_sources)
     {
-        CSoundRender_Source* s = it->second;
+        CSoundRender_Source* s = kv.second;
         s->unload();
         s->load(*s->fname);
     }

--- a/src/xrSound/SoundRender_Core.h
+++ b/src/xrSound/SoundRender_Core.h
@@ -55,7 +55,7 @@ protected:
     CDB::MODEL* geom_ENV;
 
     // Containers
-    xr_unordered_map<std::string, CSoundRender_Source*> s_sources;
+    xr_unordered_map<xr_string, CSoundRender_Source*> s_sources;
     xr_vector<CSoundRender_Emitter*> s_emitters;
     u32 s_emitters_u; // emitter update marker
     xr_vector<CSoundRender_Target*> s_targets;

--- a/src/xrSound/SoundRender_Core.h
+++ b/src/xrSound/SoundRender_Core.h
@@ -3,6 +3,7 @@
 #include "SoundRender.h"
 #include "SoundRender_Environment.h"
 #include "SoundRender_Cache.h"
+#include "xrCommon/xr_unordered_map.h"
 
 class CSoundRender_Core : public ISoundManager
 {
@@ -54,7 +55,7 @@ protected:
     CDB::MODEL* geom_ENV;
 
     // Containers
-    xr_vector<CSoundRender_Source*> s_sources;
+    xr_unordered_map<std::string, CSoundRender_Source*> s_sources;
     xr_vector<CSoundRender_Emitter*> s_emitters;
     u32 s_emitters_u; // emitter update marker
     xr_vector<CSoundRender_Target*> s_targets;

--- a/src/xrSound/SoundRender_Core_SourceManager.cpp
+++ b/src/xrSound/SoundRender_Core_SourceManager.cpp
@@ -11,7 +11,7 @@ CSoundRender_Source* CSoundRender_Core::i_create_source(pcstr name)
     xr_strlwr(id);
     if (strext(id))
         *strext(id) = 0;
-    xr_unordered_map<std::string, CSoundRender_Source*>::iterator it = s_sources.find(id);
+    auto it = s_sources.find(id);
     if (it != s_sources.end())
     {
         return it->second;

--- a/src/xrSound/SoundRender_Core_SourceManager.cpp
+++ b/src/xrSound/SoundRender_Core_SourceManager.cpp
@@ -11,16 +11,16 @@ CSoundRender_Source* CSoundRender_Core::i_create_source(pcstr name)
     xr_strlwr(id);
     if (strext(id))
         *strext(id) = 0;
-    for (u32 it = 0; it < s_sources.size(); it++)
+    xr_unordered_map<std::string, CSoundRender_Source*>::iterator it = s_sources.find(id);
+    if (it != s_sources.end())
     {
-        if (0 == xr_strcmp(*s_sources[it]->fname, id))
-            return s_sources[it];
+        return it->second;
     }
 
     // Load a _new one
     CSoundRender_Source* S = new CSoundRender_Source();
     S->load(id);
-    s_sources.push_back(S);
+    s_sources.insert({id, S});
     return S;
 }
 


### PR DESCRIPTION
This avoids iterating the entire list whenever a new sound source is created (which was contributing to the stuttering mentioned in #142 and #131).