### PR TITLE
xrRender: Font: don't change state if there is no text to render

### DIFF
--- a/src/Layers/xrRender/dxFontRender.cpp
+++ b/src/Layers/xrRender/dxFontRender.cpp
@@ -21,6 +21,13 @@ extern ENGINE_API Fvector2 g_current_font_scale;
 void dxFontRender::OnRender(CGameFont& owner)
 {
     VERIFY(g_bRendering);
+
+    if (owner.strings.size() == 0)
+    {
+        // early exit if there is no text to render
+        return;
+    }
+
     if (pShader)
         RCache.set_Shader(pShader);
 


### PR DESCRIPTION
This eliminates unnecessary backend state changes while rendering empty stats 