### PR TITLE
Linux. CPack improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cmake_install.cmake
 cmake-build-debug
 install_manifest.txt
 bin/
+build/
 intermediate/
 intermediate_plugs/
 lib/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,31 +24,6 @@ elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "e2k")
 	set(PROJECT_PLATFORM_E2K TRUE)
 endif()
 
-if(NOT WIN32)
-    IF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
-        set(CPACK_PACKAGE_NAME "openxray")
-        set(CPACK_FILE_NAME "openxray")
-        set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
-        set(CPACK_PACKAGE_VERSION "1.6.02")
-        set(CPACK_PACKAGE_CONTACT "OpenXRay <openxray@yahoo.com>")
-        set(CPACK_PACKAGE_DESCRIPTION "OpenXRay is an improved version of the X-Ray Engine, the game engine used in the world-famous S.T.A.L.K.E.R. game series by GSC Game World.")
-        set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})
-        set(CPACK_DEBIAN_PACKAGE_SECTION "games")
-        set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/OpenXRay/xray-16")
-        set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-        set(CPACK_STRIP_FILES TRUE)
-        set(CPACK_GENERATOR DEB)
-        set(CPACK_SOURCE_IGNORE_FILES "/.gitattributes")
-        set(CPACK_RESOURCE_FILE_README ${PROJECT_SOURCE_DIR}/README.md)
-        set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/License.txt)
-        set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
-        set(CPACK_DEBIAN_REVISON "ubuntu-bionic-a1")
-        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_REVISON}_${_OS_ARCH}")
-        set(CPACK_DEBIAN_PACKAGE_SOURCE "OpenXRay")
-        INCLUDE(CPack)
-    ENDIF(EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
-endif()
-
 option ( TBB_PARALLEL "Use tbb::parallel for prarticle and skinning acceleration on SMP." ON )
 option ( USE_CRYPTOPP "Use Crypto++ Library (REQUIRED FOR MULTIPLAYER)" ON )
 
@@ -218,25 +193,6 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/Common )
 add_subdirectory(Externals)
 add_subdirectory(src)
 add_subdirectory(res)
-
-# Unix system configuration
-if (UNIX)
-    # --------------------------------------------------
-    # Uninstall target
-    # --------------------------------------------------
-    # To clean system folder from libraries and binaries
-    # that was installed with `sudo make install`
-    # just run `sudo make uninstall`
-    #
-    if(NOT TARGET uninstall)
-        configure_file(
-                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-                "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-                IMMEDIATE @ONLY)
-
-        add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-    endif()
-endif()
 
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
 

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -1,0 +1,56 @@
+set(PACKAGE_PROJECT_NAME        "OpenXRay")
+set(PACKAGE_PROJECT_DESCRIPTION "OpenXRay is an improved version of the X-Ray Engine, the game engine used in the world-famous S.T.A.L.K.E.R. game series by GSC Game World.")
+set(PACKAGE_PROJECT_CONTACT     "OpenXRay <openxray@yahoo.com>")
+set(PACKAGE_PROJECT_VERSION     "1.6.02")
+set(PACKAGE_PROJECT_HOME_URL    "https://github.com/OpenXRay/xray-16")
+
+if (UNIX)
+    if (EXISTS "${CMAKE_ROOT}/Modules/CPack.cmake")
+        set(CPACK_PACKAGE_NAME ${PACKAGE_PROJECT_NAME})
+        set(CPACK_FILE_NAME "openxray")
+        set(CPACK_PACKAGE_VERSION ${PACKAGE_PROJECT_VERSION})
+        set(CPACK_PACKAGE_CONTACT ${PACKAGE_PROJECT_CONTACT})
+        set(CPACK_PACKAGE_DESCRIPTION ${PACKAGE_PROJECT_DESCRIPTION})
+        set(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})
+        set(CPACK_STRIP_FILES TRUE)
+        set(CPACK_SOURCE_IGNORE_FILES "/.gitattributes")
+        set(CPACK_RESOURCE_FILE_README ${PROJECT_SOURCE_DIR}/README.md)
+        set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/License.txt)
+
+        # --- SELECT PROPER CPACK GENERATOR ---
+        if (DEBIAN_FOUND)
+            set(CPACK_GENERATOR DEB)
+
+            set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+            set(CPACK_DEBIAN_PACKAGE_CONTROL_STRICT_PERMISSION TRUE)
+            set(CPACK_DEBIAN_REVISON "ubuntu-bionic-a1") # TODO: This one need to be detected dynamically
+            set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_REVISON}_${_OS_ARCH}")
+            set(CPACK_DEBIAN_PACKAGE_SOURCE "OpenXRay")
+            set(CPACK_DEBIAN_PACKAGE_SECTION "games")
+            set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${PACKAGE_PROJECT_HOME_URL})
+            set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+        endif()
+
+        if (FEDORA_FOUND OR REDHAT_FOUND OR CENTOS_FOUND)
+            set(CPACK_GENERATOR RPM)
+
+            set(CPACK_RPM_PACKAGE_NAME ${PACKAGE_PROJECT_NAME})
+            set(CPACK_RPM_PACKAGE_DESCRIPTION ${PACKAGE_PROJECT_DESCRIPTION})
+            set(CPACK_RPM_PACKAGE_VERSION ${PACKAGE_PROJECT_VERSION})
+            set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games")
+            set(CPACK_RPM_PACKAGE_VENDOR ${PACKAGE_PROJECT_NAME})
+            set(CPACK_RPM_PACKAGE_URL ${PACKAGE_PROJECT_HOME_URL})
+        endif()
+
+        INCLUDE(CPack)
+    endif()
+endif()
+
+# TODO: Need to be implemented in future
+if (WIN32)
+    #set(CPACK_GENERATOR NSIS)
+endif()
+
+if (APPLE)
+    #set(CPACK_GENERATOR "DRAGNDROP")
+endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,14 +1,14 @@
 macro(add_dir DIRS)
-  foreach(dir ${DIRS})
-    message( "adding  ${dir} to ${PROJECT_NAME}")
-    include_directories  (${dir} )
-    file( GLOB ${dir}__INCLUDES_H ${dir} ${dir}/*.h)
-    file( GLOB ${dir}__INCLUDES_HPP ${dir} ${dir}/*.hpp)
-    list( APPEND ${PROJECT_NAME}__INCLUDES ${${dir}__INCLUDES_H} ${${dir}__INCLUDES_HPP} )
-    file( GLOB ${dir}__SOURCES_CPP ${dir} ${dir}/*.cpp ${dir}/*.cxx)
-    file( GLOB ${dir}__SOURCES_C ${dir} ${dir}/*.c)
-    list( APPEND ${PROJECT_NAME}__SOURCES ${${dir}__SOURCES_C} ${${dir}__SOURCES_CPP} )
-  endforeach()
+    foreach (dir ${DIRS})
+        message("adding  ${dir} to ${PROJECT_NAME}")
+        include_directories(${dir})
+        file(GLOB ${dir}__INCLUDES_H ${dir} ${dir}/*.h)
+        file(GLOB ${dir}__INCLUDES_HPP ${dir} ${dir}/*.hpp)
+        list(APPEND ${PROJECT_NAME}__INCLUDES ${${dir}__INCLUDES_H} ${${dir}__INCLUDES_HPP})
+        file(GLOB ${dir}__SOURCES_CPP ${dir} ${dir}/*.cpp ${dir}/*.cxx)
+        file(GLOB ${dir}__SOURCES_C ${dir} ${dir}/*.c)
+        list(APPEND ${PROJECT_NAME}__SOURCES ${${dir}__SOURCES_C} ${${dir}__SOURCES_CPP})
+    endforeach()
 endmacro()
 
 
@@ -16,7 +16,35 @@ endmacro()
 # Detect arch type ( x86 or x64 )
 # ------------------------------------------
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(ARCH_TYPE x64)
-else(CMAKE_SIZEOF_VOID_P EQUAL 4)
-  set(ARCH_TYPE x86)
+    set(ARCH_TYPE x64)
+else (CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(ARCH_TYPE x86)
 endif()
+
+# Unix system configuration
+if (UNIX)
+    # Try to find specific OS files to determine type of linux distribution
+    find_file(FEDORA_FOUND fedora-release PATHS /etc)
+    find_file(REDHAT_FOUND redhat-release inittab.RH PATHS /etc)
+    find_file(CENTOS_FOUND centos-release PATHS /etc)
+    # If we found debian then we don't need to check further for ubuntu
+    # as it uses debian core.
+    find_file(DEBIAN_FOUND debian_version debconf.conf PATHS /etc)
+
+    # --------------------------------------------------
+    # Uninstall target
+    # --------------------------------------------------
+    # To clean system folder from libraries and binaries
+    # that was installed with `sudo make install`
+    # just run `sudo make uninstall`
+    if (NOT TARGET uninstall)
+        configure_file(
+                "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+                IMMEDIATE @ONLY)
+
+        add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    endif()
+endif()
+
+include(${PROJECT_SOURCE_DIR}/cmake/packaging.cmake)


### PR DESCRIPTION
- Added support for dynamic detection of linux distribution for configuration of CPack for RPM and DEB packages. 
- Remove non needed parts from main CMakeLists.txt to utils.cmake and packaging.cmake helper files. 
- Added "build" folder to .gitignore file. 

Note: Checked on Debian, Ubuntu, Fedora, CentOS. Fedora and CentOS users still need to install rpmbuild package ( `yum install rpm-build` )

This is a reopened version of https://github.com/OpenXRay/xray-16/pull/621