### PR TITLE
Linux: debug: ud2 changed to int3

### DIFF
--- a/src/xrCommon/inlining_macros.h
+++ b/src/xrCommon/inlining_macros.h
@@ -4,7 +4,7 @@
 #define NO_INLINE __attribute__((noinline))
 #define FORCE_INLINE __attribute__((always_inline)) inline
 #define ALIGN(a) __attribute__((aligned(a)))
-#define DEBUG_BREAK __builtin_trap()
+#define DEBUG_BREAK __asm__ volatile ("int $3");
 #elif defined(_MSC_VER)
 #define NO_INLINE __declspec(noinline)
 #define FORCE_INLINE __forceinline


### PR DESCRIPTION
Current EH prints back trace and calls `__builtin_trap()` to stop crashed application. clang and gcc uses `ud2` as the built-in implementation wich cause to illegal instruction exception. This will emit SIGILL which will be processed by the EH again and produce more prints (not informative in this case). Eventually it will be propagated to the OS and app will exit. 

How it looks now:
```
< some crash happened here >
 
FATAL ERROR
 
[error] Expression    : <no expression>
[error] Function      : handler_base
[error] File          : /mnt/repos/xray-16/src/xrCore/xrDebug.cpp
[error] Line          : 841
[error] Description   : segmentation fault
 

stack trace:

/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug10GatherInfoEPcjRK13ErrorLocationPKcS5_S5_S5_+0x1c0) [0xb78ebb50]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug4FailERbRK13ErrorLocationPKcS5_S5_S5_+0xbf) [0xb78ebcff]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x3c133) [0xb78ec133]
linux-gate.so.1(__kernel_sigreturn+0) [0xb7ed8ae8]
 
FATAL ERROR
 
[error] Expression    : <no expression>
[error] Function      : handler_base
[error] File          : /mnt/repos/xray-16/src/xrCore/xrDebug.cpp
[error] Line          : 841
[error] Description   : illegal instruction
 

stack trace:

/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug10GatherInfoEPcjRK13ErrorLocationPKcS5_S5_S5_+0x1c0) [0xb78ebb50]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug4FailERbRK13ErrorLocationPKcS5_S5_S5_+0xbf) [0xb78ebcff]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x3c133) [0xb78ec133]
linux-gate.so.1(__kernel_sigreturn+0) [0xb7ed8ae8]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x1d790) [0xb78cd790]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x3c133) [0xb78ec133]
linux-gate.so.1(__kernel_sigreturn+0) [0xb7ed8ae8]
Illegal instruction (core dumped)
```

..and how it will look:

```
< The same crash happened again >
 
FATAL ERROR
 
[error] Expression    : <no expression>
[error] Function      : handler_base
[error] File          : /mnt/repos/xray-16/src/xrCore/xrDebug.cpp
[error] Line          : 841
[error] Description   : segmentation fault
 

stack trace:

/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug10GatherInfoEPcjRK13ErrorLocationPKcS5_S5_S5_+0x1c0) [0xb793fb50]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug4FailERbRK13ErrorLocationPKcS5_S5_S5_+0xbf) [0xb793fcff]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x3c1d3) [0xb79401d3]
linux-gate.so.1(__kernel_sigreturn+0) [0xb7f2cae8]
Trace/breakpoint trap (core dumped)
```