### PR TITLE
PKGBUILD fix

### DIFF
--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -1,5 +1,12 @@
-pkgname=openxray                                    
-pkgver=1.6.02_df255fe83                                          
+# Contributor: chip_exe
+# https://aur.archlinux.org/packages/openxray-git/
+# <openxray@yahoo.com>
+#This PKGBUILD compiles the package without downloading the source code. It is mainly intended for developers who use
+#ArchLinux or Majaro.
+#To build the package, open a terminal, go to the xray-16/ArchLinux directory and run the makepkg -fi command
+#where the options are -f to overwrite the package if it was built before that -i install the package after the build.
+pkgname=openxray-dev                                    
+pkgver=1.6.02_
 pkgrel=1          
 pkgdesc="Unofficial X-Ray Engine Linux port by OpenXRay team (Originally developed by GSC Game World)"                                          
 arch=('x86_64') 
@@ -7,7 +14,8 @@ url="https://github.com/OpenXRay/xray-16"
 license=('custom:Custom 3-сlause BSD')
 install="info.install"
 makedepends=(gcc git cmake libglvnd libjpeg6-turbo ncurses pcre2 pcre)
-depends=(glew sdl2 openal intel-tbb crypto++ liblockfile freeimage libogg libtheora libvorbis lzo lzop libjpeg-turbo) 
+depends=(glew sdl2 openal intel-tbb crypto++ liblockfile freeimage libogg libtheora libvorbis lzo lzop libjpeg-turbo)
+conflicts=(openxray openxray-git)
 
 pkgver() {
   cd ../..
@@ -17,7 +25,7 @@ pkgver() {
 build() {
    cd ../..
 #  rm -f -R bin
-   mkdir bin
+   mkdir -p bin
    cd bin
    cmake ..
    make


### PR DESCRIPTION
Build rule fixed. Now makepkg will not wake up and give the error "mkdir: cannot create the bin directory: File exists", the name of the package has been changed, a new package conflict has been added