### PR TITLE
xrCore: Debug: correct path to fsltx in error message

### DIFF
--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -901,7 +901,7 @@ IReader* CLocatorAPI::setup_fs_ltx(pcstr fs_name)
 #endif // MASTER_GOLD
 
     CHECK_OR_EXIT(fsltx_is_available,
-        make_string("Cannot open file \"%s\".\nCheck your working folder.", fs_file_name));
+        make_string("Cannot open file \"%s\".\nCheck your working folder.", fs_name ? fs_name : fs_file_name));
 
 #ifdef DEBUG
     Msg("final $fs_root$ = %s", get_path("$fs_root$")->m_Path);

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -590,12 +590,12 @@ void xrDebug::DoExit(const std::string& message)
 
     if (ShowErrorMessage)
     {
-        const auto result = ShowMessage("Error", message.c_str(), false);
+        const auto result = ShowMessage(Core.ApplicationName, message.c_str(), false);
         if (result != AssertionResult::abort && DebuggerIsPresent())
             DEBUG_BREAK;
     }
     else
-        ShowMessage("Error", message.c_str());
+        ShowMessage(Core.ApplicationName, message.c_str());
 
 #if defined(XR_PLATFORM_WINDOWS)
     TerminateProcess(GetCurrentProcess(), 1);


### PR DESCRIPTION
* When no game data found but `-fsltx` option specified show the missing
.ltx file path instead of last checked directory
* Message box title changed to make the error easily distinguished from
system/other app errors