### PR TITLE
added trailing separator on categories

### DIFF
--- a/res/openxray.desktop
+++ b/res/openxray.desktop
@@ -3,7 +3,7 @@
 Version=1.0
 Type=Application
 Terminal=false
-Categories = Game
+Categories = Game;
 Icon=openxray
 Exec=xr_3da
 Name = S.T.A.L.K.E.R.: Call of Pripyat (OpenXRay)


### PR DESCRIPTION
most DEs deal with it right but some envs requires standard appearance (for example, appimagetool)
https://standards.freedesktop.org/desktop-entry-spec/1.0/ar01s03.html