### PR TITLE
Fixed OOM at startup on E2K and ARM

### DIFF
--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -275,7 +275,7 @@ void TaskManager::WakeUpIfNeeded()
                 continue;
             if (worker->sleeps.load(std::memory_order_relaxed))
             {
-                worker->steal_from.store(steal_from);
+                worker->steal_from.store(steal_from, std::memory_order_relaxed);
                 worker->event.Set();
                 break;
             }

--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -275,9 +275,7 @@ void TaskManager::WakeUpIfNeeded()
                 continue;
             if (worker->sleeps.load(std::memory_order_relaxed))
             {
-                // Acquire semantic guarantees that event won't be set
-                // earlier than steal_from will be assigned
-                worker->steal_from.store(steal_from, std::memory_order_acquire);
+                worker->steal_from.store(steal_from);
                 worker->event.Set();
                 break;
             }

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -273,39 +273,39 @@ bool query_processor_info(processor_info* pinfo)
     xr_sprintf(pinfo->modelName, "%s (%s)", __builtin_cpu_name(), __builtin_cpu_arch());
     
 
-    #if (defined(__MMX__))
+    #if defined(__MMX__)
         pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
     #endif
 
-    #if (defined(__SSE__))
+    #if defined(__SSE__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE), true);
     #endif
 
-    #if (defined(__SSE2__))
+    #if defined(__SSE2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE2), true);
     #endif
 
-    #if (defined(__SSE3__))
+    #if defined(__SSE3__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE3), true);
     #endif
 
-    #if (defined(__SSSE3__))
+    #if defined(__SSSE3__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSSE3), true);
     #endif
 
-    #if (defined(__SSE4_1__))
+    #if defined(__SSE4_1__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE41), true);
     #endif
 
-    #if (defined(__SSE4_2__))
+    #if defined(__SSE4_2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE42), true);
     #endif
 
-    #if (defined(__AVX__))
+    #if defined(__AVX__)
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX), true);
     #endif
 
-    #if (defined(__AVX2__))
+    #if defined(__AVX2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX2), true);
     #endif
 

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -289,10 +289,12 @@ bool query_processor_info(processor_info* pinfo)
 }
 
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
-
+bool query_processor_info(processor_info* pinfo)
+{
     *pinfo = {};
     
     return true;
+}
 
 #endif
 

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -76,6 +76,72 @@ u32 countSetBits(ULONG_PTR bitMask)
 }
 #endif
 
+void fillInAvailableCpus(processor_info* pinfo)
+{
+    // Calculate available processors
+#ifdef XR_PLATFORM_WINDOWS
+    ULONG_PTR pa_mask_save, sa_mask_stub = 0;
+    GetProcessAffinityMask(GetCurrentProcess(), &pa_mask_save, &sa_mask_stub);
+#elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
+    u32 pa_mask_save = 0;
+    cpu_set_t my_set;
+    CPU_ZERO(&my_set);
+    pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &my_set);
+    pa_mask_save = CPU_COUNT(&my_set);
+#else
+#pragma TODO("No function to obtain process affinity")
+    u32 pa_mask_save = 0;
+#endif // XR_PLATFORM_WINDOWS
+
+    u32 processorCoreCount = 0;
+    u32 logicalProcessorCount = 0;
+
+#ifdef XR_PLATFORM_WINDOWS
+    DWORD returnedLength = 0;
+    GetLogicalProcessorInformation(nullptr, &returnedLength);
+
+    auto* buffer = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION*)xr_alloca(returnedLength);
+    GetLogicalProcessorInformation(buffer, &returnedLength);
+
+    u32 byteOffset = 0;
+    while (byteOffset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= returnedLength)
+    {
+        switch (buffer->Relationship)
+        {
+        case RelationProcessorCore:
+            processorCoreCount++;
+
+            // A hyperthreaded core supplies more than one logical processor.
+            logicalProcessorCount += countSetBits(buffer->ProcessorMask);
+            break;
+
+        default:
+            break;
+        }
+
+        byteOffset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+        buffer++;
+    }
+#elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
+    processorCoreCount = sysconf(_SC_NPROCESSORS_ONLN);
+    logicalProcessorCount = std::thread::hardware_concurrency();
+#else
+#pragma TODO("No function to obtain processor's core count")
+    logicalProcessorCount = std::thread::hardware_concurrency();
+    processorCoreCount = logicalProcessorCount;
+#endif
+
+    if (logicalProcessorCount != processorCoreCount)
+        pinfo->features.set(static_cast<u32>(CpuFeature::HyperThreading), true);
+
+    // All logical processors
+    pinfo->n_threads = logicalProcessorCount;
+    pinfo->affinity_mask = pa_mask_save;
+    pinfo->n_cores = processorCoreCount;
+}
+
+
+#if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64)
 bool query_processor_info(processor_info* pinfo)
 {
     ZeroMemory(pinfo, sizeof(processor_info));
@@ -193,67 +259,41 @@ bool query_processor_info(processor_info* pinfo)
     pinfo->model = (cpui[0] >> 4) & 0xf;
     pinfo->stepping = cpui[0] & 0xf;
 
-    // Calculate available processors
-#ifdef XR_PLATFORM_WINDOWS
-    ULONG_PTR pa_mask_save, sa_mask_stub = 0;
-    GetProcessAffinityMask(GetCurrentProcess(), &pa_mask_save, &sa_mask_stub);
-#elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
-    u32 pa_mask_save = 0;
-    cpu_set_t my_set;
-    CPU_ZERO(&my_set);
-    pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &my_set);
-    pa_mask_save = CPU_COUNT(&my_set);
-#else
-#pragma TODO("No function to obtain process affinity")
-    u32 pa_mask_save = 0;
-#endif // XR_PLATFORM_WINDOWS
-
-    u32 processorCoreCount = 0;
-    u32 logicalProcessorCount = 0;
-
-#ifdef XR_PLATFORM_WINDOWS
-    DWORD returnedLength = 0;
-    GetLogicalProcessorInformation(nullptr, &returnedLength);
-
-    auto* buffer = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION*)xr_alloca(returnedLength);
-    GetLogicalProcessorInformation(buffer, &returnedLength);
-
-    u32 byteOffset = 0;
-    while (byteOffset + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION) <= returnedLength)
-    {
-        switch (buffer->Relationship)
-        {
-            case RelationProcessorCore:
-                processorCoreCount++;
-
-                // A hyperthreaded core supplies more than one logical processor.
-                logicalProcessorCount += countSetBits(buffer->ProcessorMask);
-                break;
-
-            default:
-                break;
-        }
-
-        byteOffset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
-        buffer++;
-    }
-#elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
-    processorCoreCount = sysconf(_SC_NPROCESSORS_ONLN);
-    logicalProcessorCount = std::thread::hardware_concurrency();
-#else
-#pragma TODO("No function to obtain processor's core count")
-    logicalProcessorCount = std::thread::hardware_concurrency();
-    processorCoreCount = logicalProcessorCount;
-#endif
-
-    if (logicalProcessorCount != processorCoreCount)
-        pinfo->features.set(static_cast<u32>(CpuFeature::HyperThreading), true);
-
-    // All logical processors
-    pinfo->n_threads = logicalProcessorCount;
-    pinfo->affinity_mask = pa_mask_save;
-    pinfo->n_cores = processorCoreCount;
+    fillInAvailableCpus(pinfo);
 
     return pinfo->features.get() != 0;
 }
+
+#elif defined(XR_ARCHITECTURE_E2K)
+bool query_processor_info(processor_info* pinfo)
+{
+    *pinfo = {};
+
+    strcpy(pinfo->vendor, "MCST");
+    strcpy(pinfo->modelName, "Elbrus");
+    
+
+    pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSE), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSE2), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSE3), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSSE3), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSE41), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::SSE42), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::AVX), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::AVX2), true);
+
+    fillInAvailableCpus(pinfo);
+    
+    return true;
+}
+
+#elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
+
+    *pinfo = {};
+    
+    return true;
+
+#endif
+
 #endif

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -292,6 +292,8 @@ bool query_processor_info(processor_info* pinfo)
 bool query_processor_info(processor_info* pinfo)
 {
     *pinfo = {};
+
+    fillInAvailableCpus(pinfo);
     
     return true;
 }

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -273,41 +273,41 @@ bool query_processor_info(processor_info* pinfo)
     xr_sprintf(pinfo->modelName, "%s (%s)", __builtin_cpu_name(), __builtin_cpu_arch());
     
 
-    #if defined(__MMX__)
+#if defined(__MMX__)
         pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
-    #endif
+#endif
 
-    #if defined(__SSE__)
+#if defined(__SSE__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE), true);
-    #endif
+#endif
 
-    #if defined(__SSE2__)
+#if defined(__SSE2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE2), true);
-    #endif
+#endif
 
-    #if defined(__SSE3__)
+#if defined(__SSE3__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE3), true);
-    #endif
+#endif
 
-    #if defined(__SSSE3__)
+#if defined(__SSSE3__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSSE3), true);
-    #endif
+#endif
 
-    #if defined(__SSE4_1__)
+#if defined(__SSE4_1__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE41), true);
-    #endif
+#endif
 
-    #if defined(__SSE4_2__)
+#if defined(__SSE4_2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE42), true);
-    #endif
+#endif
 
-    #if defined(__AVX__)
+#if defined(__AVX__)
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX), true);
-    #endif
+#endif
 
-    #if defined(__AVX2__)
+#if defined(__AVX2__)
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX2), true);
-    #endif
+#endif
 
     fillInAvailableCpus(pinfo);
     

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -270,18 +270,44 @@ bool query_processor_info(processor_info* pinfo)
     *pinfo = {};
 
     strcpy(pinfo->vendor, "MCST");
-    strcpy(pinfo->modelName, "Elbrus");
+    xr_sprintf(pinfo->modelName, "%s (%s)", __builtin_cpu_name(), __builtin_cpu_arch());
     
 
-    pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
+    #if (defined(__MMX__))
+        pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
+    #endif
+
+    #if (defined(__SSE__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE), true);
+    #endif
+
+    #if (defined(__SSE2__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE2), true);
+    #endif
+
+    #if (defined(__SSE3__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE3), true);
+    #endif
+
+    #if (defined(__SSSE3__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSSE3), true);
+    #endif
+
+    #if (defined(__SSE4_1__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE41), true);
+    #endif
+
+    #if (defined(__SSE4_2__))
     pinfo->features.set(static_cast<u32>(CpuFeature::SSE42), true);
+    #endif
+
+    #if (defined(__AVX__))
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX), true);
+    #endif
+
+    #if (defined(__AVX2__))
     pinfo->features.set(static_cast<u32>(CpuFeature::AVX2), true);
+    #endif
 
     fillInAvailableCpus(pinfo);
     


### PR DESCRIPTION
Not filling `cpui` and leaving trash in it for ARM and E2K architectures was causing program to crash on startup inside `query_processor_info()`. The program was eating away all available memory and then crashing.
Since trying to determine CPU features x86-way on alternative architectures makes no sense, added separate implementations for them.

Also fixed incorrectly specified memory order for store operation. [Order must be one of std::memory_order_relaxed, std::memory_order_release or std::memory_order_seq_cst. Otherwise the behavior is undefined.](https://en.cppreference.com/w/cpp/atomic/atomic/store) This was causing Windows debug build to crash with failed assertion inside `std::atomic`.