### PR TITLE
CMake: switch mimalloc to OpenXray fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	url = https://github.com/g-truc/gli.git
 [submodule "Externals/mimalloc"]
 	path = Externals/mimalloc
-	url = https://github.com/microsoft/mimalloc.git
+	url = https://github.com/OpenXRay/mimalloc.git


### PR DESCRIPTION
This PR fix problem with build linux package with new mimalloc library (by add special cmake options)