### PR TITLE
Tiny improvements for e2k (MCST Elbrus 2000)

### DIFF
--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -271,10 +271,13 @@ bool query_processor_info(processor_info* pinfo)
 
     strcpy(pinfo->vendor, "MCST");
     xr_sprintf(pinfo->modelName, "%s (%s)", __builtin_cpu_name(), __builtin_cpu_arch());
-    
 
 #if defined(__MMX__)
-        pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
+    pinfo->features.set(static_cast<u32>(CpuFeature::MMX), true);
+#endif
+
+#if defined(__3dNOW__)
+    pinfo->features.set(static_cast<u32>(CpuFeature::_3DNow), true);
 #endif
 
 #if defined(__SSE__)
@@ -310,7 +313,7 @@ bool query_processor_info(processor_info* pinfo)
 #endif
 
     fillInAvailableCpus(pinfo);
-    
+
     return true;
 }
 
@@ -320,7 +323,7 @@ bool query_processor_info(processor_info* pinfo)
     *pinfo = {};
 
     fillInAvailableCpus(pinfo);
-    
+
     return true;
 }
 

--- a/src/xrGame/CMakeLists.txt
+++ b/src/xrGame/CMakeLists.txt
@@ -2678,6 +2678,7 @@ if ((CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebI
         PRIVATE
         -g0 
     )
+    message(STATUS "Build type is ${CMAKE_BUILD_TYPE}, so disable generation of debug info for xrGame module, because MCST lcc compiler does not support a file > 4 GB (this is a bug in EDG frontend).")
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES


### PR DESCRIPTION
- src/xrCore/xr_cpuid.cpp: added check of 3DNow for e2k
- src/xrGame/CMakeLists.txt: added additional message for debug case on e2k