### PR TITLE
travis: use core_count=2 for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,11 @@ install:
   - ${CXX} --version
 
 before_script:
-  - export core_count=$(nproc || echo 4) && echo core_count = $core_count
+  - if [ $TRAVIS_CPU_ARCH == arm64 ]; then
+      export core_count=2 && echo core_count = $core_count;
+    else
+      export core_count=$(nproc || echo 4) && echo core_count = $core_count;
+    fi
   - git submodule deinit Externals/cryptopp
   - mkdir bin && cd bin
 


### PR DESCRIPTION
The `nproc` on travis arm64 report full amount of cores (32) of underlying host, however the actual amount available for build running within LXD container is min 2vCPU + possibly some additional cpu time.
source: https://travis-ci.community/t/nproc-reports-32-cores-on-arm64/5851

Using `-j32` leads to high load and killing processes `g++-8: fatal error: Killed signal terminated program cc1plus`
So, here is simple fix. 