### PR TITLE
xrRender: fixed OpenGL errors queue behavior (close #647)

### DIFF
--- a/src/Layers/xrRenderGL/glSH_Texture.cpp
+++ b/src/Layers/xrRenderGL/glSH_Texture.cpp
@@ -147,6 +147,9 @@ void CTexture::Preload()
 {
     m_bumpmap = RImplementation.Resources->m_textures_description.GetBumpName(cName);
     m_material = RImplementation.Resources->m_textures_description.GetMaterial(cName);
+
+    if (glGetError() != GL_NO_ERROR)
+	    Msg("Warning: can't preload texture %s", cName.c_str());
 }
 
 void CTexture::Load()


### PR DESCRIPTION
I've managed to reproduce the bug. When the green screen appears the following message is seen in log:

```bash
	intro_start intro_game
	Invalid video stream: 0x500
```

This leads to file `xrRenderGL/glSH_Texture.cpp`:

```cpp
            GLenum err = glGetError();
            if (err != GL_NO_ERROR)
            {
                Msg("Invalid video stream: 0x%x", err);
                xr_delete(pTheora);
                pSurface = 0;
            }
```

However the actual errors appears a few lines above:

```cpp
	Preload();
```

After this function call the OpenGL errors queue contains an `0x500` error. If we check what is happening in the end of this function:

```
	void CTexture::Preload()
	{
	    m_bumpmap = RImplementation.Resources->m_textures_description.GetBumpName(cName);
	    m_material = RImplementation.Resources->m_textures_description.GetMaterial(cName);

	    if (glGetError() != GL_NO_ERROR)
		    Msg("Warning: can't preload texture %s", cName.c_str());
	}
```

we will get

```bash
	Warning: can't preload texture water\water_flowing_nmap
```

So, I guess this texture is just broken.

This check actually fixes the bug because it clears the OpenGL errors queue and the following code could work correctly.