### PR TITLE
Optimize explosions

### DIFF
--- a/src/xrGame/Explosive.cpp
+++ b/src/xrGame/Explosive.cpp
@@ -563,16 +563,19 @@ void CExplosive::OnEvent(NET_Packet& P, u16 type)
     {
     case GE_GRENADE_EXPLODE:
     {
-        Fvector pos, normal;
-        u16 parent_id;
-        P.r_u16(parent_id);
-        P.r_vec3(pos);
-        P.r_vec3(normal);
+        if (!m_explosion_flags.test(flExploding))
+        {
+            Fvector pos, normal;
+            u16 parent_id;
+            P.r_u16(parent_id);
+            P.r_vec3(pos);
+            P.r_vec3(normal);
 
-        SetInitiator(parent_id);
-        ExplodeParams(pos, normal);
-        Explode();
-        m_fExplodeDuration = m_fExplodeDurationMax;
+            SetInitiator(parent_id);
+            ExplodeParams(pos, normal);
+            Explode();
+            m_fExplodeDuration = m_fExplodeDurationMax;
+        }
         break;
     }
     }


### PR DESCRIPTION
We don't need to restart explosion if multiple GE_GRENADE_EXPLODE events arrive.