### PR TITLE
luajit.cmake: Clean up old buildvm_arch.h header

### DIFF
--- a/Externals/luajit.cmake
+++ b/Externals/luajit.cmake
@@ -17,6 +17,9 @@ set(NODOTABIVER 51)
 
 set(LUAJIT_DIR ${CMAKE_CURRENT_LIST_DIR}/LuaJIT/src CACHE PATH "Location of luajit sources")
 
+# delete the left over buildvm_arch.h file if we've built an old commit before
+file(REMOVE "${LUAJIT_DIR}/host/buildvm_arch.h")
+
 option(BUILD_STATIC_LIB "Build static lib" OFF)
 option(BUILD_DYNAMIC_LIB "Build dynamic lib" ON)
 


### PR DESCRIPTION
This header is now generated in the build directory. However if an old buildvm_arch.h header is still present in the source directory it will be preferred by the compiler over the newly generated header in the build directory.

Automatically deleting the old header fixes clones that have built commits with the old luajit.cmake