### PR TITLE
Integration of .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+
+[*.{c,h,cpp,hpp}]
+indent_style = space
+indent_size = 4
+max_line_length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.git*
 !.appveyor*
 !.travis.yml
+!.editorconfig
 
 # exclude binaries and temporary files
 CMakeCache.txt


### PR DESCRIPTION
Added .editorconfig to project to prevent further code format errors and support project code format standart partially.