### PR TITLE
Add gamepad bind menu to UI

### DIFF
--- a/res/gamedata/configs/text/eng/openxray.xml
+++ b/res/gamedata/configs/text/eng/openxray.xml
@@ -69,6 +69,9 @@
 	<string id="ui_mm_localization">
 		<text>Language</text>
 	</string>
+	<string id="ui_mm_gamepad_setup">
+		<text>Gamepad setup</text>
+	</string>
 	<string id="eng">
 		<text>English</text>
 	</string>

--- a/res/gamedata/configs/text/pol/openxray.xml
+++ b/res/gamedata/configs/text/pol/openxray.xml
@@ -69,6 +69,9 @@
 	<string id="ui_mm_localization">
 		<text>Jêzyk</text>
 	</string>
+	<string id="ui_mm_gamepad_setup">
+		<text>Konfiguracja gamepada</text>
+	</string>
 	<string id="eng">
 		<text>Angielski (English)</text>
 	</string>

--- a/res/gamedata/configs/text/rus/openxray.xml
+++ b/res/gamedata/configs/text/rus/openxray.xml
@@ -69,6 +69,9 @@
 	<string id="ui_mm_localization">
 		<text>Язык</text>
 	</string>
+	<string id="ui_mm_gamepad_setup">
+		<text>Настройка геймпада</text>
+	</string>
 	<string id="eng">
 		<text>Английский (English)</text>
 	</string>

--- a/res/gamedata/configs/ui/ui_mm_opt.xml
+++ b/res/gamedata/configs/ui/ui_mm_opt.xml
@@ -780,8 +780,70 @@
 				<e r="210" g="210" b="210"/>
 			</text_color>
         </btn_default>
+		
+		<btn_advanced x="201" y="322" width="133" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_gamepad_setup</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_advanced>
     </tab_controls>
+	
+	<tab_controls_gpad>
+		<cap_gamepadsetup x="0" y="65" width="430" height="15">
+            <texture a="150">ui_inGame2_servers_list_button</texture>
+            <auto_static x="10" y="0" width="135" height="15">
+                <text r="170" g="170" b="170" font="letterica16" vert_align="c">ui_mm_gamepad_setup</text>
+            </auto_static>
+        </cap_gamepadsetup>
+		
+		<key_binding_gpad x="0" y="85" width="430" height="240" gamepad_bind="1">
+            <header_1 x="0" y="0" width="220" height="15">
+                <texture a="150">ui_inGame2_servers_list_button</texture>
+                <auto_static x="2" y="0" width="220" height="15">
+                    <text r="170" g="170" b="170" font="arial_14" x="2" y="1" align="l" vert_align="c" complex_mode="0">ui_mm_action</text>
+                </auto_static>
+            </header_1>
+            <header_2 x="220" y="0" width="210" height="15">
+                <texture a="150">ui_inGame2_servers_list_button</texture>
+                <auto_static x="2" y="0" width="210" height="15">
+                    <text r="170" g="170" b="170" font="arial_14" x="2" y="1" align="l" vert_align="c" complex_mode="0">ui_mm_key</text>
+                </auto_static>
+            </header_2>
 
+            <frame x="0" y="15" width="429" height="215">
+                <texture>ui_inGame2_servers_list_frame</texture>
+            </frame>
+
+            <scroll_view x="3" y="17" width="424" height="211" always_show_scroll="1" vert_interval="3">
+                <item_group x="0" y="0" width="160" height="25">
+                    <text r="230" g="230" b="230" font="letterica18"/>
+                </item_group>
+
+                <item_key x="0" y="0" width="414" height="18">
+                    <text r="170" g="170" b="170" font="letterica16"/>
+                </item_key>
+            </scroll_view>
+        </key_binding_gpad>
+
+		<btn_default x="338" y="322" width="108" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_default</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_default>
+		
+		<btn_controls x="191" y="322" width="143" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_keyboard_setup</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_controls>
+	</tab_controls_gpad>
+	
     <download_static x="186" y="717" width="603" height="51">
         <texture>ui_patch_back</texture>
     </download_static>

--- a/res/gamedata/configs/ui/ui_mm_opt_16.xml
+++ b/res/gamedata/configs/ui/ui_mm_opt_16.xml
@@ -782,7 +782,69 @@
 				<e r="210" g="210" b="210"/>
 			</text_color>
         </btn_default>
+		
+		<btn_advanced x="156" y="322" width="110" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_gamepad_setup</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_advanced>
     </tab_controls>
+	
+	<tab_controls_gpad>
+		<cap_gamepadsetup x="0" y="65" width="344" height="15">
+            <texture a="150">ui_inGame2_servers_list_button</texture>
+            <auto_static x="8" y="0" width="108" height="15">
+                <text r="170" g="170" b="170" font="letterica16" vert_align="c">ui_mm_gamepad_setup</text>
+            </auto_static>
+        </cap_gamepadsetup>
+		
+		<key_binding_gpad x="0" y="85" width="344" height="240" gamepad_bind="1">
+            <header_1 x="0" y="0" width="176" height="15">
+                <texture a="150">ui_inGame2_servers_list_button</texture>
+                <auto_static x="2" y="0" width="176" height="15">
+                    <text r="170" g="170" b="170" font="arial_14" x="2" y="1" align="l" vert_align="c" complex_mode="0">ui_mm_action</text>
+                </auto_static>
+            </header_1>
+            <header_2 x="176" y="0" width="168" height="15">
+                <texture a="150">ui_inGame2_servers_list_button</texture>
+                <auto_static x="2" y="0" width="168" height="15">
+                    <text r="170" g="170" b="170" font="arial_14" x="2" y="1" align="l" vert_align="c" complex_mode="0">ui_mm_key</text>
+                </auto_static>
+            </header_2>
+
+            <frame x="0" y="15" width="343" height="215">
+                <texture>ui_inGame2_servers_list_frame</texture>
+            </frame>
+
+            <scroll_view x="2" y="17" width="341" height="211" always_show_scroll="1" vert_interval="3">
+                <item_group x="0" y="0" width="160" height="25">
+                    <text r="230" g="230" b="230" font="letterica18"/>
+                </item_group>
+
+                <item_key x="0" y="0" width="331" height="18">
+                    <text r="170" g="170" b="170" font="letterica16"/>
+                </item_key>
+            </scroll_view>
+        </key_binding_gpad>
+
+		<btn_default x="270" y="322" width="86" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_default</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_default>
+		
+		<btn_controls x="150" y="322" width="116" height="24" stretch="1">
+            <text align="c" font="letterica16">ui_mm_keyboard_setup</text>
+            <texture>ui_inGame2_button</texture>
+			<text_color>
+				<e r="210" g="210" b="210"/>
+			</text_color>
+        </btn_controls>
+	</tab_controls_gpad>
 
     <download_static x="251" y="717" width="482" height="51" stretch="1">
         <texture>ui_patch_back</texture>

--- a/res/gamedata/scripts/ui_mm_opt_controls.script
+++ b/res/gamedata/scripts/ui_mm_opt_controls.script
@@ -1,0 +1,32 @@
+class "opt_controls" (CUIWindow)
+
+function opt_controls:__init() super()
+end
+
+function opt_controls:__finalize()
+
+end
+
+function opt_controls:InitControls(x, y, xml, handler)
+
+	self:SetWndPos(vector2():set(x,y))
+	self:SetWndSize(vector2():set(738,416))
+
+	self:SetAutoDelete(true)
+
+--	self.bk = xml:InitFrame("frame", self)
+
+	xml:InitStatic		("tab_controls:cap_mousesens",			self)
+	xml:InitFrameLine	("tab_controls:cap_keyboardsetup",		self)
+	xml:InitFrameLine	("tab_controls:cap_keyboardsetup",		self)
+	xml:InitTrackBar	("tab_controls:track_mousesens",		self)
+	xml:InitStatic		("tab_controls:cap_check_mouseinvert",	self)
+	xml:InitCheck		("tab_controls:check_mouseinvert",		self)
+	xml:InitKeyBinding	("tab_controls:key_binding",			self)
+
+	local btn
+	btn = xml:Init3tButton("tab_controls:btn_default", 			self)
+	handler:Register(btn, "btn_keyb_default")
+
+
+end

--- a/res/gamedata/scripts/ui_mm_opt_controls.script
+++ b/res/gamedata/scripts/ui_mm_opt_controls.script
@@ -28,5 +28,6 @@ function opt_controls:InitControls(x, y, xml, handler)
 	btn = xml:Init3tButton("tab_controls:btn_default", 			self)
 	handler:Register(btn, "btn_keyb_default")
 
-
+	btn_adv	= xml:Init3tButton	("tab_controls:btn_advanced",	self)
+	handler:Register			(btn_adv, "btn_gpad_controls")
 end

--- a/res/gamedata/scripts/ui_mm_opt_controls_gpad.script
+++ b/res/gamedata/scripts/ui_mm_opt_controls_gpad.script
@@ -1,0 +1,25 @@
+class "opt_controls_gpad"(CUIWindow)
+
+function opt_controls_gpad:__init() super()
+end
+
+function opt_controls_gpad:__finalize()
+end
+
+function opt_controls_gpad:InitControls(x, y, xml, handler)
+	
+	self:SetWndPos(vector2():set(x,y))
+	self:SetWndSize(vector2():set(738,416))
+	self:SetAutoDelete(true)
+	
+	xml:InitFrameLine	("tab_controls_gpad:cap_gamepadsetup", self)
+	xml:InitFrameLine	("tab_controls_gpad:cap_gamepadsetup", self)
+	
+	xml:InitKeyBinding	("tab_controls_gpad:key_binding_gpad", self)
+
+	btn_def = xml:Init3tButton("tab_controls_gpad:btn_default", self)
+	handler:Register(btn_def, "btn_gpad_default")
+	
+	btn_back = xml:Init3tButton("tab_controls_gpad:btn_controls", self)
+	handler:Register(btn_back, "btn_keyboard_controls")
+end

--- a/res/gamedata/scripts/ui_mm_opt_main.script
+++ b/res/gamedata/scripts/ui_mm_opt_main.script
@@ -59,6 +59,12 @@ function options_dialog:InitControls()
 	self.dlg_video_adv:Show		(false)
 	self.dialog:AttachChild		(self.dlg_video_adv)
 	xml:InitWindow				("tab_size", 0, self.dlg_video_adv)
+	
+	self.dlg_controls_gpad		= ui_mm_opt_controls_gpad.opt_controls_gpad()
+	self.dlg_controls_gpad:InitControls(0,0, xml, self)
+	self.dlg_controls_gpad:Show	(false)
+	self.dialog:AttachChild		(self.dlg_controls_gpad)
+	xml:InitWindow				("tab_size", 0, self.dlg_controls_gpad)
 
 	local btn
 	btn = xml:Init3tButton		("main_dialog:btn_accept", self.dialog)
@@ -104,6 +110,9 @@ function options_dialog:SetCurrentValues()
 
 	opt:SetCurrentValues("mm_opt_controls")
 	opt:SaveBackupValues("mm_opt_controls")
+	
+	--opt:SetCurrentValues("mm_opt_controls_adv")
+	--opt:SaveBackupValues("mm_opt_controls_adv")
 
 	opt:SetCurrentValues("key_binding")
 	opt:SaveBackupValues("key_binding")
@@ -176,6 +185,9 @@ function options_dialog:InitCallBacks()
 	self:AddCallback("check_simple_pickup",	ui_events.BUTTON_CLICKED,	self.OnPickupOptionChange,	self)
 	self:AddCallback("track_r3_dyn_wet_surf_near", ui_events.BUTTON_CLICKED, self.OnDynWetSurfNearUpdate, self)
 	self:AddCallback("track_r3_dyn_wet_surf_far", ui_events.BUTTON_CLICKED,  self.OnDynWetSurfFarUpdate, self)
+	self:AddCallback("btn_gpad_controls", 	ui_events.BUTTON_CLICKED,	self.OnBtnGpadControls,		self)
+	self:AddCallback("btn_keyboard_controls", ui_events.BUTTON_CLICKED,	self.OnBtnKbdControls,		self)
+	self:AddCallback("btn_gpad_default",	ui_events.BUTTON_CLICKED,	self.OnBtnGpadDefault,		self)
 
 	self:AddCallback("mb",					ui_events.MESSAGE_BOX_YES_CLICKED, self.OnApplyChanges, self)
 	self:AddCallback("mb",					ui_events.MESSAGE_BOX_NO_CLICKED, self.OnDiscardChanges,self)
@@ -228,6 +240,7 @@ function options_dialog:OnBtnAccept()
 	opt:SaveValues("mm_opt_gameplay")
 	opt:SaveValues("mm_opt_sound")
 	opt:SaveValues("mm_opt_controls")
+	--opt:SaveValues("mm_opt_controls_adv")
 
 	if opt:NeedVidRestart() then
 		_G.b_discard_settings_shown = true
@@ -262,6 +275,7 @@ function options_dialog:OnTabChange()
 	self.dlg_gameplay:Show	(false)
 	self.dlg_controls:Show	(false)
 	self.dlg_video_adv:Show	(false)
+	self.dlg_controls_gpad:Show(false)
 
 	local ids = self.tab:GetActiveId()
 	if ids == "video" then
@@ -306,6 +320,19 @@ end
 function options_dialog:OnSimplyGraphic()
 	self.dlg_video:Show		(true)
 	self.dlg_video_adv:Show	(false)
+end
+
+function options_dialog:OnBtnGpadControls()
+	self.dlg_controls:Show		(false)
+	self.dlg_controls_gpad:Show	(true)
+end
+
+function options_dialog:OnBtnKbdControls()
+	self.dlg_controls:Show		(true)
+	self.dlg_controls_gpad:Show	(false)
+end
+
+function options_dialog:OnBtnGpadDefault()
 end
 
 function options_dialog:OnKeyboard(dik, keyboard_action)

--- a/res/gamedata/scripts/ui_mm_opt_main.script
+++ b/res/gamedata/scripts/ui_mm_opt_main.script
@@ -116,6 +116,9 @@ function options_dialog:SetCurrentValues()
 
 	opt:SetCurrentValues("key_binding")
 	opt:SaveBackupValues("key_binding")
+	
+	opt:SetCurrentValues("key_binding_gpad")
+	opt:SaveBackupValues("key_binding_gpad")
 
 	self:UpdateDependControls()
 end
@@ -241,6 +244,7 @@ function options_dialog:OnBtnAccept()
 	opt:SaveValues("mm_opt_sound")
 	opt:SaveValues("mm_opt_controls")
 	--opt:SaveValues("mm_opt_controls_adv")
+	opt:SaveValues("key_binding_gpad")
 
 	if opt:NeedVidRestart() then
 		_G.b_discard_settings_shown = true
@@ -333,6 +337,12 @@ function options_dialog:OnBtnKbdControls()
 end
 
 function options_dialog:OnBtnGpadDefault()
+	local console			= get_console()
+	console:execute			("default_controls")
+
+	local opt				= COptionsManager()
+	opt:SetCurrentValues	("mm_opt_controls")
+	opt:SetCurrentValues	("key_binding_gpad")
 end
 
 function options_dialog:OnKeyboard(dik, keyboard_action)

--- a/src/xrGame/ui/UIEditKeyBind.cpp
+++ b/src/xrGame/ui/UIEditKeyBind.cpp
@@ -87,6 +87,10 @@ bool CUIEditKeyBind::OnMouseDown(int mouse_btn)
         m_keyboard = DikToPtr(mouse_btn, true);
         if (!m_keyboard)
             return true;
+
+        if (m_isGamepadBinds && (mouse_btn <= XR_CONTROLLER_BUTTON_A || mouse_btn >= XR_CONTROLLER_BUTTON_DPAD_RIGHT))
+            return true;
+
         SetValue();
         OnFocusLost();
 
@@ -117,6 +121,9 @@ bool CUIEditKeyBind::OnKeyboardAction(int dik, EUIMessages keyboard_action)
     {
         m_keyboard = DikToPtr(dik, true);
         if (!m_keyboard)
+            return true;
+
+        if (m_isGamepadBinds && (dik <= XR_CONTROLLER_BUTTON_A || dik >= XR_CONTROLLER_BUTTON_DPAD_RIGHT))
             return true;
 
         SetValue();

--- a/src/xrGame/ui/UIEditKeyBind.cpp
+++ b/src/xrGame/ui/UIEditKeyBind.cpp
@@ -208,10 +208,6 @@ bool CUIEditKeyBind::IsChangedOptValue() const
 
 void CUIEditKeyBind::BindAction2Key()
 {
-    xr_string comm_unbind = (!m_isGamepadBinds) ? ((m_primary) ? "unbind " : "unbind_sec ") : "unbind_gpad ";
-    comm_unbind += m_action->action_name;
-    Console->Execute(comm_unbind.c_str());
-
     if (m_keyboard)
     {
         xr_string comm_bind = (!m_isGamepadBinds) ? ((m_primary) ? "bind " : "bind_sec ") : "bind_gpad ";

--- a/src/xrGame/ui/UIKeyBinding.cpp
+++ b/src/xrGame/ui/UIKeyBinding.cpp
@@ -87,7 +87,10 @@ void CUIKeyBinding::FillUpList(CUIXml& xml_doc_ui, LPCSTR path_ui)
                 editKB = new CUIEditKeyBind(false, true);
             editKB->SetAutoDelete(true);
             editKB->InitKeyBind(Fvector2().set(item_pos, 0.0f), Fvector2().set(item_width, item->GetWndSize().y));
-            editKB->AssignProps(exe, "key_binding");
+            if (!m_isGamepadBinds)
+                editKB->AssignProps(exe, "key_binding");
+            else
+                editKB->AssignProps(exe, "key_binding_gpad");
             item->AttachChild(editKB);
 
             if (!m_isGamepadBinds)


### PR DESCRIPTION
Looks like that, but now a little better (old screenshot).

Also now you can bind multiple actions on one key. This fixes the inability to save the game on the F5 button.

![](https://cdn.discordapp.com/attachments/489453264157409281/597815830864068643/unknown.png)