### PR TITLE
Some PVS-Studio static analyzer warning fixes

### DIFF
--- a/src/Common/LevelGameDef.h
+++ b/src/Common/LevelGameDef.h
@@ -51,10 +51,10 @@ xr_token rpoint_type[] = {
 #define POINT_BASE 0x2000
 
 // POINT chunks
-#define RPOINT_CHUNK POINT_BASE + ptRPoint
+#define RPOINT_CHUNK (POINT_BASE + ptRPoint)
 
 // WAY chunks
-#define WAY_PATROLPATH_CHUNK WAY_BASE + wtPatrolPath
+#define WAY_PATROLPATH_CHUNK (WAY_BASE + wtPatrolPath)
 //----------------------------------------------------
 
 #define WAYOBJECT_VERSION 0x0013

--- a/src/Layers/xrRenderGL/glBufferUtils.cpp
+++ b/src/Layers/xrRenderGL/glBufferUtils.cpp
@@ -163,6 +163,9 @@ void ConvertVertexDeclaration(const VertexElement* dxdecl, SDeclaration* decl)
         GLenum type = VertexTypeList[desc.Type];
         GLboolean normalized = VertexNormalizedList[desc.Type];
 
+        if (location < 0)
+            continue; // Unsupported
+
         location += desc.UsageIndex;
         CHK_GL(glVertexAttribFormat(location, size, type, normalized, desc.Offset));
         CHK_GL(glVertexAttribBinding(location, desc.Stream));

--- a/src/Layers/xrRenderGL/glBufferUtils.cpp
+++ b/src/Layers/xrRenderGL/glBufferUtils.cpp
@@ -163,9 +163,6 @@ void ConvertVertexDeclaration(const VertexElement* dxdecl, SDeclaration* decl)
         GLenum type = VertexTypeList[desc.Type];
         GLboolean normalized = VertexNormalizedList[desc.Type];
 
-        if (location < 0)
-            continue; // Unsupported
-
         location += desc.UsageIndex;
         CHK_GL(glVertexAttribFormat(location, size, type, normalized, desc.Offset));
         CHK_GL(glVertexAttribBinding(location, desc.Stream));

--- a/src/Layers/xrRenderGL/glState.cpp
+++ b/src/Layers/xrRenderGL/glState.cpp
@@ -194,7 +194,7 @@ void glState::UpdateRenderState(u32 name, u32 value)
 
 void glState::UpdateSamplerState(u32 stage, u32 name, u32 value)
 {
-    if (stage < 0 || CTexture::mtMaxCombinedShaderTextures < stage)
+    if (stage < 0 || stage >= CTexture::mtMaxCombinedShaderTextures)
         return;
 
     GLint currentFilter = (GLint)GL_NEAREST;

--- a/src/editors/xrManagedApi/core/PostProcessAnimator.hpp
+++ b/src/editors/xrManagedApi/core/PostProcessAnimator.hpp
@@ -109,7 +109,7 @@ public:
         [FieldOffset(1 * sizeof(float))] float g;
         [FieldOffset(2 * sizeof(float))] float b;
 
-        Color(float r, float g, float b) : r(r), g(g), b(b) {}
+        Color(float _r, float _g, float _b) : r(_r), g(_g), b(_b) {}
         operator UInt32()
         {
             int _r = clampr(iFloor(r * 255.0f + 0.5f), 0, 255);

--- a/src/editors/xrWeatherEngine/editor_environment_manager_properties.cpp
+++ b/src/editors/xrWeatherEngine/editor_environment_manager_properties.cpp
@@ -221,4 +221,3 @@ manager::manager()
             setter, s_properties7_enum, 3);
     }
 }
-#endif

--- a/src/utils/ETools/ArbitraryList.h
+++ b/src/utils/ETools/ArbitraryList.h
@@ -64,7 +64,6 @@ public:
     // Returns the pointer to the first item.
     IC T* resize(u32 iNum)
     {
-        VERIFY(iNum >= 0);
         iSize = iNum;
         if (iNum <= iReservedSize)
         {

--- a/src/utils/ETools/ogg_enc.cpp
+++ b/src/utils/ETools/ogg_enc.cpp
@@ -46,7 +46,7 @@ ETOOLS_API int __stdcall ogg_enc(const char* in_fn, const char* out_fn, float qu
     out = fopen(out_fn, "wb");
     if (out == NULL)
     {
-        fclose(out);
+        fclose(in);
         return 0;
     }
 

--- a/src/utils/ETools/resample.cpp
+++ b/src/utils/ETools/resample.cpp
@@ -240,9 +240,8 @@ static int push(res_state const* const state, SAMPLE* pool, int* const poolfill,
 
     SAMPLE *const destbase = dest, *poolhead = pool + *poolfill, *poolend = pool + state->taps, *newpool = pool;
     SAMPLE const *refill, *base, *endpoint;
-    int lencheck;
 
-    lencheck = res_push_check(state, srclen);
+    const int lencheck = res_push_check(state, srclen);
 
     /* fill the pool before diving in */
     while (poolhead < poolend && srclen > 0)

--- a/src/utils/ETools/resample.cpp
+++ b/src/utils/ETools/resample.cpp
@@ -230,10 +230,6 @@ static SAMPLE sum(
 static int push(res_state const* const state, SAMPLE* pool, int* const poolfill, int* const offset, SAMPLE* dest,
     int dststep, SAMPLE const* source, int srcstep, size_t srclen)
 {
-    SAMPLE *const destbase = dest, *poolhead = pool + *poolfill, *poolend = pool + state->taps, *newpool = pool;
-    SAMPLE const *refill, *base, *endpoint;
-    int lencheck;
-
     assert(state);
     assert(pool);
     assert(poolfill);
@@ -241,6 +237,10 @@ static int push(res_state const* const state, SAMPLE* pool, int* const poolfill,
     assert(source);
 
     assert(state->poolfill != -1);
+
+    SAMPLE *const destbase = dest, *poolhead = pool + *poolfill, *poolend = pool + state->taps, *newpool = pool;
+    SAMPLE const *refill, *base, *endpoint;
+    int lencheck;
 
     lencheck = res_push_check(state, srclen);
 

--- a/src/utils/LWO/envelope.c
+++ b/src/utils/LWO/envelope.c
@@ -44,7 +44,7 @@ Read an ENVL chunk from an LWO2 file.
 lwEnvelope* lwGetEnvelope(FILE* fp, int cksize)
 {
     lwEnvelope* env;
-    lwKey* key;
+    lwKey* key = NULL;
     lwPlugin* plug;
     unsigned int id;
     unsigned short sz;

--- a/src/utils/LWO/lwob.c
+++ b/src/utils/LWO/lwob.c
@@ -193,8 +193,8 @@ Read an lwSurface from an LWOB file.
 lwSurface* lwGetSurface5(FILE* fp, int cksize, lwObject* obj)
 {
     lwSurface* surf;
-    lwTexture* tex;
-    lwPlugin* shdr;
+    lwTexture* tex = NULL;
+    lwPlugin* shdr = NULL;
     char* s;
     float v[3];
     unsigned int id, flags;

--- a/src/utils/xrDXT/dds/tPixel.h
+++ b/src/utils/xrDXT/dds/tPixel.h
@@ -639,7 +639,7 @@ typedef fpPixel* fp_i;
 
 inline int operator==(const fpPixel& v1, const fpPixel& v2)
 {
-    return v1.a == v2.a && v1.r == v2.r && v1.b == v2.g && v1.g == v2.b;
+    return v1.a == v2.a && v1.r == v2.r && v1.b == v2.b && v1.g == v2.g;
 }
 
 inline fpPixel& fpPixel::operator=(const fpPixel& v)

--- a/src/utils/xrLC/NvMender2002/nv_algebra.cpp
+++ b/src/utils/xrLC/NvMender2002/nv_algebra.cpp
@@ -691,7 +691,7 @@ mat4& perspective(mat4& M, const nv_scalar fovy, const nv_scalar aspect, const n
 
 const quat quat::Identity(0, 0, 0, 1);
 
-quat::quat(nv_scalar x, nv_scalar y, nv_scalar z, nv_scalar w) : x(x), y(y), z(z), w(w) {}
+quat::quat(nv_scalar x_, nv_scalar y_, nv_scalar z_, nv_scalar w_) : x(x_), y(y_), z(z_), w(w_) {}
 quat::quat(const quat& quat)
 {
     x = quat.x;

--- a/src/utils/xrLC/NvMender2002/nv_algebra.cpp
+++ b/src/utils/xrLC/NvMender2002/nv_algebra.cpp
@@ -691,7 +691,7 @@ mat4& perspective(mat4& M, const nv_scalar fovy, const nv_scalar aspect, const n
 
 const quat quat::Identity(0, 0, 0, 1);
 
-quat::quat(nv_scalar x_, nv_scalar y_, nv_scalar z_, nv_scalar w_) : x(x_), y(y_), z(z_), w(w_) {}
+quat::quat(nv_scalar xIn, nv_scalar yIn, nv_scalar zIn, nv_scalar wIn) : x(xIn), y(yIn), z(zIn), w(wIn) {}
 quat::quat(const quat& quat)
 {
     x = quat.x;

--- a/src/utils/xrLC/xrPhase_AdaptiveHT.cpp
+++ b/src/utils/xrLC/xrPhase_AdaptiveHT.cpp
@@ -143,7 +143,6 @@ public:
         for (u32 vit = _from; vit < _to; vit++)
         {
             base_color_c vC;
-            R_ASSERT(vit != u32(-1));
             vecVertex& verts = lc_global_data()->g_vertices();
             R_ASSERT(vit < verts.size());
             Vertex* V = verts[vit];

--- a/src/utils/xrLC/xrPhase_AdaptiveHT.cpp
+++ b/src/utils/xrLC/xrPhase_AdaptiveHT.cpp
@@ -145,7 +145,6 @@ public:
             base_color_c vC;
             R_ASSERT(vit != u32(-1));
             vecVertex& verts = lc_global_data()->g_vertices();
-            R_ASSERT(vit >= 0);
             R_ASSERT(vit < verts.size());
             Vertex* V = verts[vit];
 

--- a/src/utils/xrLCUtil/LevelCompilerLoggerWindow.cpp
+++ b/src/utils/xrLCUtil/LevelCompilerLoggerWindow.cpp
@@ -195,6 +195,7 @@ void LevelCompilerLoggerWindow::clLog(const char* format, ...)
     char buf[1024];
     va_start(args, format);
     vsprintf(buf, format, args);
+    va_end(args);
     csLog.Enter();
     Log(buf);
     csLog.Leave();

--- a/src/utils/xrLC_Light/base_lighting.cpp
+++ b/src/utils/xrLC_Light/base_lighting.cpp
@@ -7,16 +7,15 @@ void base_lighting::select(xr_vector<R_Light>& dest, xr_vector<R_Light>& src, Fv
     Fsphere Sphere;
     Sphere.set(P, R);
     dest.clear();
-    R_Light* L = &*src.begin();
-    for (; L != &*src.end(); L++)
+    for (auto &&L : src)
     {
-        if (L->type == LT_POINT)
+        if (L.type == LT_POINT)
         {
-            float dist = Sphere.P.distance_to(L->position);
-            if (dist > (Sphere.R + L->range))
+            float dist = Sphere.P.distance_to(L.position);
+            if (dist > (Sphere.R + L.range))
                 continue;
         }
-        dest.push_back(*L);
+        dest.push_back(L);
     }
 }
 void base_lighting::select(base_lighting& from, Fvector& P, float R)

--- a/src/utils/xrLC_Light/base_lighting.cpp
+++ b/src/utils/xrLC_Light/base_lighting.cpp
@@ -7,7 +7,7 @@ void base_lighting::select(xr_vector<R_Light>& dest, xr_vector<R_Light>& src, Fv
     Fsphere Sphere;
     Sphere.set(P, R);
     dest.clear();
-    for (auto &&L : src)
+    for (const R_Light& L : src)
     {
         if (L.type == LT_POINT)
         {

--- a/src/utils/xrLC_Light/base_lighting.cpp
+++ b/src/utils/xrLC_Light/base_lighting.cpp
@@ -15,7 +15,7 @@ void base_lighting::select(xr_vector<R_Light>& dest, xr_vector<R_Light>& src, Fv
             if (dist > (Sphere.R + L.range))
                 continue;
         }
-        dest.push_back(L);
+        dest.emplace_back(L);
     }
 }
 void base_lighting::select(base_lighting& from, Fvector& P, float R)

--- a/src/utils/xrLC_Light/net_exec_pool.cpp
+++ b/src/utils/xrLC_Light/net_exec_pool.cpp
@@ -18,8 +18,8 @@ LPCSTR make_time(string64& buf, float fsec)
     if (sec < 0)
         sec = 0;
     xr_sprintf(buf, "%2.0d:%2.0d:%2.0d", sec / 3600, (sec % 3600) / 60, sec % 60);
-    int len = int(xr_strlen(buf));
-    for (int i = 0; i < len; i++)
+    size_t len = xr_strlen(buf);
+    for (size_t i = 0; i < len; i++)
         if (buf[i] == ' ')
             buf[i] = '0';
     return buf;

--- a/src/utils/xrLC_Light/net_exec_pool.cpp
+++ b/src/utils/xrLC_Light/net_exec_pool.cpp
@@ -14,7 +14,7 @@ LPCSTR make_time(string64& buf, float fsec)
 {
     // char		buf[64];
 
-    u32 sec = iFloor(fsec);
+    int sec = iFloor(fsec);
     if (sec < 0)
         sec = 0;
     xr_sprintf(buf, "%2.0d:%2.0d:%2.0d", sec / 3600, (sec % 3600) / 60, sec % 60);

--- a/src/utils/xrLC_Light/xrFace.cpp
+++ b/src/utils/xrLC_Light/xrFace.cpp
@@ -245,6 +245,9 @@ void DataFace::AddChannel(Fvector2& p1, Fvector2& p2, Fvector2& p3)
 
 BOOL DataFace::hasImplicitLighting()
 {
+    if (nullptr == this)
+        return FALSE;
+
     if (!Shader().flags.bRendering)
         return FALSE;
     VERIFY(inlc_global_data());

--- a/src/utils/xrLC_Light/xrFace.cpp
+++ b/src/utils/xrLC_Light/xrFace.cpp
@@ -245,8 +245,6 @@ void DataFace::AddChannel(Fvector2& p1, Fvector2& p2, Fvector2& p3)
 
 BOOL DataFace::hasImplicitLighting()
 {
-    if (0 == this)
-        return FALSE;
     if (!Shader().flags.bRendering)
         return FALSE;
     VERIFY(inlc_global_data());

--- a/src/xrAICore/Components/problem_solver_inline.h
+++ b/src/xrAICore/Components/problem_solver_inline.h
@@ -84,7 +84,7 @@ IC void CProblemSolverAbstract::add_operator(const _operator_id_type& operator_i
     validate_properties(_op->effects());
 #endif
     m_actuality = false;
-    m_operators.insert(I, SOperator(operator_id, _op));
+    m_operators.emplace(I, operator_id, _op);
 }
 
 #ifdef DEBUG

--- a/src/xrAICore/Navigation/PathManagers/path_manager_generic_inline.h
+++ b/src/xrAICore/Navigation/PathManagers/path_manager_generic_inline.h
@@ -21,6 +21,7 @@ IC CGenericPathManager::CPathManagerGeneric()
     graph = 0;
     data_storage = 0;
     path = 0;
+    max_visited_node_count = 0;
 }
 
 TEMPLATE_SPECIALIZATION

--- a/src/xrAICore/Navigation/PathManagers/path_manager_generic_inline.h
+++ b/src/xrAICore/Navigation/PathManagers/path_manager_generic_inline.h
@@ -22,6 +22,7 @@ IC CGenericPathManager::CPathManagerGeneric()
     data_storage = 0;
     path = 0;
     max_visited_node_count = 0;
+    best_node_index = nullptr;
 }
 
 TEMPLATE_SPECIALIZATION

--- a/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
@@ -22,8 +22,10 @@
 CPatrolPoint::CPatrolPoint(const CPatrolPath* path)
 {
 #ifdef DEBUG
-    m_path = path;
+    m_level_vertex_id = 0;
+    m_game_vertex_id = 0;
     m_initialized = false;
+    m_path = path;
 #endif
 }
 

--- a/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
@@ -22,6 +22,7 @@
 CPatrolPoint::CPatrolPoint(const CPatrolPath* path)
 {
 #ifdef DEBUG
+    m_flags = 0;
     m_level_vertex_id = 0;
     m_game_vertex_id = 0;
     m_initialized = false;

--- a/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
@@ -20,14 +20,10 @@
 #endif
 
 CPatrolPoint::CPatrolPoint(const CPatrolPath* path)
-{
 #ifdef DEBUG
-    m_flags = 0;
-    m_level_vertex_id = 0;
-    m_game_vertex_id = 0;
-    m_initialized = false;
-    m_path = path;
+    : m_flags(0), m_level_vertex_id(0), m_game_vertex_id(0), m_initialized(false), m_path(path)
 #endif
+{
 }
 
 #ifdef DEBUG

--- a/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_point.cpp
@@ -20,8 +20,9 @@
 #endif
 
 CPatrolPoint::CPatrolPoint(const CPatrolPath* path)
+    : m_flags(0), m_level_vertex_id(u32(-1)), m_game_vertex_id(u32(-1))
 #ifdef DEBUG
-    : m_flags(0), m_level_vertex_id(0), m_game_vertex_id(0), m_initialized(false), m_path(path)
+    , m_initialized(false), m_path(path)
 #endif
 {
 }

--- a/src/xrAICore/Navigation/data_storage_bucket_list_inline.h
+++ b/src/xrAICore/Navigation/data_storage_bucket_list_inline.h
@@ -22,6 +22,7 @@ inline CBucketList::CDataStorage(const u32 vertex_count) : TManagerDataStorage(v
     m_min_bucket_value = typename TManagerDataStorage::Vertex::Distance(0);
     m_max_bucket_value = typename TManagerDataStorage::Vertex::Distance(1000);
     ZeroMemory(m_buckets, BucketCount * sizeof(typename TManagerDataStorage::Vertex*));
+    m_min_bucket_id = 0;
 }
 
 TEMPLATE_SPECIALIZATION

--- a/src/xrAICore/Navigation/graph_abstract_inline.h
+++ b/src/xrAICore/Navigation/graph_abstract_inline.h
@@ -25,7 +25,7 @@ TEMPLATE_SPECIALIZATION
 IC void CAbstractGraph::add_vertex(const _data_type& data, const _vertex_id_type& vertex_id)
 {
     VERIFY(!vertex(vertex_id));
-    m_vertices.insert(std::make_pair(vertex_id, xr_new<CVertex>(data, vertex_id, &m_edge_count)));
+    m_vertices.emplace(vertex_id, xr_new<CVertex>(data, vertex_id, &m_edge_count));
 }
 
 TEMPLATE_SPECIALIZATION

--- a/src/xrCore/Compression/Model.cpp
+++ b/src/xrCore/Compression/Model.cpp
@@ -630,6 +630,7 @@ NO_LOOP:
         return pc;
     ct.NumStats = 0;
     ct.SummFreq = 0;
+    ct.Stats = nullptr;
     ct.Flags = 0x10 * (sym >= 0x40);
     ct.oneState().Symbol = sym = *(BYTE*)UpBranch;
     ct.oneState().Successor = (PPM_CONTEXT*)(((BYTE*)UpBranch) + 1);

--- a/src/xrCore/Compression/Model.cpp
+++ b/src/xrCore/Compression/Model.cpp
@@ -629,6 +629,7 @@ NO_LOOP:
     if (pps == ps)
         return pc;
     ct.NumStats = 0;
+    ct.SummFreq = 0;
     ct.Flags = 0x10 * (sym >= 0x40);
     ct.oneState().Symbol = sym = *(BYTE*)UpBranch;
     ct.oneState().Successor = (PPM_CONTEXT*)(((BYTE*)UpBranch) + 1);

--- a/src/xrCore/FS.h
+++ b/src/xrCore/FS.h
@@ -371,14 +371,14 @@ public:
     IC void seek(size_t ptr)
     {
         Pos = ptr;
-        VERIFY((Pos <= Size) && (Pos >= 0));
+        VERIFY(Pos <= Size);
     }
     IC size_t length() const { return Size; }
     IC void* pointer() const { return &(data[Pos]); }
     IC void advance(size_t cnt)
     {
         Pos += cnt;
-        VERIFY((Pos <= Size) && (Pos >= 0));
+        VERIFY(Pos <= Size);
     }
 
 public:

--- a/src/xrCore/FS.h
+++ b/src/xrCore/FS.h
@@ -79,7 +79,7 @@ public:
     }
     IC void w_stringZ(const xr_string& p)
     {
-        w(p.c_str() ? p.c_str() : "", p.size());
+        w(p.c_str(), p.size());
         w_u8(0);
     }
     IC void w_fcolor(const Fcolor& v) { w(&v, sizeof(Fcolor)); }

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -612,7 +612,7 @@ void CLocatorAPI::ProcessOne(pcstr path, const _finddata_t& entry)
             return;
         if (0 == xr_strcmp(entry.name, ".."))
             return;
-        if(path[xr_strlen(path) - 1] != _DELIMITER && path[xr_strlen(path) - 1] != '/')
+        if (path[xr_strlen(path) - 1] != _DELIMITER && path[xr_strlen(path) - 1] != '/')
             xr_strcat(N, DELIMITER);
         Register(N, VFS_STANDARD_FILE, 0, 0, entry.size, entry.size, (u32)entry.time_write);
         Recurse(N);

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -612,7 +612,7 @@ void CLocatorAPI::ProcessOne(pcstr path, const _finddata_t& entry)
             return;
         if (0 == xr_strcmp(entry.name, ".."))
             return;
-        if(path[xr_strlen(path) - 1] != _DELIMITER || path[xr_strlen(path) - 1] != '/')
+        if(path[xr_strlen(path) - 1] != _DELIMITER && path[xr_strlen(path) - 1] != '/')
             xr_strcat(N, DELIMITER);
         Register(N, VFS_STANDARD_FILE, 0, 0, entry.size, entry.size, (u32)entry.time_write);
         Recurse(N);

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -772,7 +772,7 @@ bool CLocatorAPI::Recurse(pcstr path)
         rec_files.erase(rec_files.begin() + oldSize, rec_files.end());
     }
     // insert self
-    if (path && path[0] != 0)
+    if (path[0] != '\0')
         Register(path, VFS_STANDARD_FILE, 0, 0, 0, 0, 0);
 
     return true;

--- a/src/xrCore/LocatorAPI_defs.h
+++ b/src/xrCore/LocatorAPI_defs.h
@@ -65,7 +65,7 @@ struct XRCORE_API FS_File
     void set(const xr_string& nm, long sz, time_t modif, unsigned attr);
 
 public:
-    FS_File() {}
+    FS_File() : attrib(0), time_write(0), size(0) {}
     FS_File(const xr_string& nm);
     FS_File(const _FINDDATA_T& f);
     FS_File(const xr_string& nm, const _FINDDATA_T& f);

--- a/src/xrCore/XML/tinyxml.h
+++ b/src/xrCore/XML/tinyxml.h
@@ -328,7 +328,7 @@ protected:
         {
             // strncpy( _value, p, *length );	// lots of compilers don't like this function (unsafe),
             // and the null terminator isn't needed
-            for (int i = 0; p[i] && i < *length; ++i)
+            for (int i = 0; i < *length && p[i]; ++i)
             {
                 _value[i] = p[i];
             }

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -388,36 +388,37 @@ void xrDebug::GatherInfo(char* assertionInfo, size_t bufferSize, const ErrorLoca
         expr = "<no expression>";
     bool extendedDesc = desc && strchr(desc, '\n');
     pcstr prefix = "[error] ";
-    buffer += xr_sprintf(buffer, bufferSize, "\nFATAL ERROR\n\n");
-    buffer += xr_sprintf(buffer, bufferSize, "%sExpression    : %s\n", prefix, expr);
-    buffer += xr_sprintf(buffer, bufferSize, "%sFunction      : %s\n", prefix, loc.Function);
-    buffer += xr_sprintf(buffer, bufferSize, "%sFile          : %s\n", prefix, loc.File);
-    buffer += xr_sprintf(buffer, bufferSize, "%sLine          : %d\n", prefix, loc.Line);
+    const char* oneAboveBuffer = assertionInfo + bufferSize;
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "\nFATAL ERROR\n\n");
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sExpression    : %s\n", prefix, expr);
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sFunction      : %s\n", prefix, loc.Function);
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sFile          : %s\n", prefix, loc.File);
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sLine          : %d\n", prefix, loc.Line);
     if (extendedDesc)
     {
-        buffer += xr_sprintf(buffer, bufferSize, "\n%s\n", desc);
+        buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "\n%s\n", desc);
         if (arg1)
         {
-            buffer += xr_sprintf(buffer, bufferSize, "%s\n", arg1);
+            buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%s\n", arg1);
             if (arg2)
-                buffer += xr_sprintf(buffer, bufferSize, "%s\n", arg2);
+                buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%s\n", arg2);
         }
     }
     else
     {
-        buffer += xr_sprintf(buffer, bufferSize, "%sDescription   : %s\n", prefix, desc);
+        buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sDescription   : %s\n", prefix, desc);
         if (arg1)
         {
             if (arg2)
             {
-                buffer += xr_sprintf(buffer, bufferSize, "%sArgument 0    : %s\n", prefix, arg1);
-                buffer += xr_sprintf(buffer, bufferSize, "%sArgument 1    : %s\n", prefix, arg2);
+                buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sArgument 0    : %s\n", prefix, arg1);
+                buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sArgument 1    : %s\n", prefix, arg2);
             }
             else
-                buffer += xr_sprintf(buffer, bufferSize, "%sArguments     : %s\n", prefix, arg1);
+                buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%sArguments     : %s\n", prefix, arg1);
         }
     }
-    buffer += xr_sprintf(buffer, bufferSize, "\n");
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "\n");
     
     Log(assertionInfo);
     FlushLog();
@@ -429,7 +430,7 @@ void xrDebug::GatherInfo(char* assertionInfo, size_t bufferSize, const ErrorLoca
 #endif
     Log("stack trace:\n");
 #ifdef USE_OWN_ERROR_MESSAGE_WINDOW
-    buffer += xr_sprintf(buffer, bufferSize, "stack trace:\n\n");
+    buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "stack trace:\n\n");
 #endif // USE_OWN_ERROR_MESSAGE_WINDOW
 #if defined(XR_PLATFORM_WINDOWS)
     xr_vector<xr_string> stackTrace = BuildStackTrace();
@@ -437,7 +438,7 @@ void xrDebug::GatherInfo(char* assertionInfo, size_t bufferSize, const ErrorLoca
     {
         Log(stackTrace[i].c_str());
 #ifdef USE_OWN_ERROR_MESSAGE_WINDOW
-        buffer += xr_sprintf(buffer, bufferSize, "%s\n", stackTrace[i].c_str());
+        buffer += xr_sprintf(buffer, oneAboveBuffer - buffer, "%s\n", stackTrace[i].c_str());
 #endif // USE_OWN_ERROR_MESSAGE_WINDOW
     }
 #elif defined(XR_PLATFORM_LINUX)

--- a/src/xrCore/xrDebug.h
+++ b/src/xrCore/xrDebug.h
@@ -39,6 +39,8 @@ public:
         Function = function;
     }
 
+    ErrorLocation(const ErrorLocation& rhs) : ErrorLocation(rhs.File, rhs.Line, rhs.Function) { }
+
     ErrorLocation& operator=(const ErrorLocation& rhs)
     {
         File = rhs.File;

--- a/src/xrCore/xr_ini.cpp
+++ b/src/xrCore/xr_ini.cpp
@@ -832,7 +832,7 @@ u32 CInifile::r_color(pcstr S, pcstr L) const
 {
     pcstr C = r_string(S, L);
     u32 r = 0, g = 0, b = 0, a = 255;
-    sscanf(C, "%d,%d,%d,%d", &r, &g, &b, &a);
+    sscanf(C, "%u,%u,%u,%u", &r, &g, &b, &a);
     return color_rgba(r, g, b, a);
 }
 

--- a/src/xrCore/xr_shared.h
+++ b/src/xrCore/xr_shared.h
@@ -35,7 +35,7 @@ public:
             result = xr_new<T>();
             result->m_ref_cnt = 0;
             if (p(key, result))
-                container.insert(std::make_pair(key, result));
+                container.emplace(key, result);
             else
                 xr_delete(result);
         }

--- a/src/xrEngine/ObjectDump.cpp
+++ b/src/xrEngine/ObjectDump.cpp
@@ -73,19 +73,19 @@ ENGINE_API std::string dbg_object_props_dump_string(const IGameObject* obj)
         "net_ID :%d, bActiveCounter :%d, bEnabled :%s, bVisible :%s, bDestroy :%s, \n "
         "net_Local %s, net_Ready :%s, net_SV_Update :%s, crow :%s, bPreDestroy : %s \n "
         "dbg_update_cl: %d, dwFrame_UpdateCL: %d, dwFrame_AsCrow :%d, Device.dwFrame :%d, Device.dwTimeGlobal: %d \n";
-    auto enabled = get_string(bool(!!props.bEnabled)).c_str();
-    auto visible = get_string(bool(!!props.bVisible)).c_str();
-    auto destroy = get_string(bool(!!props.bDestroy)).c_str();
-    auto netLocal = get_string(bool(!!props.net_Local)).c_str();
-    auto netReady = get_string(bool(!!props.net_Ready)).c_str();
-    auto netSvUpdate = get_string(bool(!!props.net_SV_Update)).c_str();
-    auto crow = get_string(bool(!!props.crow)).c_str();
-    auto preDestroy = get_string(bool(!!props.bPreDestroy)).c_str();
+    auto enabled = get_string(bool(!!props.bEnabled));
+    auto visible = get_string(bool(!!props.bVisible));
+    auto destroy = get_string(bool(!!props.bDestroy));
+    auto netLocal = get_string(bool(!!props.net_Local));
+    auto netReady = get_string(bool(!!props.net_Ready));
+    auto netSvUpdate = get_string(bool(!!props.net_SV_Update));
+    auto crow = get_string(bool(!!props.crow));
+    auto preDestroy = get_string(bool(!!props.bPreDestroy));
     auto updateFrameDbg = obj->GetDbgUpdateFrame();
     auto updateFrame = obj->GetUpdateFrame();
     auto updateFrameCrow = obj->GetCrowUpdateFrame();
-    return make_string(format, props.net_ID, props.bActiveCounter, enabled, visible, destroy, netLocal, netReady,
-        netSvUpdate, crow, preDestroy, updateFrameDbg, updateFrame, updateFrameCrow, Device.dwFrame,
+    return make_string(format, props.net_ID, props.bActiveCounter, enabled.c_str(), visible.c_str(), destroy.c_str(), netLocal.c_str(), netReady.c_str(),
+        netSvUpdate.c_str(), crow.c_str(), preDestroy.c_str(), updateFrameDbg, updateFrame, updateFrameCrow, Device.dwFrame,
         Device.dwTimeGlobal);
 }
 ENGINE_API std::string dbg_object_full_dump_string(const IGameObject* obj)

--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -187,7 +187,8 @@ public:
     Fmatrix mInvFullTransform;
 
     CRenderDevice()
-        : fWidth_2(0), fHeight_2(0), mtProcessingAllowed(false),
+        : fWidth_2(0), fHeight_2(0),
+          mtProcessingAllowed(false), mt_bMustExit(false),
           m_editor_module(nullptr), m_editor_initialize(nullptr),
           m_editor_finalize(nullptr), m_editor(nullptr)
     {

--- a/src/xrEngine/xr_input.cpp
+++ b/src/xrEngine/xr_input.cpp
@@ -127,7 +127,7 @@ void CInput::DisplayDevicesList()
             size_t it = 0;
             for (auto& token : JoysticksToken)
             {
-                if (it <= ControllersToken.size())
+                if (it < ControllersToken.size())
                 {
                     if (token.id == ControllersToken[it].id)
                     {

--- a/src/xrGame/battleye_system.cpp
+++ b/src/xrGame/battleye_system.cpp
@@ -347,6 +347,7 @@ bool BattlEyeSystem::InitDLL(LPCSTR dll_name, string_path& out_file)
             return false;
         }
         fclose(ft);
+        return true;
     }
     fclose(ft);
     return true;

--- a/src/xrPhysics/PHActorCharacter.cpp
+++ b/src/xrPhysics/PHActorCharacter.cpp
@@ -296,7 +296,7 @@ static void BigVelSeparate(dContact* c, bool& do_collide)
 
 void CPHActorCharacter::InitContact(dContact* c, bool& do_collide, u16 material_idx_1, u16 material_idx_2)
 {
-    bool b1;
+    bool b1 = false;
     SFindPredicate fp(c, &b1);
     RESTRICTOR_I r = std::find_if(begin(m_restrictors), end(m_restrictors), fp);
     bool b_restrictor = (r != end(m_restrictors));

--- a/src/xrPhysics/PHElement.cpp
+++ b/src/xrPhysics/PHElement.cpp
@@ -1182,7 +1182,6 @@ void CPHElement::add_Mass(
     }
     case SBoneShape::stSphere:
     {
-        shape.sphere;
         dMassSetSphere(&m, 1.f, shape.sphere.R);
         dMassAdjust(&m, mass);
         dMassTranslate(

--- a/src/xrScriptEngine/BindingsDumper.cpp
+++ b/src/xrScriptEngine/BindingsDumper.cpp
@@ -156,7 +156,7 @@ void BindingsDumper::FormatMemberFunction(const SignatureFormatterParams& params
             stripReturnValue = true;
         }
         else
-            funcName = refFuncName.c_str();
+            funcName = refFuncName;
     }
     bool concat = !(options.IgnoreDerived || options.StripThis || stripReturnValue);
     int signLen = params.Function->format_signature(ls, funcName.c_str(), concat);

--- a/src/xrScriptEngine/script_lua_helper.cpp
+++ b/src/xrScriptEngine/script_lua_helper.cpp
@@ -11,6 +11,7 @@ lua_State* CDbgLuaHelper::L = nullptr;
 CDbgLuaHelper::CDbgLuaHelper(CScriptDebugger* d)
 {
     m_debugger = d;
+    m_pAr = nullptr;
     m_pThis = this;
 }
 

--- a/src/xrScriptEngine/script_process.cpp
+++ b/src/xrScriptEngine/script_process.cpp
@@ -14,10 +14,9 @@
 
 string4096 g_ca_stdout; // XXX: allocate dynamically for each CScriptEngine instance
 
-CScriptProcess::CScriptProcess(CScriptEngine* scriptEngine, shared_str name, shared_str scripts)
+CScriptProcess::CScriptProcess(CScriptEngine* scriptEngine, shared_str name, shared_str scripts) : m_name(name)
 {
     this->scriptEngine = scriptEngine;
-    m_name = name;
 #ifdef DEBUG
     Msg("* Initializing %s script process", *m_name);
 #endif

--- a/src/xrScriptEngine/script_process.cpp
+++ b/src/xrScriptEngine/script_process.cpp
@@ -91,5 +91,5 @@ void CScriptProcess::update()
 
 void CScriptProcess::add_script(LPCSTR script_name, bool do_string, bool reload)
 {
-    m_scripts_to_run.push_back(CScriptToRun(script_name, do_string, reload));
+    m_scripts_to_run.emplace_back(script_name, do_string, reload);
 }

--- a/src/xrSound/OpenALDeviceList.cpp
+++ b/src/xrSound/OpenALDeviceList.cpp
@@ -118,7 +118,7 @@ void ALDeviceList::Enumerate()
                     {
                         alcGetIntegerv(device, ALC_MAJOR_VERSION, sizeof(int), &major);
                         alcGetIntegerv(device, ALC_MINOR_VERSION, sizeof(int), &minor);
-                        m_devices.push_back(ALDeviceDesc(actualDeviceName, minor, major));
+                        m_devices.emplace_back(actualDeviceName, minor, major);
                         m_devices.back().props.eax = 0;
                         if (alIsExtensionPresent("EAX2.0"))
                             m_devices.back().props.eax = 2;

--- a/src/xrSound/Sound.h
+++ b/src/xrSound/Sound.h
@@ -233,7 +233,10 @@ public:
     u32 dwBytesTotal;
     float fTimeTotal;
 
-    ref_sound_data() noexcept : handle(0), feedback(0), s_type(st_Effect), g_type(0), g_object(0) {}
+    ref_sound_data() noexcept
+        : handle(0), feedback(0), s_type(st_Effect), g_type(0), g_object(0), dwBytesTotal(0), fTimeTotal(0)
+    {
+    }
 
     ref_sound_data(pcstr fName, esound_type sound_type, int game_type, bool replaceWithNoSound = true)
     {

--- a/src/xrSound/SoundRender_Emitter.cpp
+++ b/src/xrSound/SoundRender_Emitter.cpp
@@ -91,7 +91,7 @@ void CSoundRender_Emitter::Event_Propagade()
         return;
 
     // Inform objects
-    SoundRender->s_events.push_back(std::make_pair(owner_data, range));
+    SoundRender->s_events.emplace_back(owner_data, range);
 }
 
 void CSoundRender_Emitter::switch_to_2D()


### PR DESCRIPTION
Product page: https://www.viva64.com/en/pvs-studio/
How to use for free: https://www.viva64.com/en/b/0600/

* Initialize class members to safe defaults instead of garbage.
* Small performance improvements,
* Make macroses safe to use in expressions (operators priority).
* Fix some out of buffer reads.
* Do not access destroyed temporary variables.
and more...

Feel free to discuss/fix commits, XRay is hard.