### PR TITLE
CDB Cache: setting time for archive files

### DIFF
--- a/src/xrCore/LocatorAPI.h
+++ b/src/xrCore/LocatorAPI.h
@@ -101,6 +101,7 @@ public:
         size_t size = 0;
         size_t vfs_idx = size_t(-1);
         shared_str path;
+        u32 modif = 0;
 #if defined(XR_PLATFORM_WINDOWS)
         void *hSrcFile = nullptr;
         void *hSrcMap = nullptr;


### PR DESCRIPTION
This fixes CDB cache has 0 in files timestamp, if the file is from archive.
Needs testing for windows.