### PR TITLE
xrRender: Backend: `SetTransform` removed

### DIFF
--- a/src/Layers/xrRender/R_Backend.h
+++ b/src/Layers/xrRender/R_Backend.h
@@ -261,7 +261,6 @@ public:
 #endif // USE_DX10
 
     // API
-    IC void set_xform(u32 ID, const Fmatrix& M);
     IC void set_xform_world(const Fmatrix& M);
     IC void set_xform_view(const Fmatrix& M);
     IC void set_xform_project(const Fmatrix& M);

--- a/src/Layers/xrRender/R_Backend_xform.cpp
+++ b/src/Layers/xrRender/R_Backend_xform.cpp
@@ -17,7 +17,7 @@ void R_xforms::set_W(const Fmatrix& m)
     m_bInvWValid = false;
     if (c_invw)
         apply_invw();
-    RCache.set_xform(D3DTS_WORLD, m);
+    RCache.stat.xforms++;
 }
 void R_xforms::set_V(const Fmatrix& m)
 {
@@ -33,7 +33,7 @@ void R_xforms::set_V(const Fmatrix& m)
         RCache.set_c(c_wv, m_wv);
     if (c_wvp)
         RCache.set_c(c_wvp, m_wvp);
-    RCache.set_xform(D3DTS_VIEW, m);
+    RCache.stat.xforms++;
 }
 void R_xforms::set_P(const Fmatrix& m)
 {
@@ -46,8 +46,7 @@ void R_xforms::set_P(const Fmatrix& m)
         RCache.set_c(c_vp, m_vp);
     if (c_wvp)
         RCache.set_c(c_wvp, m_wvp);
-    // always setup projection - D3D relies on it to work correctly :(
-    RCache.set_xform(D3DTS_PROJECTION, m);
+    RCache.stat.xforms++;
 }
 
 void R_xforms::apply_invw()

--- a/src/Layers/xrRenderDX10/dx10R_Backend_Runtime.h
+++ b/src/Layers/xrRenderDX10/dx10R_Backend_Runtime.h
@@ -5,13 +5,6 @@
 #include "StateManager/dx10StateManager.h"
 #include "StateManager/dx10ShaderResourceStateCache.h"
 
-IC void CBackend::set_xform(u32 ID, const Fmatrix& M)
-{
-    stat.xforms++;
-    //  TODO: DX10: Implement CBackend::set_xform
-    // VERIFY(!"Implement CBackend::set_xform");
-}
-
 IC void CBackend::set_RT(ID3DRenderTargetView* RT, u32 ID)
 {
     if (RT != pRT[ID])

--- a/src/Layers/xrRenderDX9/dx9R_Backend_Runtime.h
+++ b/src/Layers/xrRenderDX9/dx9R_Backend_Runtime.h
@@ -2,12 +2,6 @@
 #define dx9R_Backend_Runtime_included
 #pragma once
 
-IC void CBackend::set_xform(u32 ID, const Fmatrix& M)
-{
-    stat.xforms++;
-    CHK_DX(HW.pDevice->SetTransform((D3DTRANSFORMSTATETYPE)ID, (D3DMATRIX*)&M));
-}
-
 IC void CBackend::set_RT(ID3DRenderTargetView* RT, u32 ID)
 {
     if (RT != pRT[ID])

--- a/src/Layers/xrRenderGL/glR_Backend_Runtime.h
+++ b/src/Layers/xrRenderGL/glR_Backend_Runtime.h
@@ -4,13 +4,6 @@
 
 #include "glStateUtils.h"
 
-IC void CBackend::set_xform(u32 ID, const Fmatrix& M)
-{
-    stat.xforms++;
-    //	TODO: OGL: Implement CBackend::set_xform
-    //VERIFY(!"Implement CBackend::set_xform");
-}
-
 IC GLuint CBackend::get_FB()
 {
     return pFB;


### PR DESCRIPTION
`SetTransform` is legacy from fixed pipeline world. Can be safely removed