### PR TITLE
Update configuration to disable Travis CI warnings on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
        wget http://launchpadlibrarian.net/297657747/libsdl2-dev_2.0.5+dfsg1-1ubuntu1_amd64.deb;
        sudo dpkg -i *.deb;
        sudo apt-get -f -y install;
-       cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIGURATION;
+       CFLAGS="-w" CXXFLAGS="-w" cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIGURATION;
     fi
 
   - if [ $TARGET_CPU == x86 ]; then
@@ -81,7 +81,7 @@ before_script:
        wget http://launchpadlibrarian.net/297657456/libsdl2-dev_2.0.5+dfsg1-1ubuntu1_i386.deb;
        sudo dpkg -i *.deb;
        sudo apt-get -f -y install;
-       CFLAGS="-m32" CXXFLAGS="-m32" cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIGURATION -DCMAKE_ASM_FLAGS=-m32;
+       CFLAGS="-m32 -w" CXXFLAGS="-m32 -w" cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIGURATION -DCMAKE_ASM_FLAGS=-m32;
     fi
 
 script:


### PR DESCRIPTION
- Update configuration to disable Travis CI warnings on build because of log size.