### PR TITLE
fix appveyor build for linux x86

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ for:
         fi
     - sh: |
         if [ "$PLATFORM" = "x86" ]; then
-        sudo dpkg --add-architecture i386 && sudo apt-get -qq update && sudo apt-get install -y gcc-multilib g++-8-multilib libpulse-dev:i386 libglib2.0-dev:i386 &&
+        sudo dpkg --add-architecture i386 && sudo apt-get -qq update && sudo apt-get install --allow-downgrades -y gcc-multilib g++-8-multilib libpulse-dev:i386 libglib2.0-dev:i386 libllvm10:i386=1:10.0.0-4ubuntu1~18.04.1 libllvm10=1:10.0.0-4ubuntu1~18.04.1 &&
         sudo apt-get install -y libglew-dev:i386 libegl1-mesa-dev:i386 libgles2-mesa-dev:i386 libopenal-dev:i386 libtbb-dev:i386 libcrypto++-dev:i386 liblockfile-dev:i386 libfreeimage-dev:i386 libfreeimageplus-dev:i386 &&
         sudo apt-get install -y cmake liblua5.1-0-dev:i386 libssl-dev:i386 libogg-dev:i386 libtheora-dev:i386 libvorbis-dev:i386 liblzo2-dev:i386 libjpeg-dev:i386 libncurses5-dev:i386 libsdl2-dev:i386 &&
         CFLAGS="-m32 -w" CXXFLAGS="-m32 -w" cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIGURATION -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=i386 -DCMAKE_ASM_FLAGS=-m32


### PR DESCRIPTION
Appveyor has built-in ppa-s with unstable version of libllvm10 and got error like:
> `libllvm10 : Breaks: libllvm10:i386 (!= 1:10.0.1~++20200708123507+ef32c611aa2-1~exp1~20200707224105.191) but 1:10.0.0-4ubuntu1~18.04.1 is to be installed`
> `libllvm10:i386 : Breaks: libllvm10 (!= 1:10.0.0-4ubuntu1~18.04.1) but 1:10.0.1~++20200708123507+ef32c611aa2-1~exp1~20200707224105.191 is to be installed`
> `E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages`

https://ci.appveyor.com/project/q4a/xray-16/builds/34132126/job/yvl3g9b99gthl0p0#L580

So, I just fixed it with with manual installation working version `1:10.0.0-4ubuntu1~18.04.1`