### PR TITLE
xrRender: implement simple occlusion culling for particles on OpenGL

### DIFF
--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -645,7 +645,7 @@ void CParticleEffect::Render(float)
 
 #ifdef USE_OGL
     // Due to the big impact on performance
-    float distSQ = RDEVICE.vCameraPosition.distance_to_sqr(m_InitialPosition) + EPS;
+    const float distSQ = RDEVICE.vCameraPosition.distance_to_sqr(m_InitialPosition) + EPS;
     if (distSQ > _sqr(100.f*psVisDistance))
         return;
 #endif

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -643,6 +643,13 @@ void CParticleEffect::Render(float)
     TAL_SCOPED_TASK_NAMED("CParticleEffect::Render()");
 #endif // _GPA_ENABLED
 
+#ifdef USE_OGL
+    // Due to the big impact on performance
+    float distSQ = RDEVICE.vCameraPosition.distance_to_sqr(m_InitialPosition) + EPS;
+    if (distSQ > _sqr(100.f*psVisDistance))
+        return;
+#endif
+
     u32 dwOffset, dwCount;
     // Get a pointer to the particles in gp memory
     PAPI::Particle* particles;


### PR DESCRIPTION
On OpenGL renderer, performance significantly less than DirectX. One of the reasons is particles. This PR introduces a simple occlusion culling by particle distance check on OpenGL (rs_vis_dist * 100).