### PR TITLE
xrRender: GL, DX9 and DX10/11 device classes separated

### DIFF
--- a/src/Layers/xrRender/HW.h
+++ b/src/Layers/xrRender/HW.h
@@ -24,9 +24,6 @@ public:
 
     void Reset();
 
-    D3DFORMAT selectDepthStencil(D3DFORMAT);
-    u32 selectPresentInterval();
-    u32 selectGPU();
     BOOL support(D3DFORMAT fmt, DWORD type, DWORD usage);
 
 #if defined(DEBUG)
@@ -39,7 +36,11 @@ public:
     void Validate() {}
 #endif
 
-    // Variables section
+private:
+    u32 selectPresentInterval();
+    u32 selectGPU();
+    D3DFORMAT selectDepthStencil(D3DFORMAT);
+
 public:
     CHWCaps Caps;
 
@@ -52,10 +53,7 @@ public:
 #ifdef DEBUG
     IDirect3DStateBlock9* dwDebugSB = nullptr;
 #endif
-private:
-    XRay::Module hD3D = nullptr;
 
-public:
     IDirect3D9* pD3D = nullptr; // D3D
 
     UINT DevAdapter;
@@ -64,6 +62,9 @@ public:
 #if !defined(_MAYA_EXPORT)
     stats_manager stats_manager;
 #endif
+
+private:
+    XRay::Module hD3D = nullptr;
 };
 
 extern ECORE_API CHW HW;

--- a/src/Layers/xrRender/HW.h
+++ b/src/Layers/xrRender/HW.h
@@ -5,44 +5,31 @@
 #include "SDL.h"
 #include "SDL_syswm.h"
 
-#if !defined(_MAYA_EXPORT) && !defined(USE_OGL)
+#if !defined(_MAYA_EXPORT)
 #include "stats_manager.h"
 #endif
 
 class CHW
-#if defined(USE_DX10) || defined(USE_DX11)
-    : public pureAppActivate,
-      public pureAppDeactivate
-#endif //	USE_DX10
 {
-    //	Functions section
 public:
     CHW();
     ~CHW();
 
-#ifndef USE_OGL
     void CreateD3D();
     void DestroyD3D();
-#endif // !USE_OGL
 
     void CreateDevice(SDL_Window* sdlWnd);
-#if defined(USE_DX10) || defined(USE_DX11)
-    void CreateSwapChain(HWND hwnd);
-    bool CreateSwapChain2(HWND hwnd);
-#endif
 
     void DestroyDevice();
 
     void Reset();
 
-#ifndef USE_OGL
     D3DFORMAT selectDepthStencil(D3DFORMAT);
     u32 selectPresentInterval();
     u32 selectGPU();
     BOOL support(D3DFORMAT fmt, DWORD type, DWORD usage);
-#endif // !USE_OGL
 
-#if defined(DEBUG) && defined(USE_DX9)
+#if defined(DEBUG)
     void Validate()
     {
         VERIFY(pDevice);
@@ -56,48 +43,12 @@ public:
 public:
     CHWCaps Caps;
 
-#if defined(USE_OGL)
-    CHW* pDevice;
-    CHW* pContext;
-    CHW* m_pSwapChain;
-    GLuint pBaseRT;
-    GLuint pBaseZB;
-    GLuint pPP;
-    GLuint pFB;
-
-    SDL_Window* m_hWnd;
-    HDC m_hDC;
-    SDL_GLContext m_hRC;
-    pcstr AdapterName;
-    pcstr OpenGLVersion;
-    pcstr ShadingVersion;
-    bool ShaderBinarySupported;
-#else // General DirectX
     ID3DDevice* pDevice = nullptr; // render device
     ID3DRenderTargetView* pBaseRT = nullptr; // base render target
     ID3DDepthStencilView* pBaseZB = nullptr; // base depth-stencil buffer
 
     D3D_DRIVER_TYPE m_DriverType;
-#ifndef USE_DX9
-    IDXGIFactory1* m_pFactory = nullptr;
-    IDXGIAdapter1* m_pAdapter = nullptr; // pD3D equivalent
-    ID3DDeviceContext* pContext = nullptr;
-    IDXGISwapChain* m_pSwapChain = nullptr;
-    DXGI_SWAP_CHAIN_DESC m_ChainDesc; // DevPP equivalent
-    D3D_FEATURE_LEVEL FeatureLevel;
-    bool ComputeShadersSupported;
-#ifdef HAS_DX11_2
-    IDXGIFactory2* m_pFactory2 = nullptr;
-    IDXGISwapChain2* m_pSwapChain2 = nullptr;
-#endif
-#ifdef HAS_DX11_3
-    ID3D11Device3* pDevice3 = nullptr;
-#endif
-#if defined(USE_DX10)
-    ID3D10Device1* pDevice1 = nullptr;
-    ID3D10Device1* pContext1 = nullptr;
-#endif
-#else // USE_DX9
+
 #ifdef DEBUG
     IDirect3DStateBlock9* dwDebugSB = nullptr;
 #endif
@@ -109,35 +60,10 @@ public:
 
     UINT DevAdapter;
     D3DPRESENT_PARAMETERS DevPP;
-#endif // USE_DX9
-#endif // USE_OGL
 
-#if !defined(_MAYA_EXPORT) && !defined(USE_OGL)
+#if !defined(_MAYA_EXPORT)
     stats_manager stats_manager;
 #endif
-
-#ifndef USE_DX9
-    void UpdateViews();
-#endif
-#if defined(USE_DX10) || defined(USE_DX11)
-    bool CheckFormatSupport(DXGI_FORMAT format, UINT feature) const;
-    DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT formats[], size_t count) const;
-    template <size_t count>
-    inline DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT (&formats)[count]) const
-    {
-        return SelectFormat(feature, formats, count);
-    }
-    bool UsingFlipPresentationModel() const;
-    virtual void OnAppActivate();
-    virtual void OnAppDeactivate();
-#endif //	USE_DX10
-
-#ifdef USE_OGL
-    // TODO: OGL: Implement this into a compatibility layer?
-    void ClearRenderTargetView(GLuint pRenderTargetView, const FLOAT ColorRGBA[4]);
-    void ClearDepthStencilView(GLuint pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil);
-    HRESULT Present(UINT SyncInterval, UINT Flags);
-#endif // USE_OGL
 };
 
 extern ECORE_API CHW HW;

--- a/src/Layers/xrRender/HWCaps.cpp
+++ b/src/Layers/xrRender/HWCaps.cpp
@@ -4,14 +4,14 @@
 #include "HWCaps.h"
 #include "HW.h"
 
-#if !defined(_EDITOR) && !defined(USE_OGL)
+#if !defined(_EDITOR)
 #include <nvapi.h>
 #include <ags_lib/inc/amd_ags.h>
 #endif
 
 namespace
 {
-#if !defined(_EDITOR) && !defined(USE_OGL)
+#if !defined(_EDITOR)
 u32 GetNVGpuNum()
 {
     NvLogicalGpuHandle logicalGPUs[NVAPI_MAX_LOGICAL_GPUS];
@@ -110,7 +110,6 @@ u32 GetGpuNum() { return 1; }
 #endif
 }
 
-#ifdef USE_DX9
 void CHWCaps::Update()
 {
     D3DCAPS9 caps;
@@ -219,71 +218,3 @@ void CHWCaps::Update()
 
     iGPUNum = GetGpuNum();
 }
-#else // USE_DX9
-void CHWCaps::Update()
-{
-    // ***************** GEOMETRY
-    geometry_major = 4;
-    geometry_minor = 0;
-    geometry.bSoftware = FALSE;
-    geometry.bPointSprites = FALSE;
-    geometry.bNPatches = FALSE;
-    DWORD cnt = 256;
-    clamp<DWORD>(cnt, 0, 256);
-    geometry.dwRegisters = cnt;
-    geometry.dwInstructions = 256;
-    geometry.dwClipPlanes = _min(6, 15);
-#ifdef USE_OGL
-    // XXX: Disabled by default. Need to:
-    // FIX: Sky texture filtering (point filter now) when VTF is on
-    // TODO: Implement support VTF and: HW.support(D3DFMT_R32F, D3DRTYPE_TEXTURE, D3DUSAGE_QUERY_VERTEXTEXTURE)
-    geometry.bVTF = (strstr(Core.Params, "-vtf")) ? TRUE : FALSE;
-#else // USE_OGL
-    geometry.bVTF = TRUE;
-#endif // USE_OGL
-
-    // ***************** PIXEL processing
-    raster_major = 4;
-    raster_minor = 0;
-    // XXX: review this
-    raster.dwStages = 15; // Previuos value is 16, but it's out of bounds
-    raster.bNonPow2 = TRUE;
-    raster.bCubemap = TRUE;
-    raster.dwMRT_count = 4;
-    // raster.b_MRT_mixdepth		= FALSE;
-    raster.b_MRT_mixdepth = TRUE;
-    raster.dwInstructions = 256;
-    //	TODO: DX10: Find a way to detect cache size
-    geometry.dwVertexCache = 24;
-
-#ifndef USE_OGL
-    // ***************** Info
-    Msg("* GPU shading: vs(%x/%d.%d/%d), ps(%x/%d.%d/%d)", 0, geometry_major, geometry_minor,
-        CAP_VERSION(geometry_major, geometry_minor), 0, raster_major, raster_minor,
-        CAP_VERSION(raster_major, raster_minor));
-    // *******1********** Vertex cache
-    Msg("* GPU vertex cache: %s, %d", "unrecognized", u32(geometry.dwVertexCache));
-#endif // USE_OGL
-    // *******1********** Compatibility : vertex shader
-    if (0 == raster_major)
-        geometry_major = 0; // Disable VS if no PS
-
-    //
-    bTableFog = FALSE; // BOOL	(caps.RasterCaps&D3DPRASTERCAPS_FOGTABLE);
-
-    // Detect if stencil available
-    bStencil = TRUE;
-
-    // Scissoring
-    bScissor = TRUE;
-
-    // Stencil relative caps
-    soInc = D3DSTENCILOP_INCRSAT;
-    soDec = D3DSTENCILOP_DECRSAT;
-    dwMaxStencilValue = (1 << 8) - 1;
-
-    // DEV INFO
-
-    iGPUNum = GetGpuNum();
-}
-#endif // USE_DX9

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -385,13 +385,6 @@ bool CHW::UsingFlipPresentationModel() const
     ;
 }
 
-BOOL CHW::support(D3DFORMAT fmt, DWORD type, DWORD usage)
-{
-    // TODO: DX10: implement stub for this code.
-    VERIFY(!"Implement CHW::support");
-    return TRUE;
-}
-
 void CHW::UpdateViews()
 {
     const DXGI_SWAP_CHAIN_DESC& sd = m_ChainDesc;

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#include "Layers/xrRender/HW.h"
+#include "dx10HW.h"
 #include "xrEngine/xr_input.h"
 #include "xrEngine/XR_IOConsole.h"
 #include "xrCore/xr_token.h"

--- a/src/Layers/xrRenderDX10/dx10HW.cpp
+++ b/src/Layers/xrRenderDX10/dx10HW.cpp
@@ -385,13 +385,6 @@ bool CHW::UsingFlipPresentationModel() const
     ;
 }
 
-D3DFORMAT CHW::selectDepthStencil(D3DFORMAT /*fTarget*/)
-{
-// R3 hack
-#pragma todo("R3 need to specify depth format")
-    return D3DFMT_D24S8;
-}
-
 BOOL CHW::support(D3DFORMAT fmt, DWORD type, DWORD usage)
 {
     // TODO: DX10: implement stub for this code.

--- a/src/Layers/xrRenderDX10/dx10HW.h
+++ b/src/Layers/xrRenderDX10/dx10HW.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "Layers/xrRender/HWCaps.h"
+#include "xrCore/ModuleLookup.hpp"
+#include "SDL.h"
+#include "SDL_syswm.h"
+
+#if !defined(_MAYA_EXPORT)
+#include "Layers/xrRender/stats_manager.h"
+#endif
+
+class CHW
+    : public pureAppActivate,
+      public pureAppDeactivate
+{
+public:
+    CHW();
+    ~CHW();
+
+
+    void CreateD3D();
+    void DestroyD3D();
+
+    void CreateDevice(SDL_Window* sdlWnd);
+
+    void CreateSwapChain(HWND hwnd);
+    bool CreateSwapChain2(HWND hwnd);
+
+    void DestroyDevice();
+
+    void Reset();
+
+    D3DFORMAT selectDepthStencil(D3DFORMAT);
+    u32 selectPresentInterval();
+    u32 selectGPU();
+    BOOL support(D3DFORMAT fmt, DWORD type, DWORD usage);
+
+    void Validate() {}
+
+public:
+    CHWCaps Caps;
+
+    ID3DDevice* pDevice = nullptr; // render device
+    ID3DRenderTargetView* pBaseRT = nullptr; // base render target
+    ID3DDepthStencilView* pBaseZB = nullptr; // base depth-stencil buffer
+
+    D3D_DRIVER_TYPE m_DriverType;
+
+    IDXGIFactory1* m_pFactory = nullptr;
+    IDXGIAdapter1* m_pAdapter = nullptr; // pD3D equivalent
+    ID3DDeviceContext* pContext = nullptr;
+    IDXGISwapChain* m_pSwapChain = nullptr;
+    DXGI_SWAP_CHAIN_DESC m_ChainDesc; // DevPP equivalent
+    D3D_FEATURE_LEVEL FeatureLevel;
+    bool ComputeShadersSupported;
+#ifdef HAS_DX11_2
+    IDXGIFactory2* m_pFactory2 = nullptr;
+    IDXGISwapChain2* m_pSwapChain2 = nullptr;
+#endif
+#ifdef HAS_DX11_3
+    ID3D11Device3* pDevice3 = nullptr;
+#endif
+#if defined(USE_DX10)
+    ID3D10Device1* pDevice1 = nullptr;
+    ID3D10Device1* pContext1 = nullptr;
+#endif
+
+#if !defined(_MAYA_EXPORT)
+    stats_manager stats_manager;
+#endif
+
+    void UpdateViews();
+
+    bool CheckFormatSupport(DXGI_FORMAT format, UINT feature) const;
+    DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT formats[], size_t count) const;
+    template <size_t count>
+    inline DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT (&formats)[count]) const
+    {
+        return SelectFormat(feature, formats, count);
+    }
+    bool UsingFlipPresentationModel() const;
+    virtual void OnAppActivate();
+    virtual void OnAppDeactivate();
+};
+
+extern ECORE_API CHW HW;

--- a/src/Layers/xrRenderDX10/dx10HW.h
+++ b/src/Layers/xrRenderDX10/dx10HW.h
@@ -29,9 +29,7 @@ public:
 
     void Reset();
 
-    D3DFORMAT selectDepthStencil(D3DFORMAT);
     u32 selectPresentInterval();
-    u32 selectGPU();
     BOOL support(D3DFORMAT fmt, DWORD type, DWORD usage);
 
     void Validate() {}

--- a/src/Layers/xrRenderDX10/dx10HW.h
+++ b/src/Layers/xrRenderDX10/dx10HW.h
@@ -21,18 +21,29 @@ public:
     void DestroyD3D();
 
     void CreateDevice(SDL_Window* sdlWnd);
-
-    void CreateSwapChain(HWND hwnd);
-    bool CreateSwapChain2(HWND hwnd);
-
     void DestroyDevice();
 
     void Reset();
 
-    u32 selectPresentInterval();
-    BOOL support(D3DFORMAT fmt, DWORD type, DWORD usage);
-
     void Validate() {}
+
+    bool CheckFormatSupport(DXGI_FORMAT format, UINT feature) const;
+    DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT formats[], size_t count) const;
+    template <size_t count>
+    inline DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT (&formats)[count]) const
+    {
+        return SelectFormat(feature, formats, count);
+    }
+    bool UsingFlipPresentationModel() const;
+
+    void OnAppActivate() override;
+    void OnAppDeactivate() override;
+
+private:
+    void CreateSwapChain(HWND hwnd);
+    bool CreateSwapChain2(HWND hwnd);
+
+    void UpdateViews();
 
 public:
     CHWCaps Caps;
@@ -65,19 +76,6 @@ public:
 #if !defined(_MAYA_EXPORT)
     stats_manager stats_manager;
 #endif
-
-    void UpdateViews();
-
-    bool CheckFormatSupport(DXGI_FORMAT format, UINT feature) const;
-    DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT formats[], size_t count) const;
-    template <size_t count>
-    inline DXGI_FORMAT SelectFormat(D3D_FORMAT_SUPPORT feature, const DXGI_FORMAT (&formats)[count]) const
-    {
-        return SelectFormat(feature, formats, count);
-    }
-    bool UsingFlipPresentationModel() const;
-    virtual void OnAppActivate();
-    virtual void OnAppDeactivate();
 };
 
 extern ECORE_API CHW HW;

--- a/src/Layers/xrRenderDX10/dx10HW.h
+++ b/src/Layers/xrRenderDX10/dx10HW.h
@@ -17,7 +17,6 @@ public:
     CHW();
     ~CHW();
 
-
     void CreateD3D();
     void DestroyD3D();
 

--- a/src/Layers/xrRenderDX10/dx10HWCaps.cpp
+++ b/src/Layers/xrRenderDX10/dx10HWCaps.cpp
@@ -1,0 +1,171 @@
+#include "stdafx.h"
+#pragma hdrstop
+
+#include "Layers/xrRender/HWCaps.h"
+#include "dx10HW.h"
+
+#if !defined(_EDITOR)
+#include <nvapi.h>
+#include <ags_lib/inc/amd_ags.h>
+#endif
+
+namespace
+{
+#if !defined(_EDITOR)
+u32 GetNVGpuNum()
+{
+    NvLogicalGpuHandle logicalGPUs[NVAPI_MAX_LOGICAL_GPUS];
+    NvU32 logicalGPUCount;
+    NvPhysicalGpuHandle physicalGPUs[NVAPI_MAX_PHYSICAL_GPUS];
+    NvU32 physicalGPUCount;
+
+    //	int result = NVAPI_OK;
+
+    int iGpuNum = 0;
+
+    NvAPI_Status status;
+    status = NvAPI_Initialize();
+
+    if (status != NVAPI_OK)
+    {
+        Msg("* NVAPI is missing.");
+        return iGpuNum;
+    }
+
+    // enumerate logical gpus
+    status = NvAPI_EnumLogicalGPUs(logicalGPUs, &logicalGPUCount);
+    if (status != NVAPI_OK)
+    {
+        Msg("* NvAPI_EnumLogicalGPUs failed!");
+        return iGpuNum;
+        // error
+    }
+
+    // enumerate physical gpus
+    status = NvAPI_EnumPhysicalGPUs(physicalGPUs, &physicalGPUCount);
+    if (status != NVAPI_OK)
+    {
+        Msg("* NvAPI_EnumPhysicalGPUs failed!");
+        return iGpuNum;
+        // error
+    }
+
+    Msg("* NVidia MGPU: Logical(%d), Physical(%d)", physicalGPUCount, logicalGPUCount);
+
+    //	Assume that we are running on logical GPU with most physical GPUs connected.
+    for (u32 i = 0; i < logicalGPUCount; ++i)
+    {
+        status = NvAPI_GetPhysicalGPUsFromLogicalGPU(logicalGPUs[i], physicalGPUs, &physicalGPUCount);
+        if (status == NVAPI_OK)
+            iGpuNum = _max(iGpuNum, physicalGPUCount);
+    }
+
+    if (iGpuNum > 1)
+        Msg("* NVidia MGPU: %d-Way SLI detected.", iGpuNum);
+
+    return iGpuNum;
+}
+
+u32 GetATIGpuNum()
+{
+    AGSContext* ags = nullptr;
+    AGSGPUInfo gpuInfo = {};
+    AGSReturnCode status = agsInit(&ags, &gpuInfo);
+    if (status != AGS_SUCCESS)
+    {
+        Msg("* AGS: Initialization failed (%d)", status);
+        return 0;
+    }
+    int crossfireGpuCount = 1;
+    status = agsGetCrossfireGPUCount(ags, &crossfireGpuCount);
+    if (status != AGS_SUCCESS)
+    {
+        Msg("! AGS: Unable to get CrossFire GPU count (%d)", status);
+        agsDeInit(ags);
+        return 1;
+    }
+    Msg("* AGS: CrossFire GPU count: %d", crossfireGpuCount);
+    agsDeInit(ags);
+    return crossfireGpuCount;
+}
+
+u32 GetGpuNum()
+{
+    u32 res = GetNVGpuNum();
+    res = _max(res, GetATIGpuNum());
+    res = _min(res, CHWCaps::MAX_GPUS);
+
+    if (res == 0)
+    {
+        Log("! Cannot find graphic adapter. Assuming that you have one...");
+        res = 1;
+    }
+
+    Msg("* Starting rendering as %d-GPU.", res);
+
+    return res;
+}
+#else
+u32 GetGpuNum() { return 1; }
+#endif
+}
+
+
+void CHWCaps::Update()
+{
+    // ***************** GEOMETRY
+    geometry_major = 4;
+    geometry_minor = 0;
+    geometry.bSoftware = FALSE;
+    geometry.bPointSprites = FALSE;
+    geometry.bNPatches = FALSE;
+    DWORD cnt = 256;
+    clamp<DWORD>(cnt, 0, 256);
+    geometry.dwRegisters = cnt;
+    geometry.dwInstructions = 256;
+    geometry.dwClipPlanes = _min(6, 15);
+    geometry.bVTF = TRUE;
+
+    // ***************** PIXEL processing
+    raster_major = 4;
+    raster_minor = 0;
+    // XXX: review this
+    raster.dwStages = 15; // Previuos value is 16, but it's out of bounds
+    raster.bNonPow2 = TRUE;
+    raster.bCubemap = TRUE;
+    raster.dwMRT_count = 4;
+    // raster.b_MRT_mixdepth		= FALSE;
+    raster.b_MRT_mixdepth = TRUE;
+    raster.dwInstructions = 256;
+    //	TODO: DX10: Find a way to detect cache size
+    geometry.dwVertexCache = 24;
+
+    // ***************** Info
+    Msg("* GPU shading: vs(%x/%d.%d/%d), ps(%x/%d.%d/%d)", 0, geometry_major, geometry_minor,
+        CAP_VERSION(geometry_major, geometry_minor), 0, raster_major, raster_minor,
+        CAP_VERSION(raster_major, raster_minor));
+    // *******1********** Vertex cache
+    Msg("* GPU vertex cache: %s, %d", "unrecognized", u32(geometry.dwVertexCache));
+
+    // *******1********** Compatibility : vertex shader
+    if (0 == raster_major)
+        geometry_major = 0; // Disable VS if no PS
+
+    //
+    bTableFog = FALSE; // BOOL	(caps.RasterCaps&D3DPRASTERCAPS_FOGTABLE);
+
+    // Detect if stencil available
+    bStencil = TRUE;
+
+    // Scissoring
+    bScissor = TRUE;
+
+    // Stencil relative caps
+    soInc = D3DSTENCILOP_INCRSAT;
+    soDec = D3DSTENCILOP_DECRSAT;
+    dwMaxStencilValue = (1 << 8) - 1;
+
+    // DEV INFO
+
+    iGPUNum = GetGpuNum();
+}

--- a/src/Layers/xrRenderDX10/dx10HWCaps.cpp
+++ b/src/Layers/xrRenderDX10/dx10HWCaps.cpp
@@ -110,7 +110,6 @@ u32 GetGpuNum() { return 1; }
 #endif
 }
 
-
 void CHWCaps::Update()
 {
     // ***************** GEOMETRY

--- a/src/Layers/xrRenderDX9/dx9HW.cpp
+++ b/src/Layers/xrRenderDX9/dx9HW.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#include "Layers/xrRender/HW.h"
+#include "dx9HW.h"
 #include "xrEngine/xr_input.h"
 #include "xrEngine/XR_IOConsole.h"
 #include "xrCore/xr_token.h"

--- a/src/Layers/xrRenderDX9/dx9HW.h
+++ b/src/Layers/xrRenderDX9/dx9HW.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "HWCaps.h"
+#include "Layers/xrRender/HWCaps.h"
 #include "xrCore/ModuleLookup.hpp"
 #include "SDL.h"
 #include "SDL_syswm.h"
 
 #if !defined(_MAYA_EXPORT)
-#include "stats_manager.h"
+#include "Layers/xrRender/stats_manager.h"
 #endif
 
 class CHW

--- a/src/Layers/xrRenderDX9/dx9HWCaps.cpp
+++ b/src/Layers/xrRenderDX9/dx9HWCaps.cpp
@@ -1,8 +1,8 @@
 #include "stdafx.h"
 #pragma hdrstop
 
-#include "HWCaps.h"
-#include "HW.h"
+#include "Layers/xrRender/HWCaps.h"
+#include "dx9HW.h"
 
 #if !defined(_EDITOR)
 #include <nvapi.h>

--- a/src/Layers/xrRenderGL/glHW.cpp
+++ b/src/Layers/xrRenderGL/glHW.cpp
@@ -4,7 +4,7 @@
 #include "stdafx.h"
 #pragma hdrstop
 
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderGL/glHW.h"
 #include "xrEngine/xr_input.h"
 #include "xrEngine/XR_IOConsole.h"
 #include "Include/xrAPI/xrAPI.h"

--- a/src/Layers/xrRenderGL/glHW.h
+++ b/src/Layers/xrRenderGL/glHW.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Layers/xrRender/HWCaps.h"
+#include "xrCore/ModuleLookup.hpp"
+#include "SDL.h"
+#include "SDL_syswm.h"
+
+
+class CHW
+{
+public:
+    CHW();
+    ~CHW();
+
+    void CreateDevice(SDL_Window* sdlWnd);
+
+    void DestroyDevice();
+
+    void Reset();
+
+    void Validate() {}
+
+    void UpdateViews();
+
+    // TODO: OGL: Implement this into a compatibility layer?
+    void ClearRenderTargetView(GLuint pRenderTargetView, const FLOAT ColorRGBA[4]);
+
+    void ClearDepthStencilView(GLuint pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil);
+
+    HRESULT Present(UINT SyncInterval, UINT Flags);
+
+public:
+    CHWCaps Caps;
+
+    CHW* pDevice;
+    CHW* pContext;
+    CHW* m_pSwapChain;
+    GLuint pBaseRT;
+    GLuint pBaseZB;
+    GLuint pPP;
+    GLuint pFB;
+
+    SDL_Window* m_hWnd;
+    HDC m_hDC;
+    SDL_GLContext m_hRC;
+    pcstr AdapterName;
+    pcstr OpenGLVersion;
+    pcstr ShadingVersion;
+    bool ShaderBinarySupported;
+};
+
+extern ECORE_API CHW HW;

--- a/src/Layers/xrRenderGL/glHW.h
+++ b/src/Layers/xrRenderGL/glHW.h
@@ -5,7 +5,6 @@
 #include "SDL.h"
 #include "SDL_syswm.h"
 
-
 class CHW
 {
 public:

--- a/src/Layers/xrRenderGL/glHWCaps.cpp
+++ b/src/Layers/xrRenderGL/glHWCaps.cpp
@@ -4,12 +4,10 @@
 #include "Layers/xrRender/HWCaps.h"
 #include "glHW.h"
 
-
 namespace
 {
 u32 GetGpuNum() { return 1; }
 }
-
 
 void CHWCaps::Update()
 {

--- a/src/Layers/xrRenderGL/glHWCaps.cpp
+++ b/src/Layers/xrRenderGL/glHWCaps.cpp
@@ -1,0 +1,68 @@
+#include "stdafx.h"
+#pragma hdrstop
+
+#include "Layers/xrRender/HWCaps.h"
+#include "glHW.h"
+
+
+namespace
+{
+u32 GetGpuNum() { return 1; }
+}
+
+
+void CHWCaps::Update()
+{
+    // ***************** GEOMETRY
+    geometry_major = 4;
+    geometry_minor = 0;
+    geometry.bSoftware = FALSE;
+    geometry.bPointSprites = FALSE;
+    geometry.bNPatches = FALSE;
+    DWORD cnt = 256;
+    clamp<DWORD>(cnt, 0, 256);
+    geometry.dwRegisters = cnt;
+    geometry.dwInstructions = 256;
+    geometry.dwClipPlanes = _min(6, 15);
+
+    // XXX: Disabled by default. Need to:
+    // FIX: Sky texture filtering (point filter now) when VTF is on
+    // TODO: Implement support VTF and: HW.support(D3DFMT_R32F, D3DRTYPE_TEXTURE, D3DUSAGE_QUERY_VERTEXTEXTURE)
+    geometry.bVTF = (strstr(Core.Params, "-vtf")) ? TRUE : FALSE;
+
+    // ***************** PIXEL processing
+    raster_major = 4;
+    raster_minor = 0;
+    // XXX: review this
+    raster.dwStages = 15; // Previuos value is 16, but it's out of bounds
+    raster.bNonPow2 = TRUE;
+    raster.bCubemap = TRUE;
+    raster.dwMRT_count = 4;
+    // raster.b_MRT_mixdepth		= FALSE;
+    raster.b_MRT_mixdepth = TRUE;
+    raster.dwInstructions = 256;
+    //	TODO: DX10: Find a way to detect cache size
+    geometry.dwVertexCache = 24;
+
+    // *******1********** Compatibility : vertex shader
+    if (0 == raster_major)
+        geometry_major = 0; // Disable VS if no PS
+
+    //
+    bTableFog = FALSE; // BOOL	(caps.RasterCaps&D3DPRASTERCAPS_FOGTABLE);
+
+    // Detect if stencil available
+    bStencil = TRUE;
+
+    // Scissoring
+    bScissor = TRUE;
+
+    // Stencil relative caps
+    soInc = D3DSTENCILOP_INCRSAT;
+    soDec = D3DSTENCILOP_DECRSAT;
+    dwMaxStencilValue = (1 << 8) - 1;
+
+    // DEV INFO
+
+    iGPUNum = GetGpuNum();
+}

--- a/src/Layers/xrRenderPC_GL/stdafx.h
+++ b/src/Layers/xrRenderPC_GL/stdafx.h
@@ -26,7 +26,7 @@
 
 #include "xrParticles/psystem.h"
 
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderGL/glHW.h"
 #include "Layers/xrRender/Shader.h"
 #include "Layers/xrRender/R_Backend.h"
 #include "Layers/xrRender/R_Backend_Runtime.h"

--- a/src/Layers/xrRenderPC_GL/xrRender_GL.vcxproj
+++ b/src/Layers/xrRenderPC_GL/xrRender_GL.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="..\xrRenderGL\glHW.cpp" />
     <ClCompile Include="..\xrRenderGL\glBufferUtils.cpp" />
     <ClCompile Include="..\xrRenderGL\glDetailManager_VS.cpp" />
+    <ClCompile Include="..\xrRenderGL\glHWCaps.cpp" />
     <ClCompile Include="..\xrRenderGL\glMinMaxSMBlender.cpp" />
     <ClCompile Include="..\xrRenderGL\glSH_RT.cpp" />
     <ClCompile Include="..\xrRenderGL\glSH_Texture.cpp" />
@@ -261,7 +262,6 @@
     <ClCompile Include="..\xrRender\FBasicVisual.cpp" />
     <ClCompile Include="..\xrRender\FHierrarhyVisual.cpp" />
     <ClCompile Include="..\xrRender\HOM.cpp" />
-    <ClCompile Include="..\xrRender\HWCaps.cpp" />
     <ClCompile Include="..\xrRender\light.cpp" />
     <ClCompile Include="..\xrRender\LightTrack.cpp" />
     <ClCompile Include="..\xrRender\Light_DB.cpp" />
@@ -348,6 +348,7 @@
     <ClInclude Include="..\xrRenderGL\GL Rain\glRainBlender.h" />
     <ClInclude Include="..\xrRenderGL\glBufferPool.h" />
     <ClInclude Include="..\xrRenderGL\glBufferUtils.h" />
+    <ClInclude Include="..\xrRenderGL\glHW.h" />
     <ClInclude Include="..\xrRenderGL\glMinMaxSMBlender.h" />
     <ClInclude Include="..\xrRenderGL\glR_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderGL\glr_constants_cache.h" />
@@ -384,7 +385,6 @@
     <ClInclude Include="..\xrRender\FSkinned.h" />
     <ClInclude Include="..\xrRender\FTreeVisual.h" />
     <ClInclude Include="..\xrRender\FVisual.h" />
-    <ClInclude Include="..\xrRender\HW.h" />
     <ClInclude Include="..\xrRender\Light_Render_Direct.h" />
     <ClInclude Include="..\xrRender\ModelPool.h" />
     <ClInclude Include="..\xrRender\r_sun_cascades.h" />

--- a/src/Layers/xrRenderPC_GL/xrRender_GL.vcxproj.filters
+++ b/src/Layers/xrRenderPC_GL/xrRender_GL.vcxproj.filters
@@ -435,9 +435,6 @@
     <ClCompile Include="..\xrRender\SkeletonX.cpp">
       <Filter>Refactored\Execution &amp; 3D\Visuals\Skeleton</Filter>
     </ClCompile>
-    <ClCompile Include="..\xrRender\HWCaps.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
     <ClCompile Include="..\xrRender\r__sector_traversal.cpp">
       <Filter>Visibility\Sector/Portal</Filter>
     </ClCompile>
@@ -686,6 +683,9 @@
     </ClCompile>
     <ClCompile Include="..\xrRenderGL\glBufferPool.cpp">
       <Filter>dx9 to gl Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderGL\glHWCaps.cpp">
+      <Filter>Refactored\HW</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -995,9 +995,6 @@
     <ClInclude Include="..\xrRender\Light_Render_Direct.h">
       <Filter>Lights</Filter>
     </ClInclude>
-    <ClInclude Include="..\xrRender\HW.h">
-      <Filter>Refactored\HW</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\Include\xrRender\RenderFactory.h">
       <Filter>Interface implementations\RenderFactory</Filter>
     </ClInclude>
@@ -1129,6 +1126,9 @@
     </ClInclude>
     <ClInclude Include="..\xrRenderGL\glBufferPool.h">
       <Filter>dx9 to gl Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xrRenderGL\glHW.h">
+      <Filter>Refactored\HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Layers/xrRenderPC_R1/stdafx.h
+++ b/src/Layers/xrRenderPC_R1/stdafx.h
@@ -14,7 +14,7 @@
 #include "Layers/xrRender/xrD3DDefs.h"
 #endif
 #include "Layers/xrRender/Debug/dxPixEventWrapper.h"
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderDX9/dx9HW.h"
 #include "Layers/xrRender/Shader.h"
 #include "Layers/xrRender/R_Backend.h"
 #include "Layers/xrRender/R_Backend_Runtime.h"

--- a/src/Layers/xrRenderPC_R1/xrRender_R1.vcxproj
+++ b/src/Layers/xrRenderPC_R1/xrRender_R1.vcxproj
@@ -186,6 +186,7 @@
     <ClInclude Include="..\..\Include\xrRender\UISequenceVideoItem.h" />
     <ClInclude Include="..\..\Include\xrRender\UIShader.h" />
     <ClInclude Include="..\..\Include\xrRender\WallMarkArray.h" />
+    <ClInclude Include="..\xrRenderDX9\dx9HW.h" />
     <ClInclude Include="..\xrRenderDX9\dx9R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX9\dx9r_constants_cache.h" />
     <ClInclude Include="..\xrRender\Animation.h" />
@@ -238,7 +239,6 @@
     <ClInclude Include="..\xrRender\FVF.h" />
     <ClInclude Include="..\xrRender\FVisual.h" />
     <ClInclude Include="..\xrRender\HOM.h" />
-    <ClInclude Include="..\xrRender\HW.h" />
     <ClInclude Include="..\xrRender\HWCaps.h" />
     <ClInclude Include="..\xrRender\IRenderDetailModel.h" />
     <ClInclude Include="..\xrRender\KinematicAnimatedDefs.h" />
@@ -306,6 +306,8 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\xrRenderDX9\dx9HW.cpp" />
+    <ClCompile Include="..\xrRenderDX9\dx9HWCaps.cpp" />
     <ClCompile Include="..\xrRenderDX9\dx9r_constants_cache.cpp" />
     <ClCompile Include="..\xrRender\Animation.cpp" />
     <ClCompile Include="..\xrRender\blenders\Blender.cpp" />
@@ -360,8 +362,6 @@
     <ClCompile Include="..\xrRender\FTreeVisual.cpp" />
     <ClCompile Include="..\xrRender\FVisual.cpp" />
     <ClCompile Include="..\xrRender\HOM.cpp" />
-    <ClCompile Include="..\xrRender\HW.cpp" />
-    <ClCompile Include="..\xrRender\HWCaps.cpp" />
     <ClCompile Include="..\xrRender\light.cpp" />
     <ClCompile Include="..\xrRender\LightTrack.cpp" />
     <ClCompile Include="..\xrRender\Light_DB.cpp" />

--- a/src/Layers/xrRenderPC_R1/xrRender_R1.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R1/xrRender_R1.vcxproj.filters
@@ -375,9 +375,6 @@
     <ClInclude Include="..\..\Include\xrRender\UISequenceVideoItem.h">
       <Filter>Interfase implementations\UI\UISequenceVideoItem</Filter>
     </ClInclude>
-    <ClInclude Include="..\xrRender\HW.h">
-      <Filter>Refactored\HW</Filter>
-    </ClInclude>
     <ClInclude Include="..\xrRender\HWCaps.h">
       <Filter>Refactored\HW</Filter>
     </ClInclude>
@@ -575,6 +572,9 @@
     </ClInclude>
     <ClInclude Include="..\xrRender\ShaderResourceTraits.h">
       <Filter>Refactored\Execution &amp; 3D\Shaders\ShaderManager</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xrRenderDX9\dx9HW.h">
+      <Filter>Refactored\HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -791,12 +791,6 @@
     <ClCompile Include="..\xrRender\dxUISequenceVideoItem.cpp">
       <Filter>Interfase implementations\UI\UISequenceVideoItem</Filter>
     </ClCompile>
-    <ClCompile Include="..\xrRender\HW.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
-    <ClCompile Include="..\xrRender\HWCaps.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
     <ClCompile Include="..\xrRender\R_Backend.cpp">
       <Filter>Refactored\Backend</Filter>
     </ClCompile>
@@ -961,6 +955,12 @@
     </ClCompile>
     <ClCompile Include="..\xrRender\D3DXRenderBase.cpp">
       <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX9\dx9HW.cpp">
+      <Filter>Refactored\HW</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX9\dx9HWCaps.cpp">
+      <Filter>Refactored\HW</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Layers/xrRenderPC_R2/stdafx.h
+++ b/src/Layers/xrRenderPC_R2/stdafx.h
@@ -12,7 +12,7 @@
 
 #include "Layers/xrRender/xrD3DDefs.h"
 #include "Layers/xrRender/Debug/dxPixEventWrapper.h"
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderDX9/dx9HW.h"
 #include "Layers/xrRender/Shader.h"
 #include "Layers/xrRender/R_Backend.h"
 #include "Layers/xrRender/R_Backend_Runtime.h"

--- a/src/Layers/xrRenderPC_R2/xrRender_R2.vcxproj
+++ b/src/Layers/xrRenderPC_R2/xrRender_R2.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="..\..\Include\xrRender\UISequenceVideoItem.h" />
     <ClInclude Include="..\..\Include\xrRender\UIShader.h" />
     <ClInclude Include="..\..\Include\xrRender\WallMarkArray.h" />
+    <ClInclude Include="..\xrRenderDX9\dx9HW.h" />
     <ClInclude Include="..\xrRenderDX9\dx9R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX9\dx9r_constants_cache.h" />
     <ClInclude Include="..\xrRender\Animation.h" />
@@ -240,7 +241,6 @@
     <ClInclude Include="..\xrRender\FVF.h" />
     <ClInclude Include="..\xrRender\FVisual.h" />
     <ClInclude Include="..\xrRender\HOM.h" />
-    <ClInclude Include="..\xrRender\HW.h" />
     <ClInclude Include="..\xrRender\HWCaps.h" />
     <ClInclude Include="..\xrRender\IRenderDetailModel.h" />
     <ClInclude Include="..\xrRender\KinematicAnimatedDefs.h" />
@@ -318,6 +318,8 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\xrRenderDX9\dx9HW.cpp" />
+    <ClCompile Include="..\xrRenderDX9\dx9HWCaps.cpp" />
     <ClCompile Include="..\xrRenderDX9\dx9r_constants_cache.cpp" />
     <ClCompile Include="..\xrRender\Animation.cpp" />
     <ClCompile Include="..\xrRender\blenders\Blender.cpp" />
@@ -372,8 +374,6 @@
     <ClCompile Include="..\xrRender\FTreeVisual.cpp" />
     <ClCompile Include="..\xrRender\FVisual.cpp" />
     <ClCompile Include="..\xrRender\HOM.cpp" />
-    <ClCompile Include="..\xrRender\HW.cpp" />
-    <ClCompile Include="..\xrRender\HWCaps.cpp" />
     <ClCompile Include="..\xrRender\light.cpp" />
     <ClCompile Include="..\xrRender\LightTrack.cpp" />
     <ClCompile Include="..\xrRender\Light_DB.cpp" />

--- a/src/Layers/xrRenderPC_R2/xrRender_R2.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R2/xrRender_R2.vcxproj.filters
@@ -342,9 +342,6 @@
     <ClInclude Include="..\xrRender\ColorMapManager.h">
       <Filter>Core_Target\ColorMap</Filter>
     </ClInclude>
-    <ClInclude Include="..\xrRender\HW.h">
-      <Filter>Refactored\HW</Filter>
-    </ClInclude>
     <ClInclude Include="..\xrRender\HWCaps.h">
       <Filter>Refactored\HW</Filter>
     </ClInclude>
@@ -614,6 +611,9 @@
     </ClInclude>
     <ClInclude Include="..\xrRender\ShaderResourceTraits.h">
       <Filter>Refactored\Execution &amp; 3D\Shaders\ShaderManager</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xrRenderDX9\dx9HW.h">
+      <Filter>Refactored\HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -911,12 +911,6 @@
     <ClCompile Include="..\xrRender\ColorMapManager.cpp">
       <Filter>Core_Target\ColorMap</Filter>
     </ClCompile>
-    <ClCompile Include="..\xrRender\HW.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
-    <ClCompile Include="..\xrRender\HWCaps.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
     <ClCompile Include="..\xrRender\R_Backend.cpp">
       <Filter>Refactored\Backend</Filter>
     </ClCompile>
@@ -1105,6 +1099,12 @@
     </ClCompile>
     <ClCompile Include="..\xrRender\D3DXRenderBase.cpp">
       <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX9\dx9HW.cpp">
+      <Filter>Refactored\HW</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX9\dx9HWCaps.cpp">
+      <Filter>Refactored\HW</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Layers/xrRenderPC_R3/r3.cpp
+++ b/src/Layers/xrRenderPC_R3/r3.cpp
@@ -229,19 +229,6 @@ void CRender::create()
     o.fp16_filter = true;
     o.fp16_blend = true;
 
-    // search for ATI formats
-    if (!o.HW_smap && (0 == strstr(Core.Params, "-nodf24")))
-    {
-        o.HW_smap = HW.support((D3DFORMAT)(MAKEFOURCC('D', 'F', '2', '4')), D3DRTYPE_TEXTURE, D3DUSAGE_DEPTHSTENCIL);
-        if (o.HW_smap)
-        {
-            o.HW_smap_FORMAT = MAKEFOURCC('D', 'F', '2', '4');
-            o.HW_smap_PCF = FALSE;
-            o.HW_smap_FETCH4 = TRUE;
-        }
-        Msg("* DF24/F4 supported and used [%X]", o.HW_smap_FORMAT);
-    }
-
     // emulate ATI-R4xx series
     if (strstr(Core.Params, "-r4xx"))
     {

--- a/src/Layers/xrRenderPC_R3/stdafx.h
+++ b/src/Layers/xrRenderPC_R3/stdafx.h
@@ -24,7 +24,7 @@
 #define RENDER R_R3
 
 #include "xrParticles/psystem.h"
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderDX10/dx10HW.h"
 #include "Layers/xrRender/Shader.h"
 #include "Layers/xrRender/R_Backend.h"
 #include "Layers/xrRender/R_Backend_Runtime.h"

--- a/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj
+++ b/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj
@@ -197,6 +197,7 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer_impl.h" />
+    <ClInclude Include="..\xrRenderDX10\dx10HW.h" />
     <ClInclude Include="..\xrRenderDX10\dx10MinMaxSMBlender.h" />
     <ClInclude Include="..\xrRenderDX10\dx10R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX10\dx10r_constants_cache.h" />
@@ -260,7 +261,6 @@
     <ClInclude Include="..\xrRender\FVF.h" />
     <ClInclude Include="..\xrRender\FVisual.h" />
     <ClInclude Include="..\xrRender\HOM.h" />
-    <ClInclude Include="..\xrRender\HW.h" />
     <ClInclude Include="..\xrRender\HWCaps.h" />
     <ClInclude Include="..\xrRender\IRenderDetailModel.h" />
     <ClInclude Include="..\xrRender\KinematicsAddBoneTransform.hpp" />
@@ -352,6 +352,7 @@
     <ClCompile Include="..\xrRenderDX10\dx10ConstantBuffer.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10DetailManager_VS.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10HW.cpp" />
+    <ClCompile Include="..\xrRenderDX10\dx10HWCaps.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10MinMaxSMBlender.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10ResourceManager_Resources.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10ResourceManager_Scripting.cpp" />
@@ -422,7 +423,6 @@
     <ClCompile Include="..\xrRender\FTreeVisual.cpp" />
     <ClCompile Include="..\xrRender\FVisual.cpp" />
     <ClCompile Include="..\xrRender\HOM.cpp" />
-    <ClCompile Include="..\xrRender\HWCaps.cpp" />
     <ClCompile Include="..\xrRender\light.cpp" />
     <ClCompile Include="..\xrRender\LightTrack.cpp" />
     <ClCompile Include="..\xrRender\Light_DB.cpp" />

--- a/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R3/xrRender_R3.vcxproj.filters
@@ -381,9 +381,6 @@
     <ClInclude Include="..\xrRender\ColorMapManager.h">
       <Filter>Core_Target\ColorMap</Filter>
     </ClInclude>
-    <ClInclude Include="..\xrRender\HW.h">
-      <Filter>Refactored\HW</Filter>
-    </ClInclude>
     <ClInclude Include="..\xrRender\HWCaps.h">
       <Filter>Refactored\HW</Filter>
     </ClInclude>
@@ -698,6 +695,9 @@
     </ClInclude>
     <ClInclude Include="..\xrRender\KinematicsAddBoneTransform.hpp">
       <Filter>Refactored\Execution &amp; 3D\Visuals\Skeleton</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xrRenderDX10\dx10HW.h">
+      <Filter>Refactored\HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1025,9 +1025,6 @@
     <ClCompile Include="..\xrRenderDX10\dx10HW.cpp">
       <Filter>Refactored\HW</Filter>
     </ClCompile>
-    <ClCompile Include="..\xrRender\HWCaps.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
     <ClCompile Include="..\xrRender\R_Backend.cpp">
       <Filter>Refactored\Backend</Filter>
     </ClCompile>
@@ -1279,6 +1276,9 @@
     </ClCompile>
     <ClCompile Include="..\xrRender\D3DXRenderBase.cpp">
       <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX10\dx10HWCaps.cpp">
+      <Filter>Refactored\HW</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -234,19 +234,6 @@ void CRender::create()
     o.fp16_filter = true;
     o.fp16_blend = true;
 
-    // search for ATI formats
-    if (!o.HW_smap && (0 == strstr(Core.Params, "-nodf24")))
-    {
-        o.HW_smap = HW.support((D3DFORMAT)(MAKEFOURCC('D', 'F', '2', '4')), D3DRTYPE_TEXTURE, D3DUSAGE_DEPTHSTENCIL);
-        if (o.HW_smap)
-        {
-            o.HW_smap_FORMAT = MAKEFOURCC('D', 'F', '2', '4');
-            o.HW_smap_PCF = FALSE;
-            o.HW_smap_FETCH4 = TRUE;
-        }
-        Msg("* DF24/F4 supported and used [%X]", o.HW_smap_FORMAT);
-    }
-
     // emulate ATI-R4xx series
     if (strstr(Core.Params, "-r4xx"))
     {

--- a/src/Layers/xrRenderPC_R4/stdafx.h
+++ b/src/Layers/xrRenderPC_R4/stdafx.h
@@ -39,7 +39,7 @@
 #define RENDER R_R4
 
 #include "xrParticles/psystem.h"
-#include "Layers/xrRender/HW.h"
+#include "Layers/xrRenderDX10/dx10HW.h"
 #include "Layers/xrRender/Shader.h"
 #include "Layers/xrRender/R_Backend.h"
 #include "Layers/xrRender/R_Backend_Runtime.h"

--- a/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj
+++ b/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj
@@ -197,6 +197,7 @@
     <ClInclude Include="..\xrRenderDX10\dx10BufferUtils.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer.h" />
     <ClInclude Include="..\xrRenderDX10\dx10ConstantBuffer_impl.h" />
+    <ClInclude Include="..\xrRenderDX10\dx10HW.h" />
     <ClInclude Include="..\xrRenderDX10\dx10R_Backend_Runtime.h" />
     <ClInclude Include="..\xrRenderDX10\dx10r_constants_cache.h" />
     <ClInclude Include="..\xrRenderDX10\dx10StateUtils.h" />
@@ -260,7 +261,6 @@
     <ClInclude Include="..\xrRender\FVF.h" />
     <ClInclude Include="..\xrRender\FVisual.h" />
     <ClInclude Include="..\xrRender\HOM.h" />
-    <ClInclude Include="..\xrRender\HW.h" />
     <ClInclude Include="..\xrRender\HWCaps.h" />
     <ClInclude Include="..\xrRender\IRenderDetailModel.h" />
     <ClInclude Include="..\xrRender\KinematicsAddBoneTransform.hpp" />
@@ -358,6 +358,7 @@
     <ClCompile Include="..\xrRenderDX10\dx10ConstantBuffer.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10DetailManager_VS.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10HW.cpp" />
+    <ClCompile Include="..\xrRenderDX10\dx10HWCaps.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10ResourceManager_Resources.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10ResourceManager_Scripting.cpp" />
     <ClCompile Include="..\xrRenderDX10\dx10r_constants.cpp" />
@@ -427,7 +428,6 @@
     <ClCompile Include="..\xrRender\FTreeVisual.cpp" />
     <ClCompile Include="..\xrRender\FVisual.cpp" />
     <ClCompile Include="..\xrRender\HOM.cpp" />
-    <ClCompile Include="..\xrRender\HWCaps.cpp" />
     <ClCompile Include="..\xrRender\light.cpp" />
     <ClCompile Include="..\xrRender\LightTrack.cpp" />
     <ClCompile Include="..\xrRender\Light_DB.cpp" />

--- a/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj.filters
+++ b/src/Layers/xrRenderPC_R4/xrRender_R4.vcxproj.filters
@@ -390,9 +390,6 @@
     <ClInclude Include="..\xrRender\ColorMapManager.h">
       <Filter>Core_Target\ColorMap</Filter>
     </ClInclude>
-    <ClInclude Include="..\xrRender\HW.h">
-      <Filter>Refactored\HW</Filter>
-    </ClInclude>
     <ClInclude Include="..\xrRender\HWCaps.h">
       <Filter>Refactored\HW</Filter>
     </ClInclude>
@@ -719,6 +716,9 @@
     </ClInclude>
     <ClInclude Include="..\xrRender\KinematicsAddBoneTransform.hpp">
       <Filter>Refactored\Execution &amp; 3D\Visuals\Skeleton</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xrRenderDX10\dx10HW.h">
+      <Filter>Refactored\HW</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1052,9 +1052,6 @@
     <ClCompile Include="..\xrRenderDX10\dx10HW.cpp">
       <Filter>Refactored\HW</Filter>
     </ClCompile>
-    <ClCompile Include="..\xrRender\HWCaps.cpp">
-      <Filter>Refactored\HW</Filter>
-    </ClCompile>
     <ClCompile Include="..\xrRender\R_Backend.cpp">
       <Filter>Refactored\Backend</Filter>
     </ClCompile>
@@ -1315,6 +1312,9 @@
     </ClCompile>
     <ClCompile Include="..\xrRender\D3DXRenderBase.cpp">
       <Filter>Core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xrRenderDX10\dx10HWCaps.cpp">
+      <Filter>Refactored\HW</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Current implementation of `CHW`  is huge bloody mess from DX and GL interfaces. Separated implementations make adding new back-end easier.