### PR TITLE
fix: rename internal function '__cpuidex' to 'xr_cpuidex'

### DIFF
--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -52,7 +52,7 @@ void nativeCpuId(int regs[4], int i)
 #ifndef XR_PLATFORM_WINDOWS
 #include <thread>
 
-void __cpuidex(int regs[4], int i, int j)
+void xr_cpuidex(int regs[4], int i, int j)
 {
     nativeCpuId(regs, i);
 }
@@ -163,7 +163,7 @@ bool query_processor_info(processor_info* pinfo)
 
     for (int i = 0; i <= nIds; ++i)
     {
-        __cpuidex(cpui.data(), i, 0);
+        xr_cpuidex(cpui.data(), i, 0);
         data.push_back(cpui);
     }
 
@@ -195,7 +195,7 @@ bool query_processor_info(processor_info* pinfo)
 
     for (int i = 0x80000000; i <= nExIds_; ++i)
     {
-        __cpuidex(cpui.data(), i, 0);
+        xr_cpuidex(cpui.data(), i, 0);
         data.push_back(cpui);
     }
 

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -52,7 +52,7 @@ void nativeCpuId(int regs[4], int i)
 #ifndef XR_PLATFORM_WINDOWS
 #include <thread>
 
-void __cpuidex(int regs[4], int i, int j)
+void xr_cpuidex(int regs[4], int i, int j)
 {
     nativeCpuId(regs, i);
 }

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -163,7 +163,11 @@ bool query_processor_info(processor_info* pinfo)
 
     for (int i = 0; i <= nIds; ++i)
     {
+#ifdef XR_PLATFORM_WINDOWS
+        __cpuidex(cpui.data(), i, 0);
+#else
         xr_cpuidex(cpui.data(), i, 0);
+#endif
         data.push_back(cpui);
     }
 
@@ -195,7 +199,11 @@ bool query_processor_info(processor_info* pinfo)
 
     for (int i = 0x80000000; i <= nExIds_; ++i)
     {
+#ifdef XR_PLATFORM_WINDOWS
+        __cpuidex(cpui.data(), i, 0);
+#else
         xr_cpuidex(cpui.data(), i, 0);
+#endif
         data.push_back(cpui);
     }
 

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -52,11 +52,7 @@ void nativeCpuId(int regs[4], int i)
 #ifndef XR_PLATFORM_WINDOWS
 #include <thread>
 
-#ifdef XR_PLATFORM_WINDOWS
 void __cpuidex(int regs[4], int i, int j)
-#else
-void xr_cpuidex(int regs[4], int i, int j)
-#endif
 {
     nativeCpuId(regs, i);
 }

--- a/src/xrCore/xr_cpuid.cpp
+++ b/src/xrCore/xr_cpuid.cpp
@@ -52,7 +52,11 @@ void nativeCpuId(int regs[4], int i)
 #ifndef XR_PLATFORM_WINDOWS
 #include <thread>
 
+#ifdef XR_PLATFORM_WINDOWS
+void __cpuidex(int regs[4], int i, int j)
+#else
 void xr_cpuidex(int regs[4], int i, int j)
+#endif
 {
     nativeCpuId(regs, i);
 }


### PR DESCRIPTION
Close #810