### PR TITLE
Added option to create all sound sources on startup

### DIFF
--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -37,7 +37,7 @@ const xr_token constant_fps_token[] =
     { nullptr, -1 }
 };
 
-const xr_token snd_create_all_sources_token[] = {{"off", 0}, {"on", 1}, {nullptr, 0}};
+const xr_token snd_precache_all_token[] = {{"off", 0}, {"on", 1}, {nullptr, 0}};
 
 void IConsole_Command::InvalidSyntax()
 {
@@ -873,7 +873,7 @@ void CCC_Register()
     CMD3(CCC_Mask, "snd_efx", &psSoundFlags, ss_EAX);
     CMD4(CCC_Integer, "snd_targets", &psSoundTargets, 4, 32);
     CMD4(CCC_Integer, "snd_cache_size", &psSoundCacheSizeMB, 4, 64);
-    CMD3(CCC_Token, "snd_create_all_sources", &psSoundCreateAllSources, snd_create_all_sources_token);
+    CMD3(CCC_Token, "snd_precache_all", &psSoundPrecacheAll, snd_precache_all_token);
 
 #ifdef DEBUG
     CMD3(CCC_Mask, "snd_stats", &g_stats_flags, st_sound);

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -37,6 +37,8 @@ const xr_token constant_fps_token[] =
     { nullptr, -1 }
 };
 
+const xr_token snd_create_all_sources_token[] = {{"off", 0}, {"on", 1}, {nullptr, 0}};
+
 void IConsole_Command::InvalidSyntax()
 {
     TInfo I;
@@ -871,6 +873,7 @@ void CCC_Register()
     CMD3(CCC_Mask, "snd_efx", &psSoundFlags, ss_EAX);
     CMD4(CCC_Integer, "snd_targets", &psSoundTargets, 4, 32);
     CMD4(CCC_Integer, "snd_cache_size", &psSoundCacheSizeMB, 4, 64);
+    CMD3(CCC_Token, "snd_create_all_sources", &psSoundCreateAllSources, snd_create_all_sources_token);
 
 #ifdef DEBUG
     CMD3(CCC_Mask, "snd_stats", &g_stats_flags, st_sound);

--- a/src/xrSound/Sound.h
+++ b/src/xrSound/Sound.h
@@ -35,6 +35,7 @@ XRSOUND_API extern float psSoundOcclusionScale;
 XRSOUND_API extern Flags32 psSoundFlags;
 XRSOUND_API extern int psSoundTargets;
 XRSOUND_API extern int psSoundCacheSizeMB;
+XRSOUND_API extern u32 psSoundCreateAllSources;
 XRSOUND_API extern xr_token* snd_devices_token;
 XRSOUND_API extern u32 snd_device_id;
 

--- a/src/xrSound/Sound.h
+++ b/src/xrSound/Sound.h
@@ -35,7 +35,7 @@ XRSOUND_API extern float psSoundOcclusionScale;
 XRSOUND_API extern Flags32 psSoundFlags;
 XRSOUND_API extern int psSoundTargets;
 XRSOUND_API extern int psSoundCacheSizeMB;
-XRSOUND_API extern u32 psSoundCreateAllSources;
+XRSOUND_API extern u32 psSoundPrecacheAll;
 XRSOUND_API extern xr_token* snd_devices_token;
 XRSOUND_API extern u32 snd_device_id;
 

--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -23,7 +23,7 @@ float psSoundVFactor = 1.0f;
 
 float psSoundVMusic = 1.f;
 int psSoundCacheSizeMB = 32;
-u32 psSoundCreateAllSources = 0;
+u32 psSoundPrecacheAll = 0;
 CSoundRender_Core* SoundRender = nullptr;
 
 CSoundRender_Core::CSoundRender_Core()
@@ -77,7 +77,7 @@ void CSoundRender_Core::_initialize()
 
     bReady = true;
 
-    if (psSoundCreateAllSources == 1)
+    if (psSoundPrecacheAll == 1)
     {
         i_create_all_sources();
     }

--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -23,6 +23,7 @@ float psSoundVFactor = 1.0f;
 
 float psSoundVMusic = 1.f;
 int psSoundCacheSizeMB = 32;
+u32 psSoundCreateAllSources = 0;
 CSoundRender_Core* SoundRender = nullptr;
 
 CSoundRender_Core::CSoundRender_Core()
@@ -75,6 +76,11 @@ void CSoundRender_Core::_initialize()
     cache.initialize(psSoundCacheSizeMB * 1024, cache_bytes_per_line);
 
     bReady = true;
+
+    if (psSoundCreateAllSources == 1)
+    {
+        i_create_all_sources();
+    }
 }
 
 extern xr_vector<u8> g_target_temp_data;

--- a/src/xrSound/SoundRender_Core.h
+++ b/src/xrSound/SoundRender_Core.h
@@ -137,6 +137,7 @@ public:
     bool i_allow_play(CSoundRender_Emitter* E);
     bool i_locked() override { return isLocked; }
     void object_relcase(IGameObject* obj) override;
+    void i_create_all_sources();
 
     float get_occlusion_to(const Fvector& hear_pt, const Fvector& snd_pt, float dispersion = 0.2f) override;
     float get_occlusion(Fvector& P, float R, Fvector* occ) override;

--- a/src/xrSound/SoundRender_Core_SourceManager.cpp
+++ b/src/xrSound/SoundRender_Core_SourceManager.cpp
@@ -28,3 +28,27 @@ void CSoundRender_Core::i_destroy_source(CSoundRender_Source* S)
 {
     // No actual destroy at all
 }
+
+void CSoundRender_Core::i_create_all_sources()
+{
+    CTimer T;
+    T.Start();
+
+    FS_FileSet flist;
+    FS.file_list(flist, "$game_sounds$", FS_ListFiles, "*.ogg");
+    for (const FS_File& file : flist)
+    {
+        string256 id;
+        xr_strcpy(id, file.name.c_str());
+
+        xr_strlwr(id);
+        if (strext(id))
+            *strext(id) = 0;
+
+        CSoundRender_Source* S = new CSoundRender_Source();
+        S->load(id);
+        s_sources.insert({id, S});
+    }
+
+    Msg("Finished creating %d sound sources. Duration: %d ms", flist.size(), T.GetElapsed_ms());
+}


### PR DESCRIPTION
While researching issues #142 and #131, I used xperf to profile the stuttering that happens when a new AI comes online. During the stutter, most of the time is in CSoundRender_Core::i_create_source (and child calls).
This change adds a console variable that causes all sound sources to be created on startup, instead of being created when the sound is first needed. So it frontloads the work to make the actual play experience smoother. On my machine, on a release build, this adds 2.7 seconds to the startup time, but 90%+ of the stutter is eliminated when an AI comes online. These times will probably change depending on CPU and disk hardware.