### PR TITLE
Ability to undo sudo make install command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # exclude binaries and temporary files
 CMakeCache.txt
 cmake_install.cmake
+cmake-build-debug
 install_manifest.txt
 bin/
 intermediate/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,13 @@ add_subdirectory(res)
 
 # Unix system configuration
 if (UNIX)
-    # uninstall target
+    # --------------------------------------------------
+    # Uninstall target
+    # --------------------------------------------------
+    # To clean system folder from libraries and binaries
+    # that was installed with `sudo make install`
+    # just run `sudo make uninstall`
+    #
     if(NOT TARGET uninstall)
         configure_file(
                 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,3 +172,16 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/Common )
 add_subdirectory(Externals)
 add_subdirectory(src)
 add_subdirectory(res)
+
+# Unix system configuration
+if (UNIX)
+    # uninstall target
+    if(NOT TARGET uninstall)
+        configure_file(
+                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+                IMMEDIATE @ONLY)
+
+        add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    endif()
+endif()

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program(
+                "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+                OUTPUT_VARIABLE rm_out
+                RETURN_VALUE rm_retval
+        )
+        if(NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif(NOT "${rm_retval}" STREQUAL 0)
+    else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
Changes made:
- Improved configuration of build system on unix os.
- Added command to clean system folder from libraries and binaries that was installed with `sudo make install` command.
- Update CMakeLists.txt with instruction how to clean installed binaries & libraries from system.

Now to clean system folder just use: `sudo make uninstall`