### PR TITLE
CMake hacks for MCST e2k (Elbrus 2000) architecture

### DIFF
--- a/Externals/LuaJIT-proj/luajit.cmake
+++ b/Externals/LuaJIT-proj/luajit.cmake
@@ -309,14 +309,21 @@ target_link_libraries(minilua
 
 set(DASM_DASC ${LUAJIT_DIR}/vm_${DASM_ARCH}.dasc)
 set(DASM ${LUAJIT_DIR}/../dynasm/dynasm.lua)
-set(BUILDVM_ARCH "${CMAKE_CURRENT_BINARY_DIR}/buildvm_arch.h")
+
+if (PROJECT_PLATFORM_E2K)
+    set(BUILDVM_ARCH "${LUAJIT_DIR}/host/buildvm_arch.h")
+else()
+    set(BUILDVM_ARCH "${CMAKE_CURRENT_BINARY_DIR}/buildvm_arch.h")
+endif()
 
 # Generate buildvm arch header
-add_custom_target(buildvm_arch
-	COMMAND minilua ${DASM} ${DASM_FLAGS} -o ${BUILDVM_ARCH} ${DASM_DASC}
-	DEPENDS minilua
-	BYPRODUCTS ${BUILDVM_ARCH}
-)
+if (NOT PROJECT_PLATFORM_E2K)
+    add_custom_target(buildvm_arch
+        COMMAND minilua ${DASM} ${DASM_FLAGS} -o ${BUILDVM_ARCH} ${DASM_DASC}
+        DEPENDS minilua
+        BYPRODUCTS ${BUILDVM_ARCH}
+    )
+endif()
 
 # Buildvm
 set(BUILDVM_SRC
@@ -343,7 +350,9 @@ target_compile_options(buildvm
 	${HOST_ACFLAGS}
 )
 
-add_dependencies(buildvm buildvm_arch)
+if (NOT PROJECT_PLATFORM_E2K)
+    add_dependencies(buildvm buildvm_arch)
+endif()
 
 set(LJLIB_C
 	"${LUAJIT_DIR}/lib_base.c"

--- a/src/xrGame/CMakeLists.txt
+++ b/src/xrGame/CMakeLists.txt
@@ -2673,6 +2673,13 @@ target_compile_options(${PROJECT_NAME}
     -Wno-trigraphs
 )
 
+if ((CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo") AND PROJECT_PLATFORM_E2K) # E2K: hack for debug compile (MCST lcc compiler does not support a file > 4Gb, this is a bug in EDG frontend)
+    target_compile_options(${PROJECT_NAME} 
+        PRIVATE
+        -g0 
+    )
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
     PREFIX ""
 )


### PR DESCRIPTION
- luajit.cmake: added hack for MCST version of LuaJIT
- xrGame/CMakeLists: added hack for MCST lcc compiler