### PR TITLE
xrCore: debug: Linux stack trace demangling

### DIFF
--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -441,8 +441,8 @@ void xrDebug::GatherInfo(char* assertionInfo, size_t bufferSize, const ErrorLoca
     {
         for (size_t i = 0; i < nptrs; i++)
         {
-            char *functionName = strings[i];
-            char *demangledName = nullptr;
+            char* functionName = strings[i];
+            char* demangledName = nullptr;
             Dl_info info;
 
             if (dladdr(array[i], &info))


### PR DESCRIPTION
A trivial back trace demangling implementation.

Stack trace before:

```
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug10GatherInfoEPcjRK13ErrorLocationPKcS5_S5_S5_+0x1c0) [0xb78eeb50]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN7xrDebug4FailERbRK13ErrorLocationPKcS5_S5_S5_+0xbf) [0xb78eecff]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x21f24) [0xb78d4f24]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN11CLocatorAPI12setup_fs_ltxEPKc+0x93) [0xb78dad13]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN11CLocatorAPI11_initializeEjPKcS1_+0x3ae) [0xb78dfe3e]
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(_ZN6xrCore10InitializeEPKcS1_11LogCallbackbS1_b+0x4bb) [0xb78ee5eb]
./xr_3da(+0x1692) [0x47e692]
./xr_3da(+0x136b) [0x47e36b]
/usr/lib/libc.so.6(__libc_start_main+0xf5) [0xb6a8de65]
./xr_3da(_start+0x35) [0x47e485]
```

..and after:

```
xrDebug::GatherInfo(char*, unsigned int, ErrorLocation const&, char const*, char const*, char const*, char const*)
xrDebug::Fail(bool&, ErrorLocation const&, char const*, char const*, char const*, char const*)
/mnt/repos/xray-16/build/src/xrCore/xrCore.so(+0x21fb4) [0xb7976fb4]
CLocatorAPI::setup_fs_ltx(char const*)
CLocatorAPI::_initialize(unsigned int, char const*, char const*)
xrCore::Initialize(char const*, char const*, LogCallback, bool, char const*, bool)
./xr_3da(+0x1692) [0x449692]
./xr_3da(+0x136b) [0x44936b]
/usr/lib/libc.so.6(__libc_start_main+0xf5) [0xb6b2fe65]
./xr_3da(_start+0x35) [0x449485]