### PR TITLE
xrRender: HW: `Validate` removed

### DIFF
--- a/src/Layers/xrRender/D3DXRenderBase.cpp
+++ b/src/Layers/xrRender/D3DXRenderBase.cpp
@@ -58,10 +58,6 @@ void D3DXRenderBase::OnDeviceDestroy(bool bKeepTextures)
     RCache.OnDeviceDestroy();
 }
 
-void D3DXRenderBase::ValidateHW()
-{
-    HW.Validate();
-}
 void D3DXRenderBase::DestroyHW()
 {
     xr_delete(Resources);
@@ -254,7 +250,6 @@ void D3DXRenderBase::ResourcesDumpMemoryUsage()
 }
 DeviceState D3DXRenderBase::GetDeviceState()
 {
-    HW.Validate();
     return HW.GetDeviceState();
 }
 

--- a/src/Layers/xrRender/D3DXRenderBase.h
+++ b/src/Layers/xrRender/D3DXRenderBase.h
@@ -181,7 +181,6 @@ public:
     virtual void updateGamma() override;
     //	Destroy
     virtual void OnDeviceDestroy(bool bKeepTextures) override;
-    virtual void ValidateHW() override;
     virtual void DestroyHW() override;
     virtual void Reset(SDL_Window* hWnd, u32& dwWidth, u32& dwHeight, float& fWidth_2, float& fHeight_2) override;
     //	Init

--- a/src/Layers/xrRenderDX10/dx10HW.h
+++ b/src/Layers/xrRenderDX10/dx10HW.h
@@ -25,8 +25,6 @@ public:
 
     void Reset();
 
-    void Validate() {}
-
     std::pair<u32, u32> GetSurfaceSize() const;
 
     bool CheckFormatSupport(DXGI_FORMAT format, UINT feature) const;

--- a/src/Layers/xrRenderDX9/dx9HW.cpp
+++ b/src/Layers/xrRenderDX9/dx9HW.cpp
@@ -393,14 +393,6 @@ D3DFORMAT CHW::GetSurfaceFormat() const
     return DevPP.BackBufferFormat;
 }
 
-void CHW::Validate()
-{
-#if defined(DEBUG)
-    VERIFY(pDevice);
-    VERIFY(pD3D);
-#endif
-};
-
 void CHW::Present()
 {
     pDevice->Present(nullptr, nullptr, nullptr, nullptr);

--- a/src/Layers/xrRenderDX9/dx9HW.h
+++ b/src/Layers/xrRenderDX9/dx9HW.h
@@ -29,7 +29,6 @@ public:
     D3DFORMAT GetSurfaceFormat() const;
     void Present();
     DeviceState GetDeviceState();
-    void Validate();
 
 private:
     u32 selectPresentInterval();

--- a/src/Layers/xrRenderGL/glHW.h
+++ b/src/Layers/xrRenderGL/glHW.h
@@ -16,8 +16,6 @@ public:
 
     void Reset();
 
-    void Validate() {}
-
     std::pair<u32, u32> GetSurfaceSize() const;
 
     void UpdateViews();

--- a/src/xrEngine/Device_destroy.cpp
+++ b/src/xrEngine/Device_destroy.cpp
@@ -13,7 +13,6 @@ void CRenderDevice::Destroy()
     if (!b_is_Ready)
         return;
     Log("Destroying Render...");
-    GEnv.Render->ValidateHW();
     GEnv.DU->OnDeviceDestroy();
     b_is_Ready = false;
     Statistic->OnDeviceDestroy();

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -384,7 +384,6 @@ public:
 
     //	Destroy
     virtual void OnDeviceDestroy(bool bKeepTextures) = 0;
-    virtual void ValidateHW() = 0;
     virtual void DestroyHW() = 0;
     virtual void Reset(SDL_Window* hWnd, u32& dwWidth, u32& dwHeight, float& fWidth_2, float& fHeight_2) = 0;
     //	Init


### PR DESCRIPTION
`Validate` is useless. If one needs to query device state it's better to use `GetDeviceState` instead.