### PR TITLE
Fix engine initialization issues in Linux

### DIFF
--- a/src/Layers/xrRenderPC_GL/rgl.cpp
+++ b/src/Layers/xrRenderPC_GL/rgl.cpp
@@ -489,9 +489,7 @@ void CRender::MakeContextCurrent(bool acquire)
         result = SDL_GL_MakeCurrent(HW.m_hWnd, HW.m_hRC);
     else
         result = SDL_GL_MakeCurrent(nullptr, nullptr);
-#ifdef WINDOWS // FIXME: find out why Linux always fails.. But works.
     R_ASSERT2(result == 0, "Failed to switch OpenGL context");
-#endif
 }
 
 // Implementation

--- a/src/xrCore/Threading/Event.cpp
+++ b/src/xrCore/Threading/Event.cpp
@@ -52,7 +52,7 @@ void Event::Wait() noexcept
 }
 bool Event::Wait(u32 millisecondsTimeout) noexcept
 {
-    bool result = false;
+    bool result = true;
     pthread_mutex_lock(&m_id.mutex);
 
     timespec ts;
@@ -69,7 +69,7 @@ bool Event::Wait(u32 millisecondsTimeout) noexcept
         int res = pthread_cond_timedwait(&m_id.cond, &m_id.mutex, &ts);
         if(res == ETIMEDOUT)
         {
-            result = true;
+            result = m_id.signaled;
             break;
         }
     }

--- a/src/xrCore/Threading/Event.hpp
+++ b/src/xrCore/Threading/Event.hpp
@@ -28,7 +28,10 @@ public:
     void Set() noexcept;
     // Wait indefinitely for the object to become signalled.
     void Wait() noexcept;
-    // Wait, with a time limit, for the object to become signalled.
+    /*! \brief Wait, with a time limit, for the object to become signalled
+
+        \return True if the object becomes signalled in the time limit, false otherwise
+    */
     bool Wait(u32 millisecondsTimeout) noexcept;
 
     void* GetHandle() noexcept { return handle; }

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -175,13 +175,13 @@ void CRenderDevice::PrimaryThreadProc(void* context)
     GEnv.Render->MakeContextCurrent(false);
     device.deviceCreated.Set();
 
-    device.deviceReadyToRun.Wait(); // ping
+    device.deviceReadyToRun.Wait();
     GEnv.Render->MakeContextCurrent(true);
     
     device.seqAppStart.Process();
     GEnv.Render->ClearTarget();
 
-    device.deviceReadyToRun.Set(); // pong
+    device.primaryReadyToRun.Set();
 
     while (true)
     {
@@ -520,10 +520,10 @@ void CRenderDevice::Run()
 
     // Pre start
     GEnv.Render->MakeContextCurrent(false);
-    deviceReadyToRun.Set();  // ping
+    deviceReadyToRun.Set();
 
-    while (!deviceReadyToRun.Wait(MaximalWaitTime))
-        SDL_PumpEvents(); // pong
+    while (!primaryReadyToRun.Wait(MaximalWaitTime))
+        SDL_PumpEvents();
 
     splash::hide();
     SDL_HideWindow(m_sdlWnd);

--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -303,7 +303,7 @@ private:
     std::atomic<bool> precacheWhileReset;
     std::atomic<bool> mtProcessingAllowed;
     Event deviceCreated, deviceReadyToRun;
-    Event primaryProcessFrame, primaryFrameDone, primaryThreadExit; // Primary thread events
+    Event primaryReadyToRun, primaryProcessFrame, primaryFrameDone, primaryThreadExit; // Primary thread events
     Event syncProcessFrame, syncFrameDone, syncThreadExit; // Secondary thread events
     Event renderProcessFrame, renderFrameDone, renderThreadExit; // Render thread events
 

--- a/src/xrGame/ui/UIMapWnd.cpp
+++ b/src/xrGame/ui/UIMapWnd.cpp
@@ -23,6 +23,7 @@
 CUIMapWnd* g_map_wnd = NULL; // quick temporary solution -(
 CUIMapWnd* GetMapWnd() { return g_map_wnd; }
 CUIMapWnd::CUIMapWnd(UIHint* hint)
+    : m_ActionPlanner(nullptr)
 {
     m_tgtMap = NULL;
     m_GlobalMap = NULL;


### PR DESCRIPTION
Certain changes in b21c156bcb51 and some faults in the Event class definition for Linux introduced some race conditions in the initialization, that caused random crashes when starting the engine. This pull request fixes them