### PR TITLE
xrCommon/xr_string.h: Fix for incorrect hash function, it's also disabled on Windows now

### DIFF
--- a/src/xrCommon/xr_string.h
+++ b/src/xrCommon/xr_string.h
@@ -29,15 +29,16 @@ inline xr_string xr_substrreplace(const xr_string& src, const xr_string& src_sub
     return res;
 }
 
+#if !defined(WINDOWS)
 namespace std
 {
 template<>
 struct hash<xr_string>
 {
-    // XXX: enable C++17 for all projects to be able to use nodiscard attribute
-    /*[[nodiscard]]*/ size_t operator()(const xr_string& str) const noexcept
+    [[nodiscard]] size_t operator()(const xr_string& str) const noexcept
     {
-        return std::hash<pcstr>{}(str.c_str());
+        return std::hash<std::string_view>{}(str.c_str());
     }
 };
 }
+#endif


### PR DESCRIPTION
1) Original one was calculating hash for pointer, not string itself. So it's was almost always fail to compare two strings by it's hash. 
2) It's not needed for Windows - it has it's own hash implementation in VC++ Redist