### PR TITLE
Added use of Intrinsics on e2k (MCST Elbrus 2000)

### DIFF
--- a/src/Layers/xrRender/DetailManager.cpp
+++ b/src/Layers/xrRender/DetailManager.cpp
@@ -17,7 +17,7 @@
 #else
 #include "xrEngine/IGame_Persistent.h"
 #include "xrEngine/Environment.h"
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -5,7 +5,7 @@
 #include "tbb/blocked_range.h"
 
 #ifndef _EDITOR
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
@@ -348,7 +348,7 @@ IC void FillSprite_fpu(FVF::LIT*& pv, const Fvector& pos, const Fvector& dir, co
 //----------------------------------------------------
 Lock m_sprite_section;
 
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 IC void FillSprite(FVF::LIT*& pv, const Fvector& T, const Fvector& R, const Fvector& pos, const Fvector2& lt,
     const Fvector2& rb, float r1, float r2, u32 clr, float sina, float cosa)
 {
@@ -477,7 +477,7 @@ ICF void FillSprite(FVF::LIT*& pv, const Fvector& pos, const Fvector& dir, const
 }
 #else
 #error Specify your platform explicitly
-#endif // defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#endif // defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 
 extern ENGINE_API float psHUD_FOV;
 
@@ -490,7 +490,7 @@ struct PRS_PARAMS
     CParticleEffect* pPE;
 };
 
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 ICF void magnitude_sse(Fvector& vec, float& res) // XXX: move this to Fvector class
 {
     __m128 tv, tu;

--- a/src/utils/xrAI/xrAI.cpp
+++ b/src/utils/xrAI/xrAI.cpp
@@ -106,7 +106,7 @@ void execute(pstr cmd)
 
             R_ASSERT2(hFactory->IsLoaded(), "Factory DLL raised exception during loading or there is no factory DLL at all");
 
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
             pcstr create_entity_name = "create_entity";
             pcstr destroy_entity_name = "destroy_entity";
 #else

--- a/src/utils/xrLC/xrPhase_MergeLM_Surface.cpp
+++ b/src/utils/xrLC/xrPhase_MergeLM_Surface.cpp
@@ -3,7 +3,7 @@
 #include "xrPhase_MergeLM_Rect.h"
 #include "utils/xrLC_Light/xrdeflector.h"
 
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <intrin.h>
 #else
 #include <mmintrin.h>
@@ -74,7 +74,7 @@ bool Place_Perpixel(L_rect& R, lm_layer* D, BOOL bRotate)
             for (x = 0; x < s_x - 8; x += 8, P += 8, S += 8)
             {
                 // if ( (*P) && ( *S >= alpha_ref ) ) goto r_false;	// overlap
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
                 __m128i regS = _mm_set1_epi64x(*((__int64*)S));
                 __m128i regP = _mm_set1_epi64x(*((__int64*)P));
                 __m128i mm_max = _mm_max_epu8(regS, mm_alpha_ref);

--- a/src/xrCDB/ISpatial_q_ray.cpp
+++ b/src/xrCDB/ISpatial_q_ray.cpp
@@ -8,7 +8,7 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4995)
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"

--- a/src/xrCDB/xrCDB_ray.cpp
+++ b/src/xrCDB/xrCDB_ray.cpp
@@ -3,7 +3,7 @@
 #include "xrCore/_fbox.h"
 #pragma warning(push)
 #pragma warning(disable : 4995)
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"

--- a/src/xrCore/Math/MathUtil.cpp
+++ b/src/xrCore/Math/MathUtil.cpp
@@ -11,7 +11,7 @@
 #include "xrEngine/Render.h"
 #include "Layers/xrRender/light.h"
 #endif
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include "PLC_SSE.hpp"
 #endif
 #if defined(XR_PLATFORM_WINDOWS) && defined(XR_ARCHITECTURE_X86)
@@ -50,7 +50,7 @@ void Initialize()
     Skin2W = Skin2W_CPP;
     Skin3W = Skin3W_CPP;
     Skin4W = Skin4W_CPP;
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
     PLCCalc = PLCCalc_SSE;
 #else
     PLCCalc = PLCCalc_CPP;

--- a/src/xrCore/_math.cpp
+++ b/src/xrCore/_math.cpp
@@ -16,7 +16,7 @@
 #endif
 
 #elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <x86intrin.h> // __rdtsc
 #elif defined(XR_ARCHITECTURE_ARM)
 #include <sys/syscall.h>
@@ -254,7 +254,7 @@ XRCORE_API u64 GetCLK()
 
 #elif defined(XR_COMPILER_GCC)
 
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
     return __rdtsc();
 #elif defined(XR_ARCHITECTURE_ARM)
     long long result = 0;

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -389,19 +389,19 @@ void xrCore::_destroy()
 constexpr pcstr xrCore::GetBuildConfiguration()
 {
 #ifdef NDEBUG
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
     return "Rx64";
 #else
     return "Rx86";
 #endif
 #elif defined(MIXED)
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
     return "Mx64";
 #else
     return "Mx86";
 #endif
 #else
-#ifdef XR_ARCHITECTURE_X64
+#if defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
     return "Dx64";
 #else
     return "Dx86";

--- a/src/xrParticles/noise.cpp
+++ b/src/xrParticles/noise.cpp
@@ -3,7 +3,7 @@
 #include "noise.h"
 
 #ifndef _EDITOR
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"

--- a/src/xrParticles/particle_actions_collection.cpp
+++ b/src/xrParticles/particle_actions_collection.cpp
@@ -1619,7 +1619,7 @@ extern void noise3Init();
 
 #ifndef _EDITOR
 
-#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"


### PR DESCRIPTION
MCST e2k (Elbrus 2000) architecture has half native / half software support of most Intel/AMD SIMD
e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4