### PR TITLE
xrRender: Rename "shaders_cache" to "shaders_cache_oxr" (to not mess with original game)

### DIFF
--- a/src/Layers/xrRenderPC_GL/rgl_shaders.cpp
+++ b/src/Layers/xrRenderPC_GL/rgl_shaders.cpp
@@ -536,7 +536,7 @@ HRESULT CRender::shader_compile(LPCSTR name, IReader* fs, LPCSTR pFunctionName,
     if (HW.ShaderBinarySupported)
     {
         string_path file;
-        strconcat(sizeof(file), file, "shaders_cache" DELIMITER, filename);
+        strconcat(sizeof(file), file, "shaders_cache_oxr" DELIMITER, filename);
         FS.update_path(full_path, "$app_data_root$", file);
 
         string_path shadersFolder;

--- a/src/Layers/xrRenderPC_R1/FStaticRender_Shaders.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_Shaders.cpp
@@ -205,7 +205,7 @@ HRESULT CRender::shader_compile(LPCSTR name, IReader* fs, LPCSTR pFunctionName, 
     if (!match_shader_id(name, sh_name, m_file_set, temp_file_name))
     {
         string_path file;
-        strconcat(sizeof(file), file, "shaders_cache" DELIMITER, filename, DELIMITER, sh_name);
+        strconcat(sizeof(file), file, "shaders_cache_oxr" DELIMITER, filename, DELIMITER, sh_name);
         strconcat(sizeof(filename), filename, filename, DELIMITER, sh_name);
         FS.update_path(file_name, "$app_data_root$", file);
     }

--- a/src/Layers/xrRenderPC_R2/r2_shaders.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_shaders.cpp
@@ -469,7 +469,7 @@ HRESULT CRender::shader_compile(
     if (!match_shader_id(name, sh_name, m_file_set, temp_file_name))
     {
         string_path file;
-        strconcat(sizeof(file), file, "shaders_cache" DELIMITER, filename, DELIMITER, sh_name);
+        strconcat(sizeof(file), file, "shaders_cache_oxr" DELIMITER, filename, DELIMITER, sh_name);
         strconcat(sizeof(filename), filename, filename, DELIMITER, sh_name);
         FS.update_path(file_name, "$app_data_root$", file);
     }

--- a/src/Layers/xrRenderPC_R3/r3_shaders.cpp
+++ b/src/Layers/xrRenderPC_R3/r3_shaders.cpp
@@ -648,7 +648,7 @@ HRESULT CRender::shader_compile(LPCSTR name, IReader* fs, LPCSTR pFunctionName, 
     if (!match_shader_id(name, sh_name, m_file_set, temp_file_name))
     {
         string_path file;
-        strconcat(sizeof(file), file, "shaders_cache" DELIMITER, filename, DELIMITER, sh_name);
+        strconcat(sizeof(file), file, "shaders_cache_oxr" DELIMITER, filename, DELIMITER, sh_name);
         strconcat(sizeof(filename), filename, filename, DELIMITER, sh_name);
         FS.update_path(file_name, "$app_data_root$", file);
     }

--- a/src/Layers/xrRenderPC_R4/r4_shaders.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_shaders.cpp
@@ -500,7 +500,7 @@ HRESULT CRender::shader_compile(LPCSTR name, IReader* fs, LPCSTR pFunctionName,
     if (!match_shader_id(name, sh_name.c_str(), m_file_set, temp_file_name))
     {
         string_path file;
-        strconcat(sizeof(file), file, "shaders_cache" DELIMITER, filename, DELIMITER, sh_name.c_str());
+        strconcat(sizeof(file), file, "shaders_cache_oxr" DELIMITER, filename, DELIMITER, sh_name.c_str());
         strconcat(sizeof(filename), filename, filename, DELIMITER, sh_name.c_str());
         FS.update_path(file_name, "$app_data_root$", file);
     }


### PR DESCRIPTION
At least it's critical for HQ Geometry Fix shaders, since original engine can't invalidate cache for skin.h (unlike OpenXRay). So user may be confused.