### PR TITLE
xrRender: fix for crash in debug DX9 renderer

### DIFF
--- a/src/Layers/xrRender/R_Backend_Runtime.cpp
+++ b/src/Layers/xrRender/R_Backend_Runtime.cpp
@@ -21,7 +21,6 @@ void CBackend::OnFrameEnd()
         CHK_DX(HW.pDevice->SetIndices(nullptr));
         CHK_DX(HW.pDevice->SetVertexShader(nullptr));
         CHK_DX(HW.pDevice->SetPixelShader(nullptr));
-        CHK_DX(HW.pDevice->EndScene());
 #endif
         Invalidate();
     }

--- a/src/Layers/xrRenderDX9/dx9HW.cpp
+++ b/src/Layers/xrRenderDX9/dx9HW.cpp
@@ -395,6 +395,7 @@ std::pair<u32, u32> CHW::GetSurfaceSize() const
 
 void CHW::Present()
 {
+    CHK_DX(pDevice->EndScene());
     pDevice->Present(nullptr, nullptr, nullptr, nullptr);
     CurrentBackBuffer = (CurrentBackBuffer + 1) % BackBufferCount;
 }


### PR DESCRIPTION
я тебе породив, я тебе і вб'ю

*Fixes regression after #471 (read more here https://github.com/OpenXRay/xray-16/pull/471#discussion_r327866582)*