### PR TITLE
Allow read a file paths with upper case symbols

### DIFF
--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -592,6 +592,35 @@ bool CLocatorAPI::load_all_unloaded_archives()
     return res;
 }
 
+IC bool pred_str_ff(const _finddata_t& x, const _finddata_t& y) { return xr_strcmp(x.name, y.name) < 0; }
+bool ignore_name(const char* _name)
+{
+    if (!strcmp(_name, "Thumbs.db"))
+        return true; // ignore windows hidden Thumbs.db
+    if (!strcmp(_name, ".svn"))
+        return true; // ignore ".svn" folders
+    if (!strcmp(_name, ".vs"))
+        return true; // ignore ".vs" folders
+    const size_t len = strlen(_name);
+#define ENDS_WITH(n) (len > sizeof(n) && !strcmp(_name + len - (sizeof(n) - 1), n))
+    if (ENDS_WITH("Thumbs.db"))
+        return true;
+    if (ENDS_WITH(".VC.db"))
+        return true;
+    if (ENDS_WITH(".VC.opendb"))
+        return true;
+    if (ENDS_WITH(".sln"))
+        return true;
+    if (ENDS_WITH(".pdb"))
+        return true;
+    if (ENDS_WITH(".ipdb"))
+        return true;
+    if (ENDS_WITH(".iobj"))
+        return true;
+#undef ENDS_WITH
+    return false;
+}
+
 void CLocatorAPI::ProcessOne(pcstr path, const _finddata_t& entry)
 {
     string_path N;
@@ -602,6 +631,11 @@ void CLocatorAPI::ProcessOne(pcstr path, const _finddata_t& entry)
     xr_strcpy(N, sizeof N, entry.name);
 #endif
     xr_fs_strlwr(N);
+
+    bool ignore = ignore_name(N);
+
+    if (ignore)
+        return;
 
     if (entry.attrib & _A_HIDDEN)
         return;
@@ -626,33 +660,6 @@ void CLocatorAPI::ProcessOne(pcstr path, const _finddata_t& entry)
         else
             Register(N, VFS_STANDARD_FILE, 0, 0, entry.size, entry.size, (u32)entry.time_write);
     }
-}
-
-IC bool pred_str_ff(const _finddata_t& x, const _finddata_t& y) { return xr_strcmp(x.name, y.name) < 0; }
-bool ignore_name(const char* _name)
-{
-    if (!strcmp(_name, "Thumbs.db"))
-        return true; // ignore windows hidden Thumbs.db
-    if (!strcmp(_name, ".svn"))
-        return true; // ignore ".svn" folders
-    if (!strcmp(_name, ".vs"))
-        return true; // ignore ".vs" folders
-    const size_t len = strlen(_name);
-#define ENDS_WITH(n) (len>sizeof(n) && !strcmp(_name+len-(sizeof(n)-1), n))
-    if (ENDS_WITH(".VC.db"))
-        return true;
-    if (ENDS_WITH(".VC.opendb"))
-        return true;
-    if (ENDS_WITH(".sln"))
-        return true;
-    if (ENDS_WITH(".pdb"))
-        return true;
-    if (ENDS_WITH(".ipdb"))
-        return true;
-    if (ENDS_WITH(".iobj"))
-        return true;
-#undef ENDS_WITH
-    return false;
 }
 
 // we need to check for file existance

--- a/src/xrCore/LocatorAPI_defs.cpp
+++ b/src/xrCore/LocatorAPI_defs.cpp
@@ -105,6 +105,17 @@ LPCSTR FS_Path::_update(string_path& dest, LPCSTR src) const
     R_ASSERT(src);
     string_path temp;
     xr_strcpy(temp, sizeof(temp), src);
+
+#ifdef XR_PLATFORM_LINUX
+    string_path fullPath;
+    strconcat(fullPath, m_Path, temp);
+    if (FS.exist(fullPath, FSType::External) || FS.exist(fullPath, FSType::Virtual))
+    {
+        xr_strcpy(dest, fullPath);
+        return dest;
+    }
+#endif
+
     xr_strlwr(temp);
     strconcat(sizeof(dest), dest, m_Path, temp);
     return xr_fs_strlwr(dest);

--- a/src/xrCore/xr_ini.cpp
+++ b/src/xrCore/xr_ini.cpp
@@ -451,13 +451,19 @@ void CInifile::Load(IReader* F, pcstr path, allow_include_func_t allow_include_f
             R_ASSERT(path && path[0]);
             if (_GetItem(str, 1, inc_name, '"'))
             {
-                xr_fs_nostrlwr(inc_name); // compensate removed xr_strlwr on path on Linux, etc
-
                 string_path fn;
                 strconcat(sizeof fn, fn, path, inc_name);
                 if (!allow_include_func || allow_include_func(fn))
                 {
                     IReader* I = FS.r_open(fn);
+#ifdef XR_PLATFORM_LINUX
+                    if (I == nullptr)
+                    {
+                        xr_fs_nostrlwr(inc_name);
+                        strconcat(fn, path, inc_name);
+                        I = FS.r_open(fn);
+                    }
+#endif
                     R_ASSERT3(I, "Can't find include file:", inc_name);
                     const xr_string inc_path = EFS_Utils::ExtractFilePath(fn);
                     Load(I, inc_path.c_str(), allow_include_func);


### PR DESCRIPTION
These changes allow the engine to read files containing uppercase characters.\
On Windows this shouldn't take effect