### PR TITLE
make timestamp() function cross-platform and thread-safe

### DIFF
--- a/src/xrCore/_std_extensions.cpp
+++ b/src/xrCore/_std_extensions.cpp
@@ -15,7 +15,12 @@ char* timestamp(string64& dest)
 {
     time_t     now = time(nullptr);
     struct tm  tstruct;
-    tstruct = *localtime(&now); // localtime is NOT thread-safe
+
+#if defined(WINDOWS)
+    localtime_s(&tstruct, &now);// thread-safe for windows
+#else
+    localtime_r(&now, &tstruct);// thread-safe for posix systems
+#endif
 
     strftime(dest, sizeof(dest), "%m-%d-%y_%H-%M-%S", &tstruct);
 

--- a/src/xrCore/_std_extensions.h
+++ b/src/xrCore/_std_extensions.h
@@ -265,7 +265,6 @@ inline void MemFill32(void* dst, u32 value, size_t dstSize)
         *ptr++ = value;
 }
 
-// This function is NOT thread-safe
 XRCORE_API char* timestamp(string64& dest);
 
 extern XRCORE_API u32 crc32(const void* P, u32 len);


### PR DESCRIPTION
fix for https://github.com/OpenXRay/xray-16/commit/e6402cdefe35b0b852605d18c1af11a58f973460 and https://github.com/OpenXRay/xray-16/commit/42ef1ccc58345f4935ee0d3e6de4f5c504f155eb