### PR TITLE
command line options, started transition (#570)

### DIFF
--- a/src/xrCDB/xrCDB.cpp
+++ b/src/xrCDB/xrCDB.cpp
@@ -5,6 +5,7 @@
 
 #include "xrCDB.h"
 #include "xrCore/Threading/Lock.hpp"
+#include "xrCore/command_line_key.h"
 
 namespace Opcode
 {
@@ -13,6 +14,8 @@ namespace Opcode
 
 using namespace CDB;
 using namespace Opcode;
+
+static command_line_key<bool> mt_cdb("-mt_cdb", "mt_cdb", false);
 
 // Model building
 MODEL::MODEL() :
@@ -81,7 +84,7 @@ void MODEL::build(Fvector* V, int Vcnt, TRI* T, int Tcnt, build_callback* bc, vo
 #ifdef _EDITOR
     build_internal(V, Vcnt, T, Tcnt, bc, bcp);
 #else
-    if (!strstr(Core.Params, "-mt_cdb"))
+    if (!mt_cdb.OptionValue())
     {
         build_internal(V, Vcnt, T, Tcnt, bc, bcp);
         status = S_READY;

--- a/src/xrCDB/xrCDB.cpp
+++ b/src/xrCDB/xrCDB.cpp
@@ -5,7 +5,6 @@
 
 #include "xrCDB.h"
 #include "xrCore/Threading/Lock.hpp"
-#include "xrCore/command_line_key.h"
 
 namespace Opcode
 {

--- a/src/xrCDB/xrCDB.cpp
+++ b/src/xrCDB/xrCDB.cpp
@@ -14,7 +14,7 @@ namespace Opcode
 using namespace CDB;
 using namespace Opcode;
 
-static command_line_key<bool> mt_cdb("-mt_cdb", "mt_cdb", false);
+static command_line_key<bool> mt_cdb("mt_cdb", "mt_cdb", false);
 
 // Model building
 MODEL::MODEL() :

--- a/src/xrCDB/xr_area.cpp
+++ b/src/xrCDB/xr_area.cpp
@@ -4,7 +4,6 @@
 #include "xrEngine/xr_object.h"
 #include "Common/LevelStructure.hpp"
 #include "xrEngine/xr_collide_form.h"
-#include "xrCore/command_line_key.h"
 
 
 //----------------------------------------------------------------------

--- a/src/xrCDB/xr_area.cpp
+++ b/src/xrCDB/xr_area.cpp
@@ -4,6 +4,7 @@
 #include "xrEngine/xr_object.h"
 #include "Common/LevelStructure.hpp"
 #include "xrEngine/xr_collide_form.h"
+#include "xrCore/command_line_key.h"
 
 
 //----------------------------------------------------------------------
@@ -15,6 +16,8 @@ thread_local collide::rq_results CObjectSpaceData::r_temp;
 thread_local xr_vector<ISpatial*> CObjectSpaceData::r_spatial;
 
 using namespace collide;
+
+static command_line_key<bool> cdb_cache("-cdb_cache", "Cache CDB data", false);
 
 //----------------------------------------------------------------------
 // Class	: CObjectSpace
@@ -119,7 +122,7 @@ void CObjectSpace::Create(Fvector* verts, CDB::TRI* tris, const hdrCFORM& H, CDB
     bool bUseCache = !strstr(Core.Params, "-no_cdb_cache");
     strconcat(fName, "cdb_cache" DELIMITER, FS.get_path("$level$")->m_Add, "objspace.bin");
     FS.update_path(fName, "$app_data_root$", fName);
-    if (bUseCache && FS.exist(fName) && Static.deserialize(fName))
+    if (cdb_cache.OptionValue() && FS.exist(fName) && Static.deserialize(fName))
     {
 #ifndef MASTER_GOLD
         Msg("* Loaded ObjectSpace cache (%s)...", fName);
@@ -133,7 +136,7 @@ void CObjectSpace::Create(Fvector* verts, CDB::TRI* tris, const hdrCFORM& H, CDB
 #endif
         Static.build(verts, H.vertcount, tris, H.facecount, build_callback);
 
-        if (bUseCache)
+        if (cdb_cache.OptionValue())
             Static.serialize(fName);
     }
 

--- a/src/xrCDB/xr_area.cpp
+++ b/src/xrCDB/xr_area.cpp
@@ -16,7 +16,7 @@ thread_local xr_vector<ISpatial*> CObjectSpaceData::r_spatial;
 
 using namespace collide;
 
-static command_line_key<bool> cdb_cache("-cdb_cache", "Cache CDB data", false);
+static command_line_key<bool> cdb_cache("cdb_cache", "Cache CDB data", false);
 
 //----------------------------------------------------------------------
 // Class	: CObjectSpace

--- a/src/xrCore/CMakeLists.txt
+++ b/src/xrCore/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SRC_FILES
     "buffer_vector_inline.h"
     "cdecl_cast.hpp"
     "ChooseTypes.H"
+    "command_line_key.cpp"
+    "command_line_key.h"
     "client_id.h"
     "clsid.cpp"
     "clsid.h"

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -39,11 +39,12 @@ static constexpr pcstr FSLTX = "fs.ltx"
 static constexpr pcstr FSLTX = "fsgame.ltx";
 #endif
 
+XRCORE_API command_line_key<pcstr> fsltx_path("-fsltx", "path to game config ltx", "");
+
 static command_line_key<bool> auto_load_arch("-auto_load_arch", "auto_load_arch", false);
 static command_line_key<pcstr> overlaypath("-overlaypath", "overlaypath", "");
 static command_line_key<bool> nolog("-nolog", "nolog", false);
 
-extern command_line_key<pcstr> fsltx_path;
 extern command_line_key<bool> shoc_flag, soc_flag, cs_flag;
 
 

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -40,10 +40,10 @@ static constexpr pcstr FSLTX = "fsgame.ltx";
 #endif
 
 static command_line_key<bool> auto_load_arch("-auto_load_arch", "auto_load_arch", false);
-static command_line_key<pstr> overlaypath("-overlaypath", "overlaypath", "");
+static command_line_key<pcstr> overlaypath("-overlaypath", "overlaypath", "");
 static command_line_key<bool> nolog("-nolog", "nolog", false);
 
-extern command_line_key<pstr> fsltx_path;
+extern command_line_key<pcstr> fsltx_path;
 extern command_line_key<bool> shoc_flag, soc_flag, cs_flag;
 
 

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -38,11 +38,11 @@ static constexpr pcstr FSLTX = "fs.ltx"
 static constexpr pcstr FSLTX = "fsgame.ltx";
 #endif
 
-XRCORE_API command_line_key<pcstr> fsltx_path("-fsltx", "path to game config ltx", "");
+XRCORE_API command_line_key<pcstr> fsltx_path("fsltx", "path to game config ltx", "");
 
-static command_line_key<bool> auto_load_arch("-auto_load_arch", "auto_load_arch", false);
-static command_line_key<pcstr> overlaypath("-overlaypath", "overlaypath", "");
-static command_line_key<bool> nolog("-nolog", "nolog", false);
+static command_line_key<bool> auto_load_arch("auto_load_arch", "auto_load_arch", false);
+static command_line_key<pcstr> overlaypath("overlaypath", "overlaypath", "");
+static command_line_key<bool> nolog("nolog", "nolog", false);
 
 extern command_line_key<bool> shoc_flag, soc_flag, cs_flag;
 

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -19,7 +19,6 @@
 #include "file_stream_reader.h"
 #include "xrCore/Threading/Lock.hpp"
 #include "Crypto/trivial_encryptor.h"
-#include "command_line_key.h"
 
 #if defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_FREEBSD)
 #include "SDL.h"

--- a/src/xrCore/LocatorAPI_auth.cpp
+++ b/src/xrCore/LocatorAPI_auth.cpp
@@ -3,7 +3,6 @@
 #include "xrCore/Threading/Lock.hpp"
 
 #ifdef DEBUG
-#include "command_line_key.h"
 static command_line_key<bool> auth_debug("auth_debug", "auth_debug", false);
 static command_line_key<int> b_extern_auth("asdf", "b_extern_auth", 0);
 #endif

--- a/src/xrCore/LocatorAPI_auth.cpp
+++ b/src/xrCore/LocatorAPI_auth.cpp
@@ -3,6 +3,7 @@
 #include "xrCore/Threading/Lock.hpp"
 
 #ifdef DEBUG
+#include "command_line_key.h"
 static command_line_key<bool> auth_debug("auth_debug", "auth_debug", false);
 static command_line_key<int> b_extern_auth("asdf", "b_extern_auth", 0);
 #endif

--- a/src/xrCore/LocatorAPI_auth.cpp
+++ b/src/xrCore/LocatorAPI_auth.cpp
@@ -2,6 +2,12 @@
 #pragma hdrstop // huh?
 #include "xrCore/Threading/Lock.hpp"
 
+#ifdef DEBUG
+static command_line_key<bool> auth_debug("auth_debug", "auth_debug", false);
+static command_line_key<int> b_extern_auth("asdf", "b_extern_auth", 0);
+#endif
+
+
 struct auth_options
 {
     xr_vector<shared_str> ignore;
@@ -35,7 +41,7 @@ void CLocatorAPI::auth_runtime(void* params)
     m_auth_code = crc32(writer.pointer(), writer.size());
 
 #ifdef DEBUG
-    if (strstr(Core.Params, "auth_debug"))
+    if (auth_debug.OptionValue())
     {
         string_path tmp_path;
         update_path(tmp_path, "$app_data_root$", "auth_psettings.ltx");
@@ -48,8 +54,7 @@ void CLocatorAPI::auth_runtime(void* params)
     bool do_break = false;
 
 #ifdef DEBUG
-    bool b_extern_auth = !!strstr(Core.Params, "asdf");
-    if (!b_extern_auth)
+    if (!b_extern_auth.OptionValue())
 #endif // DEBUG
     {
         for (auto it = m_files.begin(); it != m_files.end(); ++it)
@@ -82,7 +87,7 @@ void CLocatorAPI::auth_runtime(void* params)
                     u32 crc = crc32(r->pointer(), r->length());
 
 #ifdef DEBUG
-                    if (strstr(Core.Params, "auth_debug"))
+                    if (auth_debug.OptionValue())
                         Msg("auth %s = 0x%08x", f.name, crc);
 #endif // DEBUG
 
@@ -101,9 +106,7 @@ void CLocatorAPI::auth_runtime(void* params)
 #ifdef DEBUG
     else
     {
-        string64 c_auth_code;
-        sscanf(strstr(Core.Params, "asdf ") + 5, "%[^ ] ", c_auth_code);
-        m_auth_code = atoll(c_auth_code);
+        m_auth_code = b_extern_auth.OptionValue();
     }
 #endif // DEBUG
     xr_delete(_o);

--- a/src/xrCore/Threading/ThreadUtil.cpp
+++ b/src/xrCore/Threading/ThreadUtil.cpp
@@ -75,7 +75,7 @@ u32 __stdcall ThreadEntry(void* params)
 
 bool SpawnThread(EntryFuncType entry, pcstr name, u32 stack, void* arglist)
 {
-    xrDebug::Initialize();
+    xrDebug::Initialize(Core.Params);
 
     SThreadStartupInfo* info = xr_new<SThreadStartupInfo>();
     info->threadName = name;
@@ -144,7 +144,7 @@ void* __cdecl ThreadEntry(void* params)
 
 bool SpawnThread(EntryFuncType entry, pcstr name, u32 stack, void* arglist)
 {
-    xrDebug::Initialize();
+    xrDebug::Initialize(Core.Params);
 
     SThreadStartupInfo* info = xr_new<SThreadStartupInfo>();
     info->threadName = name;

--- a/src/xrCore/Threading/ThreadUtil.cpp
+++ b/src/xrCore/Threading/ThreadUtil.cpp
@@ -75,7 +75,7 @@ u32 __stdcall ThreadEntry(void* params)
 
 bool SpawnThread(EntryFuncType entry, pcstr name, u32 stack, void* arglist)
 {
-    xrDebug::Initialize(Core.Params);
+    xrDebug::Initialize();
 
     SThreadStartupInfo* info = xr_new<SThreadStartupInfo>();
     info->threadName = name;
@@ -144,7 +144,7 @@ void* __cdecl ThreadEntry(void* params)
 
 bool SpawnThread(EntryFuncType entry, pcstr name, u32 stack, void* arglist)
 {
-    xrDebug::Initialize(Core.Params);
+    xrDebug::Initialize();
 
     SThreadStartupInfo* info = xr_new<SThreadStartupInfo>();
     info->threadName = name;

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -93,7 +93,7 @@ void command_line_key<T>::PrintHelp()
     while (current_node != nullptr)
     {
         pcstr isreq = current_node->required ? "(mandatory)" : "(optional)";
-        Msg("%-20s \t %-10s \t %-25s", current_node->option_name,
+        Msg("-%-20s \t %-10s \t %-25s", current_node->option_name,
             isreq, current_node->description);
         current_node = current_node->l_next;
     }
@@ -110,9 +110,7 @@ bool ParseCommandLine(int argc, char** argv)
             continue;
         }
 
-        pcstr current_arg = argv[n];
-        // this is for later
-        // pcstr current_arg = &argv[n][1];
+        pcstr current_arg = &argv[n][1];
 
         // is this a bool option?
         if (auto clkey = command_line_key<bool>::find_option(current_arg))

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -1,0 +1,216 @@
+#include "command_line_key.h"
+#include "xrMemory.h"
+#include "log.h"
+
+template<> command_line_key<bool> *command_line_key<bool>::l_head = nullptr;
+template<> command_line_key<int> *command_line_key<int>::l_head = nullptr;
+template<> command_line_key<pstr> *command_line_key<pstr>::l_head = nullptr;
+
+// command_line_key
+
+// when adding make sure it's beginning with a '-'
+template<typename T>
+command_line_key<T>::command_line_key(pcstr opname, pcstr desc, const T defval, bool req)
+    : provided(false), required(req)
+{
+    if(!IsOptionFlag(opname))
+    {
+        size_t opsz = xr_strlen(opname) + 1;
+        option_name = xr_alloc<char>(opsz);
+        option_name[0] = '-';
+        xr_strcpy(&option_name[1], opsz - 1, opname);
+    }
+    else
+    {
+        option_name = xr_strdup(opname);
+    }
+    description = xr_strdup(desc);
+    copy_argument(defval);
+
+    // add the option list node
+    l_next = l_head;
+    l_head = this;
+}
+
+
+template<typename T>
+void command_line_key<T>::copy_argument(T arg) {
+    argument = arg;
+}
+
+template<>
+void command_line_key<pstr>::copy_argument(pstr arg) {
+    argument = xr_strdup(arg);
+}
+
+template<typename T>
+void command_line_key<T>::free_argument() {
+    return;
+}
+
+template<>
+void command_line_key<pstr>::free_argument() {
+    xr_free(argument);
+}
+
+
+template<typename T>
+command_line_key<T> *command_line_key<T>::find_option(pcstr flag_name)
+{
+    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    while(current_node != nullptr)
+    {
+        if (!xr_strcmp(current_node->option_name, flag_name)) break;
+        current_node = current_node->l_next;
+    }
+    return current_node;
+}
+
+template<typename T>
+command_line_key<T>::~command_line_key()
+{
+    xr_free(option_name);
+    xr_free(description);
+    free_argument();
+
+    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    command_line_key<T> *prev_node = nullptr;
+    while(current_node != nullptr)
+    {
+        if (current_node == this) break;
+        prev_node = current_node;
+        current_node = current_node->l_next;
+    }
+
+    if(!current_node)
+        return;
+
+    if(prev_node)
+        prev_node->l_next = current_node->l_next;
+    else
+        command_line_key<T>::l_head = current_node->l_next;
+}
+
+template<typename T>
+bool command_line_key<T>::IsProvided() const
+{
+    return provided;
+}
+
+template<typename T>
+T command_line_key<T>::OptionValue() const
+{
+    return argument;
+}
+
+template<typename T>
+bool command_line_key<T>::CheckArguments()
+{
+    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    while(current_node != nullptr)
+    {
+        if(current_node->required && !current_node->provided)
+        {
+            Log("Error: Required option %s", current_node->option_name);
+            return false;
+        }
+        current_node = current_node->l_next;
+    }
+    return true;
+}
+
+template<>
+bool command_line_key<bool>::parse_option(pcstr option, pcstr arg)
+{
+    auto clkey = command_line_key<bool>::find_option(option);
+    if(!clkey) return false; // not found
+
+    clkey->argument = true;
+    clkey->provided = true;
+    return true;                // found and set
+}
+
+template<>
+bool command_line_key<int>::parse_option(pcstr option, pcstr arg)
+{
+    auto clkey = command_line_key<int>::find_option(option);
+    if(!clkey) return false; // not found
+
+    clkey->argument = std::stoi(arg); // may throw
+    clkey->provided = true;
+    return true;
+}
+
+template<>
+bool command_line_key<pstr>::parse_option(pcstr option, pcstr arg)
+{
+    auto clkey = command_line_key<pstr>::find_option(option);
+    if(!clkey) return false; // not found
+
+    clkey->argument = xr_strdup(arg);
+    clkey->provided = true;
+    return true;
+}
+
+template<typename T>
+void command_line_key<T>::PrintHelp() {
+    command_line_key<T> *current_node = command_line_key<T>::l_head;
+    while(current_node != nullptr)
+    {
+        pcstr isreq = current_node->required ? "(mandatory)" : "(optional)";
+        Msg("%-10s \t %-10s \t %-25s", current_node->option_name,
+            isreq, current_node->description);
+    }
+}
+
+bool ParseCommandLine(int argc, char **argv)
+{
+    // put these back into class methods?
+    for(int n = 1; n < argc; n++)
+    {
+        if(!IsOptionFlag(argv[n]))
+        {
+            Msg("Unknown option/argument <%s>", argv[n]);
+            continue;
+        }
+
+        // is this a bool option?
+        if(command_line_key<bool>::parse_option(argv[n], nullptr))
+        {
+            continue;
+        }
+        // the rest of the flags will require an argument
+        else if((n + 1 >= argc) || IsOptionFlag(argv[n + 1]))
+        {
+            Msg("Error: Missing argument for command line option <%s>", argv[n]);
+            return false;
+        }
+        else if(command_line_key<int>::parse_option(argv[n], argv[n + 1])
+                || command_line_key<pstr>::parse_option(argv[n], argv[n + 1]))
+        {
+            n++;
+            continue;
+        }
+
+        Msg("Unknown option <%s>", argv[n]);
+    }
+    return true;
+}
+
+
+bool CLCheckAllArguments()
+{
+    return (command_line_key<bool>::CheckArguments()
+            && command_line_key<int>::CheckArguments()
+            && command_line_key<pstr>::CheckArguments());
+}
+
+XRCORE_API void CLPrintAllHelp() {
+    command_line_key<bool>::PrintHelp();
+    command_line_key<int>::PrintHelp();
+    command_line_key<pstr>::PrintHelp();
+}
+
+template class XRCORE_API command_line_key<bool>;
+template class XRCORE_API command_line_key<int>;
+template class XRCORE_API command_line_key<pstr>;

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -160,8 +160,9 @@ void command_line_key<T>::PrintHelp() {
     while(current_node != nullptr)
     {
         pcstr isreq = current_node->required ? "(mandatory)" : "(optional)";
-        Msg("%-10s \t %-10s \t %-25s", current_node->option_name,
+        Msg("%-20s \t %-10s \t %-25s", current_node->option_name,
             isreq, current_node->description);
+        current_node = current_node->l_next;
     }
 }
 

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -11,11 +11,11 @@ template<> command_line_key<pcstr> *command_line_key<pcstr>::l_head = nullptr;
 // command_line_key
 
 // when adding make sure it's beginning with a '-'
-template<typename T>
+template < typename T >
 command_line_key<T>::command_line_key(pcstr opname, pcstr desc,T defval, bool req)
     : provided(false), required(req)
 {
-    if(!IsOptionFlag(opname))
+    if (!IsOptionFlag(opname))
     {
         size_t opsz = xr_strlen(opname) + 1;
         option_name = xr_alloc<char>(opsz);
@@ -71,9 +71,11 @@ template < typename T >
 command_line_key<T> *command_line_key<T>::find_option(pcstr flag_name)
 {
     auto current_node =  command_line_key<T>::l_head;
-    while(current_node != nullptr)
+    while (current_node != nullptr)
     {
-        if (!xr_strcmp(current_node->option_name, flag_name)) break;
+        if (!xr_strcmp(current_node->option_name, flag_name))
+            break;
+
         current_node = current_node->l_next;
     }
     return current_node;
@@ -86,43 +88,45 @@ command_line_key<T>::~command_line_key()
     xr_free(description);
     free_argument();
 
-    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    auto current_node =  command_line_key<T>::l_head;
     command_line_key<T> *prev_node = nullptr;
-    while(current_node != nullptr)
+    while (current_node != nullptr)
     {
-        if (current_node == this) break;
+	    if (current_node == this)
+            break;
+
         prev_node = current_node;
         current_node = current_node->l_next;
     }
 
-    if(!current_node)
+    if (!current_node)
         return;
 
-    if(prev_node)
+    if (prev_node)
         prev_node->l_next = current_node->l_next;
     else
         command_line_key<T>::l_head = current_node->l_next;
 }
 
-template<typename T>
+template < typename T >
 bool command_line_key<T>::IsProvided() const
 {
     return provided;
 }
 
-template<typename T>
+template < typename T >
 T command_line_key<T>::OptionValue() const
 {
     return argument;
 }
 
-template<typename T>
+template < typename T >
 bool command_line_key<T>::CheckArguments()
 {
     auto current_node =  command_line_key<T>::l_head;
-    while(current_node != nullptr)
+    while (current_node != nullptr)
     {
-        if(current_node->required && !current_node->provided)
+        if (current_node->required && !current_node->provided)
         {
             Log("Error: Required option %s", current_node->option_name);
             return false;
@@ -136,7 +140,9 @@ template<>
 bool command_line_key<bool>::parse_option(pcstr option, pcstr arg)
 {
     auto clkey = command_line_key<bool>::find_option(option);
-    if(!clkey) return false; // not found
+
+    if (!clkey)
+        return false; // not found
 
     clkey->argument = true;
     clkey->provided = true;
@@ -147,7 +153,9 @@ template<>
 bool command_line_key<int>::parse_option(pcstr option, pcstr arg)
 {
     auto clkey = command_line_key<int>::find_option(option);
-    if(!clkey) return false; // not found
+
+    if (!clkey)
+        return false; // not found
 
     clkey->argument = std::stoi(arg); // may throw
     clkey->provided = true;
@@ -158,18 +166,20 @@ template<>
 bool command_line_key<pcstr>::parse_option(pcstr option, pcstr arg)
 {
     auto clkey = command_line_key<pcstr>::find_option(option);
-    if(!clkey) return false; // not found
+
+    if (!clkey)
+        return false; // not found
 
     clkey->argument = xr_strdup(arg);
     clkey->provided = true;
     return true;
 }
 
-template<typename T>
+template < typename T >
 void command_line_key<T>::PrintHelp()
 {
     auto current_node = command_line_key<T>::l_head;
-    while(current_node != nullptr)
+    while (current_node != nullptr)
     {
         pcstr isreq = current_node->required ? "(mandatory)" : "(optional)";
         Msg("%-20s \t %-10s \t %-25s", current_node->option_name,
@@ -178,19 +188,19 @@ void command_line_key<T>::PrintHelp()
     }
 }
 
-bool ParseCommandLine(int argc, char **argv)
+bool ParseCommandLine(int argc, char** argv)
 {
     // put these back into class methods?
-    for(int n = 1; n < argc; n++)
+    for (int n = 1; n < argc; n++)
     {
-        if(!IsOptionFlag(argv[n]))
+        if (!IsOptionFlag(argv[n]))
         {
             Msg("Unknown option/argument <%s>", argv[n]);
             continue;
         }
 
         // is this a bool option?
-        if(auto clkey = command_line_key<bool>::find_option(argv[n]))
+        if (auto clkey = command_line_key<bool>::find_option(argv[n]))
         {
             clkey->set_argument(true);
             continue;
@@ -198,7 +208,7 @@ bool ParseCommandLine(int argc, char **argv)
         // is this an int argument?
         else if (auto clkey = command_line_key<int>::find_option(argv[n]))
         {
-            if((n + 1 >= argc) || IsOptionFlag(argv[n + 1]))
+            if ((n + 1 >= argc) || IsOptionFlag(argv[n + 1]))
             {
                 Msg("Error: Missing int argument for command line option <%s>", argv[n]);
                 return false;
@@ -209,7 +219,7 @@ bool ParseCommandLine(int argc, char **argv)
         // is this a string argument?
         else if (auto clkey = command_line_key<pcstr>::find_option(argv[n]))
         {
-            if((n + 1 >= argc) || IsOptionFlag(argv[n + 1]))
+            if ((n + 1 >= argc) || IsOptionFlag(argv[n + 1]))
             {
                 Msg("Error: Missing string argument for command line option <%s>", argv[n]);
                 return false;

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -1,3 +1,5 @@
+#include "stdafx.h"
+#pragma hdrstop
 #include "command_line_key.h"
 #include "xrMemory.h"
 #include "log.h"

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -4,13 +4,13 @@
 
 template<> command_line_key<bool> *command_line_key<bool>::l_head = nullptr;
 template<> command_line_key<int> *command_line_key<int>::l_head = nullptr;
-template<> command_line_key<pstr> *command_line_key<pstr>::l_head = nullptr;
+template<> command_line_key<pcstr> *command_line_key<pcstr>::l_head = nullptr;
 
 // command_line_key
 
 // when adding make sure it's beginning with a '-'
 template<typename T>
-command_line_key<T>::command_line_key(pcstr opname, pcstr desc, const T defval, bool req)
+command_line_key<T>::command_line_key(pcstr opname, pcstr desc,T defval, bool req)
     : provided(false), required(req)
 {
     if(!IsOptionFlag(opname))
@@ -39,7 +39,7 @@ void command_line_key<T>::copy_argument(T arg) {
 }
 
 template<>
-void command_line_key<pstr>::copy_argument(pstr arg) {
+void command_line_key<pcstr>::copy_argument(pcstr arg) {
     argument = xr_strdup(arg);
 }
 
@@ -49,7 +49,7 @@ void command_line_key<T>::free_argument() {
 }
 
 template<>
-void command_line_key<pstr>::free_argument() {
+void command_line_key<pcstr>::free_argument() {
     xr_free(argument);
 }
 
@@ -57,7 +57,7 @@ void command_line_key<pstr>::free_argument() {
 template<typename T>
 command_line_key<T> *command_line_key<T>::find_option(pcstr flag_name)
 {
-    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    auto current_node =  command_line_key<T>::l_head;
     while(current_node != nullptr)
     {
         if (!xr_strcmp(current_node->option_name, flag_name)) break;
@@ -106,7 +106,7 @@ T command_line_key<T>::OptionValue() const
 template<typename T>
 bool command_line_key<T>::CheckArguments()
 {
-    command_line_key<T> *current_node =  command_line_key<T>::l_head;
+    auto current_node =  command_line_key<T>::l_head;
     while(current_node != nullptr)
     {
         if(current_node->required && !current_node->provided)
@@ -142,9 +142,9 @@ bool command_line_key<int>::parse_option(pcstr option, pcstr arg)
 }
 
 template<>
-bool command_line_key<pstr>::parse_option(pcstr option, pcstr arg)
+bool command_line_key<pcstr>::parse_option(pcstr option, pcstr arg)
 {
-    auto clkey = command_line_key<pstr>::find_option(option);
+    auto clkey = command_line_key<pcstr>::find_option(option);
     if(!clkey) return false; // not found
 
     clkey->argument = xr_strdup(arg);
@@ -154,7 +154,7 @@ bool command_line_key<pstr>::parse_option(pcstr option, pcstr arg)
 
 template<typename T>
 void command_line_key<T>::PrintHelp() {
-    command_line_key<T> *current_node = command_line_key<T>::l_head;
+    auto current_node = command_line_key<T>::l_head;
     while(current_node != nullptr)
     {
         pcstr isreq = current_node->required ? "(mandatory)" : "(optional)";
@@ -186,7 +186,7 @@ bool ParseCommandLine(int argc, char **argv)
             return false;
         }
         else if(command_line_key<int>::parse_option(argv[n], argv[n + 1])
-                || command_line_key<pstr>::parse_option(argv[n], argv[n + 1]))
+                || command_line_key<pcstr>::parse_option(argv[n], argv[n + 1]))
         {
             n++;
             continue;
@@ -202,15 +202,15 @@ bool CLCheckAllArguments()
 {
     return (command_line_key<bool>::CheckArguments()
             && command_line_key<int>::CheckArguments()
-            && command_line_key<pstr>::CheckArguments());
+            && command_line_key<pcstr>::CheckArguments());
 }
 
 XRCORE_API void CLPrintAllHelp() {
     command_line_key<bool>::PrintHelp();
     command_line_key<int>::PrintHelp();
-    command_line_key<pstr>::PrintHelp();
+    command_line_key<pcstr>::PrintHelp();
 }
 
 template class XRCORE_API command_line_key<bool>;
 template class XRCORE_API command_line_key<int>;
-template class XRCORE_API command_line_key<pstr>;
+template class XRCORE_API command_line_key<pcstr>;

--- a/src/xrCore/command_line_key.cpp
+++ b/src/xrCore/command_line_key.cpp
@@ -46,14 +46,6 @@ void command_line_key<pcstr>::copy_argument(pcstr arg)
     argument = xr_strdup(arg);
 }
 
-template < typename T >
-void command_line_key<T>::set_argument(T arg)
-{
-    copy_argument(arg);
-    provided = true;
-}
-
-
 template< typename T >
 void command_line_key<T>::free_argument()
 {
@@ -202,7 +194,8 @@ bool ParseCommandLine(int argc, char** argv)
         // is this a bool option?
         if (auto clkey = command_line_key<bool>::find_option(argv[n]))
         {
-            clkey->set_argument(true);
+            clkey->copy_argument(true);
+            clkey->provided = true;
             continue;
         }
         // is this an int argument?
@@ -213,7 +206,8 @@ bool ParseCommandLine(int argc, char** argv)
                 Msg("Error: Missing int argument for command line option <%s>", argv[n]);
                 return false;
             }
-            clkey->set_argument( std::stoi(argv[++n]) );
+            clkey->copy_argument( std::stoi(argv[++n]) );
+            clkey->provided = true;
             continue;
         }
         // is this a string argument?
@@ -224,7 +218,8 @@ bool ParseCommandLine(int argc, char** argv)
                 Msg("Error: Missing string argument for command line option <%s>", argv[n]);
                 return false;
             }
-            clkey->set_argument(argv[++n]);
+            clkey->copy_argument(argv[++n]);
+            clkey->provided = true;
             continue;
         }
         Msg("Unknown option <%s>", argv[n]);

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -28,7 +28,6 @@ private:
     T argument;
 
     void copy_argument(T arg);
-    void set_argument(T arg);
     void free_argument();
     static command_line_key<T> *find_option(pcstr flag_name);
     static bool parse_option(pcstr option, pcstr arg);

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -3,9 +3,9 @@
 #include "xrCommon/xr_list.h"
 #include "_std_extensions.h"
 
-template<typename T> class XRCORE_API command_line_key;
+template < typename T > class XRCORE_API command_line_key;
 
-template<typename T>
+template < typename T >
 class XRCORE_API command_line_key
 {
 public:
@@ -16,7 +16,7 @@ public:
 
     static bool CheckArguments();
     static void PrintHelp();
-    friend XRCORE_API bool ParseCommandLine(int argc, char *argv[]);
+    friend XRCORE_API bool ParseCommandLine(int argc, char* argv[]);
 
 private:
     pstr option_name = nullptr;
@@ -40,6 +40,6 @@ inline static bool IsOptionFlag(pcstr buf)
     return (buf && buf[0] == '-');
 }
 
-XRCORE_API bool ParseCommandLine(int argc, char *argv[]);
+XRCORE_API bool ParseCommandLine(int argc, char* argv[]);
 XRCORE_API bool CLCheckAllArguments();
 XRCORE_API void CLPrintAllHelp();

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "xrCommon/xr_list.h"
+#include "_std_extensions.h"
+
+template<typename T> class XRCORE_API command_line_key;
+
+template<typename T>
+class XRCORE_API command_line_key
+{
+public:
+    command_line_key(pcstr flag_name, pcstr desc, const T defval, bool req = false);
+    ~command_line_key();
+    bool IsProvided() const;          // was the option provided in the CLI?
+    T OptionValue() const;            // value provided with the option
+
+    static bool CheckArguments();
+    static void PrintHelp();
+    friend bool ParseCommandLine(int argc, char *argv[]);
+
+private:
+    pstr option_name = nullptr;
+    pstr description = nullptr;
+    bool required;
+    bool provided = false;
+    command_line_key<T> *l_next;
+
+    T argument;
+
+    void copy_argument(T arg);
+    void free_argument();
+    static command_line_key<T> *find_option(pcstr flag_name);
+    static bool parse_option(pcstr option, pcstr arg);
+    static command_line_key<T> *l_head;
+};
+
+inline static bool IsOptionFlag(const char *buf)
+{
+    return (buf && buf[0] == '-');
+}
+
+XRCORE_API bool ParseCommandLine(int argc, char *argv[]);
+XRCORE_API bool CLCheckAllArguments();
+XRCORE_API void CLPrintAllHelp();

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -16,7 +16,7 @@ public:
 
     static bool CheckArguments();
     static void PrintHelp();
-    friend bool ParseCommandLine(int argc, char *argv[]);
+    friend XRCORE_API bool ParseCommandLine(int argc, char *argv[]);
 
 private:
     pstr option_name = nullptr;

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -3,7 +3,10 @@
 #include "xrCommon/xr_list.h"
 #include "_std_extensions.h"
 
-template < typename T > class XRCORE_API command_line_key;
+// This requires the keys be initialized as global variables
+// flag name, option name, description must be static strings
+// the flag name must be provided without a '-', it is
+// implied when parsing the command line
 
 template < typename T >
 class XRCORE_API command_line_key
@@ -19,18 +22,15 @@ public:
     friend XRCORE_API bool ParseCommandLine(int argc, char* argv[]);
 
 private:
-    pstr option_name = nullptr;
-    pstr description = nullptr;
+    pcstr option_name = nullptr;
+    pcstr description = nullptr;
     bool required;
     bool provided = false;
     command_line_key<T> *l_next;
 
     T argument;
 
-    void copy_argument(T arg);
-    void free_argument();
     static command_line_key<T> *find_option(pcstr flag_name);
-    static bool parse_option(pcstr option, pcstr arg);
     static command_line_key<T> *l_head;
 };
 

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -34,7 +34,7 @@ private:
     static command_line_key<T> *l_head;
 };
 
-inline static bool IsOptionFlag(const char *buf)
+inline static bool IsOptionFlag(pcstr buf)
 {
     return (buf && buf[0] == '-');
 }

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -28,6 +28,7 @@ private:
     T argument;
 
     void copy_argument(T arg);
+    void set_argument(T arg);
     void free_argument();
     static command_line_key<T> *find_option(pcstr flag_name);
     static bool parse_option(pcstr option, pcstr arg);

--- a/src/xrCore/command_line_key.h
+++ b/src/xrCore/command_line_key.h
@@ -9,7 +9,7 @@ template<typename T>
 class XRCORE_API command_line_key
 {
 public:
-    command_line_key(pcstr flag_name, pcstr desc, const T defval, bool req = false);
+    command_line_key(pcstr flag_name, pcstr desc,T defval, bool req = false);
     ~command_line_key();
     bool IsProvided() const;          // was the option provided in the CLI?
     T OptionValue() const;            // value provided with the option

--- a/src/xrCore/log.cpp
+++ b/src/xrCore/log.cpp
@@ -5,6 +5,7 @@
 #include "resource.h"
 #include "log.h"
 #include "xrCore/Threading/Lock.hpp"
+#include "command_line_key.h"
 
 BOOL LogExecCB = TRUE;
 string_path logFName = "engine.log";
@@ -21,6 +22,8 @@ LogCallback LogCB = 0;
 bool ForceFlushLog = false;
 IWriter* LogWriter = nullptr;
 //size_t CachedLog = 0;
+
+static command_line_key<bool> force_flushlog("-force_flushlog", "force_flushlog", false);
 
 void FlushLog()
 {
@@ -246,7 +249,7 @@ void CreateLog(BOOL nl)
         LogWriter->flush();
     }
 
-    if (strstr(Core.Params, "-force_flushlog"))
+    if (force_flushlog.OptionValue())
         ForceFlushLog = true;
 }
 

--- a/src/xrCore/log.cpp
+++ b/src/xrCore/log.cpp
@@ -22,7 +22,7 @@ bool ForceFlushLog = false;
 IWriter* LogWriter = nullptr;
 //size_t CachedLog = 0;
 
-static command_line_key<bool> force_flushlog("-force_flushlog", "force_flushlog", false);
+static command_line_key<bool> force_flushlog("force_flushlog", "force_flushlog", false);
 
 void FlushLog()
 {

--- a/src/xrCore/log.cpp
+++ b/src/xrCore/log.cpp
@@ -5,7 +5,6 @@
 #include "resource.h"
 #include "log.h"
 #include "xrCore/Threading/Lock.hpp"
-#include "command_line_key.h"
 
 BOOL LogExecCB = TRUE;
 string_path logFName = "engine.log";

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -30,7 +30,7 @@ extern compression::ppmd::stream* trained_model;
 
 XRCORE_API xrCore Core;
 
-XRCORE_API command_line_key<pstr> fsltx_path("-fsltx", "path to game config ltx", "");
+XRCORE_API command_line_key<pcstr> fsltx_path("-fsltx", "path to game config ltx", "");
 XRCORE_API command_line_key<bool> shoc_flag("-shoc", "Shadow of Chernobyl Mode", false);
 XRCORE_API command_line_key<bool> soc_flag("-soc", "Shadow of Chernobyl Mode", false);
 XRCORE_API command_line_key<bool> cs_flag("-cs", "Clear Sky Mode", false);
@@ -40,7 +40,7 @@ static command_line_key<bool> build_flag("-build", "build", false);
 static command_line_key<bool> ebuild_flag("-ebuild", "ebuild", false);
 static command_line_key<bool> cache_flag("-cache", "cache files", false);
 static command_line_key<bool> file_activity("-file_activity", "dump file activity", false);
-static command_line_key<pstr> wdir_path("-wf", "work directory", "");
+static command_line_key<pcstr> wdir_path("-wf", "work directory", "");
 
 static u32 init_counter = 0;
 

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -31,16 +31,16 @@ XRCORE_API xrCore Core;
 
 extern command_line_key<pcstr> fsltx_path;
 
-XRCORE_API command_line_key<bool> shoc_flag("-shoc", "Shadow of Chernobyl Mode", false);
-XRCORE_API command_line_key<bool> soc_flag("-soc", "Shadow of Chernobyl Mode", false);
-XRCORE_API command_line_key<bool> cs_flag("-cs", "Clear Sky Mode", false);
-XRCORE_API command_line_key<bool> cop_flag("-cop", "Call of Pripyat Mode", false);
+XRCORE_API command_line_key<bool> shoc_flag("shoc", "Shadow of Chernobyl Mode", false);
+XRCORE_API command_line_key<bool> soc_flag("soc", "Shadow of Chernobyl Mode", false);
+XRCORE_API command_line_key<bool> cs_flag("cs", "Clear Sky Mode", false);
+XRCORE_API command_line_key<bool> cop_flag("cop", "Call of Pripyat Mode", false);
 
-static command_line_key<bool> build_flag("-build", "build", false);
-static command_line_key<bool> ebuild_flag("-ebuild", "ebuild", false);
-static command_line_key<bool> cache_flag("-cache", "cache files", false);
-static command_line_key<bool> file_activity("-file_activity", "dump file activity", false);
-static command_line_key<pcstr> wdir_path("-wf", "work directory", "");
+static command_line_key<bool> build_flag("build", "build", false);
+static command_line_key<bool> ebuild_flag("ebuild", "ebuild", false);
+static command_line_key<bool> cache_flag("cache", "cache files", false);
+static command_line_key<bool> file_activity("file_activity", "dump file activity", false);
+static command_line_key<pcstr> wdir_path("wf", "work directory", "");
 
 static u32 init_counter = 0;
 

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -17,7 +17,6 @@
 #include "Math/MathUtil.hpp"
 #include "xrCore/_std_extensions.h"
 #include "Threading/TaskManager.hpp"
-#include "command_line_key.h"
 
 #include "SDL.h"
 

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -30,7 +30,8 @@ extern compression::ppmd::stream* trained_model;
 
 XRCORE_API xrCore Core;
 
-XRCORE_API command_line_key<pcstr> fsltx_path("-fsltx", "path to game config ltx", "");
+extern command_line_key<pcstr> fsltx_path;
+
 XRCORE_API command_line_key<bool> shoc_flag("-shoc", "Shadow of Chernobyl Mode", false);
 XRCORE_API command_line_key<bool> soc_flag("-soc", "Shadow of Chernobyl Mode", false);
 XRCORE_API command_line_key<bool> cs_flag("-cs", "Clear Sky Mode", false);

--- a/src/xrCore/xrCore.h
+++ b/src/xrCore/xrCore.h
@@ -54,6 +54,7 @@
 #include "xr_shared.h"
 #include "string_concatenations.h"
 #include "_flags.h"
+#include "command_line_key.h"
 
 // stl ext
 struct XRCORE_API xr_rtoken

--- a/src/xrCore/xrCore.vcxproj
+++ b/src/xrCore/xrCore.vcxproj
@@ -46,6 +46,7 @@ call .GitInfo.cmd</Command>
     <ClCompile Include="Animation\Motion.cpp" />
     <ClCompile Include="Animation\SkeletonMotions.cpp" />
     <ClCompile Include="clsid.cpp" />
+    <ClCompile Include="command_line_key.cpp" />
     <ClCompile Include="Compression\lzo_compressor.cpp" />
     <ClCompile Include="Compression\Model.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -141,6 +142,7 @@ call .GitInfo.cmd</Command>
     <ClInclude Include="buffer_vector_inline.h" />
     <ClInclude Include="cdecl_cast.hpp" />
     <ClInclude Include="clsid.h" />
+    <ClInclude Include="command_line_key.h" />
     <ClInclude Include="Compression\Coder.hpp" />
     <ClInclude Include="Compression\compression_ppmd_stream.h" />
     <ClInclude Include="Compression\compression_ppmd_stream_inline.h" />

--- a/src/xrCore/xrCore.vcxproj.filters
+++ b/src/xrCore/xrCore.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Kernel">
@@ -348,6 +348,7 @@
     <ClCompile Include="Media\ImageJPEG.cpp">
       <Filter>Media</Filter>
     </ClCompile>
+    <ClCompile Include="command_line_key.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FTimer.h">
@@ -758,6 +759,7 @@
     <ClInclude Include="Threading\ParallelForEach.hpp">
       <Filter>Threading</Filter>
     </ClInclude>
+    <ClInclude Include="command_line_key.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="xrCore.rc">

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -7,6 +7,7 @@
 #include "xrDebug.h"
 #include "os_clipboard.h"
 #include "log.h"
+#include "command_line_key.h"
 #if defined(XR_PLATFORM_WINDOWS)
 #include "Debug/dxerr.h"
 #endif
@@ -63,6 +64,9 @@ static BOOL bException = FALSE;
 #       error CPU architecture is not supported.
 #   endif
 #endif // XR_PLATFORM_WINDOWS
+
+static command_line_key<bool> show_error_window("-show_error_window",
+                                        "show error window", false);
 
 constexpr SDL_MessageBoxButtonData buttons[] =
 {
@@ -919,7 +923,7 @@ void xrDebug::OnThreadSpawn()
 #endif
 }
 
-void xrDebug::Initialize(pcstr commandLine)
+void xrDebug::Initialize()
 {
     *BugReportFile = 0;
     OnThreadSpawn();
@@ -932,6 +936,6 @@ void xrDebug::Initialize(pcstr commandLine)
 #ifdef DEBUG
     ShowErrorMessage = true;
 #else
-    ShowErrorMessage = commandLine ? !!strstr(commandLine, "-show_error_window") : false;
+    ShowErrorMessage = show_error_window.OptionValue();
 #endif
 }

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -7,7 +7,6 @@
 #include "xrDebug.h"
 #include "os_clipboard.h"
 #include "log.h"
-#include "command_line_key.h"
 #if defined(XR_PLATFORM_WINDOWS)
 #include "Debug/dxerr.h"
 #endif

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -923,7 +923,7 @@ void xrDebug::OnThreadSpawn()
 #endif
 }
 
-void xrDebug::Initialize()
+void xrDebug::Initialize(pcstr commandLine)
 {
     *BugReportFile = 0;
     OnThreadSpawn();
@@ -936,6 +936,6 @@ void xrDebug::Initialize()
 #ifdef DEBUG
     ShowErrorMessage = true;
 #else
-    ShowErrorMessage = show_error_window.OptionValue();
+    ShowErrorMessage = commandLine ? !!strstr(commandLine, "-show_error_window") : false;
 #endif
 }

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -64,7 +64,7 @@ static BOOL bException = FALSE;
 #   endif
 #endif // XR_PLATFORM_WINDOWS
 
-static command_line_key<bool> show_error_window("-show_error_window",
+static command_line_key<bool> show_error_window("show_error_window",
                                         "show error window", false);
 
 constexpr SDL_MessageBoxButtonData buttons[] =

--- a/src/xrCore/xrDebug.h
+++ b/src/xrCore/xrDebug.h
@@ -82,7 +82,7 @@ private:
 
 public:
     xrDebug() = delete;
-    static void Initialize();
+    static void Initialize(pcstr commandLine);
     static void Destroy();
     static void OnThreadSpawn();
     static void OnFilesystemInitialized();

--- a/src/xrCore/xrDebug.h
+++ b/src/xrCore/xrDebug.h
@@ -82,7 +82,7 @@ private:
 
 public:
     xrDebug() = delete;
-    static void Initialize(pcstr commandLine);
+    static void Initialize();
     static void Destroy();
     static void OnThreadSpawn();
     static void OnFilesystemInitialized();

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -9,7 +9,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
-#include "command_line_key.h"
 
 // On other platforms these options are controlled by CMake
 #if defined(XR_PLATFORM_WINDOWS)

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -4,12 +4,12 @@
 
 #if defined(XR_PLATFORM_WINDOWS)
 #include <Psapi.h>
-#include "command_line_key.h"
 #elif defined(XR_PLATFORM_LINUX)
 #include <sys/sysinfo.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
+#include "command_line_key.h"
 
 // On other platforms these options are controlled by CMake
 #if defined(XR_PLATFORM_WINDOWS)

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -4,6 +4,7 @@
 
 #if defined(XR_PLATFORM_WINDOWS)
 #include <Psapi.h>
+#include "command_line_key.h"
 #elif defined(XR_PLATFORM_LINUX)
 #include <sys/sysinfo.h>
 #include <sys/time.h>

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -47,6 +47,11 @@ constexpr size_t xr_reserved_tail = 0;
 
 constexpr size_t DEFAULT_ALIGNMENT = 16;
 
+#if defined(XR_PLATFORM_WINDOWS)
+static command_line_key<bool> swap_on_compact("-swap_on_compact", "swap_on_compact", false);
+#endif
+
+
 xrMemory Memory;
 // Also used in src\xrCore\xrDebug.cpp to prevent use of g_pStringContainer before it initialized
 bool shared_str_initialized = false;
@@ -139,7 +144,7 @@ void xrMemory::mem_compact()
         g_pSharedMemoryContainer->clean();
 
 #if defined(XR_PLATFORM_WINDOWS)
-    if (strstr(Core.Params, "-swap_on_compact"))
+    if (swap_on_compact.OptionValue())
         SetProcessWorkingSetSize(GetCurrentProcess(), size_t(-1), size_t(-1));
 #endif
 }

--- a/src/xrCore/xrMemory.cpp
+++ b/src/xrCore/xrMemory.cpp
@@ -48,7 +48,7 @@ constexpr size_t xr_reserved_tail = 0;
 constexpr size_t DEFAULT_ALIGNMENT = 16;
 
 #if defined(XR_PLATFORM_WINDOWS)
-static command_line_key<bool> swap_on_compact("-swap_on_compact", "swap_on_compact", false);
+static command_line_key<bool> swap_on_compact("swap_on_compact", "swap_on_compact", false);
 #endif
 
 

--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -7,6 +7,9 @@
 #include "GameFont.h"
 #include "PerformanceAlert.hpp"
 #include "xrCore/ModuleLookup.hpp"
+#include "xrCore/command_line_key.h"
+
+static command_line_key<bool> weather("-weather", "initialize weather editor", 0);
 
 SDL_HitTestResult WindowHitTest(SDL_Window* win, const SDL_Point* area, void* data);
 
@@ -38,7 +41,7 @@ void CRenderDevice::Initialize()
     TimerGlobal.Start();
     TimerMM.Start();
 
-    if (strstr(Core.Params, "-weather"))
+    if (weather.OptionValue())
         initialize_weather_editor();
 
     if (!m_sdlWnd)

--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -7,7 +7,6 @@
 #include "GameFont.h"
 #include "PerformanceAlert.hpp"
 #include "xrCore/ModuleLookup.hpp"
-#include "xrCore/command_line_key.h"
 
 static command_line_key<bool> weather("-weather", "initialize weather editor", 0);
 

--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -8,7 +8,7 @@
 #include "PerformanceAlert.hpp"
 #include "xrCore/ModuleLookup.hpp"
 
-static command_line_key<bool> weather("-weather", "initialize weather editor", 0);
+static command_line_key<bool> weather("weather", "initialize weather editor", 0);
 
 SDL_HitTestResult WindowHitTest(SDL_Window* win, const SDL_Point* area, void* data);
 

--- a/src/xrEngine/Device_create.cpp
+++ b/src/xrEngine/Device_create.cpp
@@ -3,10 +3,10 @@
 #include "Render.h"
 #include "xrCDB/xrXRC.h"
 
-static command_line_key<bool> gpu_sw("-gpu_sw", "gpu_sw", false);
-static command_line_key<bool> gpu_nopure("-gpu_nopure", "gpu_nopure", false);
-static command_line_key<bool> gpu_ref("-gpu_ref", "gpu_ref", false);
-static command_line_key<bool> draw_borders("-draw_borders", "draw_borders", false);
+static command_line_key<bool> gpu_sw("gpu_sw", "gpu_sw", false);
+static command_line_key<bool> gpu_nopure("gpu_nopure", "gpu_nopure", false);
+static command_line_key<bool> gpu_ref("gpu_ref", "gpu_ref", false);
+static command_line_key<bool> draw_borders("draw_borders", "draw_borders", false);
 
 extern XRCDB_API bool* cdb_bDebug;
 

--- a/src/xrEngine/Device_create.cpp
+++ b/src/xrEngine/Device_create.cpp
@@ -1,7 +1,13 @@
 #include "stdafx.h"
 #include "Include/xrRender/DrawUtils.h"
 #include "Render.h"
+#include "xrCore/command_line_key.h"
 #include "xrCDB/xrXRC.h"
+
+static command_line_key<bool> gpu_sw("-gpu_sw", "gpu_sw", false);
+static command_line_key<bool> gpu_nopure("-gpu_nopure", "gpu_nopure", false);
+static command_line_key<bool> gpu_ref("-gpu_ref", "gpu_ref", false);
+static command_line_key<bool> draw_borders("-draw_borders", "draw_borders", false);
 
 extern XRCDB_API bool* cdb_bDebug;
 
@@ -35,10 +41,8 @@ void CRenderDevice::CreateInternal()
         return; // prevent double call
 
     Statistic = xr_new<CStats>();
-    bool gpuSW = !!strstr(Core.Params, "-gpu_sw");
-    bool gpuNonPure = !!strstr(Core.Params, "-gpu_nopure");
-    bool gpuRef = !!strstr(Core.Params, "-gpu_ref");
-    GEnv.Render->SetupGPU(gpuSW, gpuNonPure, gpuRef);
+    GEnv.Render->SetupGPU(gpu_sw.OptionValue(), gpu_nopure.OptionValue(),
+                          gpu_ref.OptionValue());
     Log("Starting RENDER device...");
 #ifdef _EDITOR
     psDeviceMode.Width = dwWidth;

--- a/src/xrEngine/Device_create.cpp
+++ b/src/xrEngine/Device_create.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 #include "Include/xrRender/DrawUtils.h"
 #include "Render.h"
-#include "xrCore/command_line_key.h"
 #include "xrCDB/xrXRC.h"
 
 static command_line_key<bool> gpu_sw("-gpu_sw", "gpu_sw", false);

--- a/src/xrEngine/EngineAPI.cpp
+++ b/src/xrEngine/EngineAPI.cpp
@@ -12,6 +12,8 @@
 
 #include "xrScriptEngine/ScriptExporter.hpp"
 
+static command_line_key<bool> ivtune("-tune", "intel vtune", false);
+
 extern xr_vector<xr_token> VidQualityToken;
 
 constexpr pcstr GET_RENDERER_MODULE_FUNC = "GetRendererModule";
@@ -134,7 +136,7 @@ void CEngineAPI::Initialize(void)
     //////////////////////////////////////////////////////////////////////////
     // vTune
     tune_enabled = false;
-    if (strstr(Core.Params, "-tune"))
+    if (ivtune.OptionValue())
     {
         hTuner = XRay::LoadModule("vTuneAPI");
         tune_pause = (VTPause*)hTuner->GetProcAddress("VTPause");

--- a/src/xrEngine/EngineAPI.cpp
+++ b/src/xrEngine/EngineAPI.cpp
@@ -12,8 +12,8 @@
 
 #include "xrScriptEngine/ScriptExporter.hpp"
 
-static command_line_key<bool> ivtune("-tune", "intel vtune", false);
-static command_line_key<bool> nogame("-nogame", "nogame", false);
+static command_line_key<bool> ivtune("tune", "intel vtune", false);
+static command_line_key<bool> nogame("nogame", "nogame", false);
 
 extern xr_vector<xr_token> VidQualityToken;
 

--- a/src/xrEngine/EngineAPI.cpp
+++ b/src/xrEngine/EngineAPI.cpp
@@ -13,6 +13,7 @@
 #include "xrScriptEngine/ScriptExporter.hpp"
 
 static command_line_key<bool> ivtune("-tune", "intel vtune", false);
+static command_line_key<bool> nogame("-nogame", "nogame", false);
 
 extern xr_vector<xr_token> VidQualityToken;
 
@@ -280,6 +281,11 @@ void CEngineAPI::CreateRendererList()
             Log(mode.name);
     }
     modes.emplace_back(nullptr, -1);
+}
+
+bool CEngineAPI::CanSkipGameModuleLoading() const
+{
+    return nogame.OptionValue();
 }
 
 bool is_r2_available()

--- a/src/xrEngine/EngineAPI.h
+++ b/src/xrEngine/EngineAPI.h
@@ -13,8 +13,6 @@
 
 #include <memory>
 
-inline static command_line_key<bool> nogame("-nogame", "nogame", false);
-
 class IFactoryObject
 {
 public:
@@ -101,7 +99,7 @@ public:
     void Destroy();
 
     void CreateRendererList();
-    bool CanSkipGameModuleLoading() const { return nogame.OptionValue(); }
+    bool CanSkipGameModuleLoading() const;
 
     CEngineAPI();
     ~CEngineAPI();

--- a/src/xrEngine/EngineAPI.h
+++ b/src/xrEngine/EngineAPI.h
@@ -9,8 +9,11 @@
 #include "xrCore/ModuleLookup.hpp"
 #include "xrCore/clsid.h"
 #include "xrCore/xrCore_benchmark_macros.h"
+#include "xrCore/command_line_key.h"
 
 #include <memory>
+
+inline static command_line_key<bool> nogame("-nogame", "nogame", false);
 
 class IFactoryObject
 {
@@ -98,7 +101,7 @@ public:
     void Destroy();
 
     void CreateRendererList();
-    bool CanSkipGameModuleLoading() const { return !!strstr(Core.Params, "-nogame"); }
+    bool CanSkipGameModuleLoading() const { return nogame.OptionValue(); }
 
     CEngineAPI();
     ~CEngineAPI();

--- a/src/xrEngine/EngineAPI.h
+++ b/src/xrEngine/EngineAPI.h
@@ -9,7 +9,6 @@
 #include "xrCore/ModuleLookup.hpp"
 #include "xrCore/clsid.h"
 #include "xrCore/xrCore_benchmark_macros.h"
-#include "xrCore/command_line_key.h"
 
 #include <memory>
 

--- a/src/xrEngine/IGame_Level.cpp
+++ b/src/xrEngine/IGame_Level.cpp
@@ -8,12 +8,16 @@
 #include "Render.h"
 #include "GameFont.h"
 #include "Common/LevelStructure.hpp"
+#include "xrCore/command_line_key.h"
 #include "CameraManager.h"
 #include "xr_object.h"
 #include "Feel_Sound.h"
 #include "xrServerEntities/smart_cast.h"
 
 ENGINE_API IGame_Level* g_pGameLevel = NULL;
+
+static command_line_key<bool> nes_texture_storing("-nes_texture_storing",
+                                                  "nes_texture_storing", false);
 extern bool g_bLoaded;
 
 IGame_Level::IGame_Level()
@@ -31,7 +35,7 @@ IGame_Level::IGame_Level()
 
 IGame_Level::~IGame_Level()
 {
-    if (strstr(Core.Params, "-nes_texture_storing"))
+    if (nes_texture_storing.OptionValue())
         GEnv.Render->ResourcesStoreNecessaryTextures();
     xr_delete(pLevel);
 

--- a/src/xrEngine/IGame_Level.cpp
+++ b/src/xrEngine/IGame_Level.cpp
@@ -8,7 +8,6 @@
 #include "Render.h"
 #include "GameFont.h"
 #include "Common/LevelStructure.hpp"
-#include "xrCore/command_line_key.h"
 #include "CameraManager.h"
 #include "xr_object.h"
 #include "Feel_Sound.h"

--- a/src/xrEngine/IGame_Level.cpp
+++ b/src/xrEngine/IGame_Level.cpp
@@ -15,7 +15,7 @@
 
 ENGINE_API IGame_Level* g_pGameLevel = NULL;
 
-static command_line_key<bool> nes_texture_storing("-nes_texture_storing",
+static command_line_key<bool> nes_texture_storing("nes_texture_storing",
                                                   "nes_texture_storing", false);
 extern bool g_bLoaded;
 

--- a/src/xrEngine/IGame_Persistent.cpp
+++ b/src/xrEngine/IGame_Persistent.cpp
@@ -18,7 +18,7 @@
 #include "Include/editor/ide.hpp"
 
 #ifndef _EDITOR
-static command_line_key<bool> noprefetch("-noprefetch", "noprefetch", false);
+static command_line_key<bool> noprefetch("noprefetch", "noprefetch", false);
 #endif
 
 ENGINE_API IGame_Persistent* g_pGamePersistent = nullptr;

--- a/src/xrEngine/IGame_Persistent.cpp
+++ b/src/xrEngine/IGame_Persistent.cpp
@@ -4,6 +4,7 @@
 #include "IGame_Persistent.h"
 #include "GameFont.h"
 #include "PerformanceAlert.hpp"
+#include "xrCore/command_line_key.h"
 
 #ifndef _EDITOR
 #include "Environment.h"
@@ -16,6 +17,10 @@
 #endif
 
 #include "Include/editor/ide.hpp"
+
+#ifndef _EDITOR
+static command_line_key<bool> noprefetch("-noprefetch", "noprefetch", false);
+#endif
 
 ENGINE_API IGame_Persistent* g_pGamePersistent = nullptr;
 
@@ -134,7 +139,7 @@ void IGame_Persistent::OnGameStart()
 #ifndef _EDITOR
     SetLoadStageTitle("st_prefetching_objects");
     LoadTitle();
-    if (!strstr(Core.Params, "-noprefetch"))
+    if (!noprefetch.OptionValue())
         Prefetch();
 #endif
 }

--- a/src/xrEngine/IGame_Persistent.cpp
+++ b/src/xrEngine/IGame_Persistent.cpp
@@ -4,7 +4,6 @@
 #include "IGame_Persistent.h"
 #include "GameFont.h"
 #include "PerformanceAlert.hpp"
-#include "xrCore/command_line_key.h"
 
 #ifndef _EDITOR
 #include "Environment.h"

--- a/src/xrEngine/Stats.cpp
+++ b/src/xrEngine/Stats.cpp
@@ -18,6 +18,8 @@
 int g_ErrorLineCount = 15;
 Flags32 g_stats_flags = {0};
 
+static command_line_key<bool> xclsx("-xclsx", "xclsx", false);
+
 ENGINE_API CStatTimer gTestTimer0;
 ENGINE_API CStatTimer gTestTimer1;
 ENGINE_API CStatTimer gTestTimer2;
@@ -249,7 +251,7 @@ void CStats::Show()
 
 void CStats::OnDeviceCreate()
 {
-    g_bDisableRedText = !!strstr(Core.Params, "-xclsx");
+    g_bDisableRedText = xclsx.OptionValue();
 
     if (!GEnv.isDedicatedServer)
     {

--- a/src/xrEngine/Stats.cpp
+++ b/src/xrEngine/Stats.cpp
@@ -18,7 +18,7 @@
 int g_ErrorLineCount = 15;
 Flags32 g_stats_flags = {0};
 
-static command_line_key<bool> xclsx("-xclsx", "xclsx", false);
+static command_line_key<bool> xclsx("xclsx", "xclsx", false);
 
 ENGINE_API CStatTimer gTestTimer0;
 ENGINE_API CStatTimer gTestTimer1;

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -22,6 +22,7 @@
 
 #include "xrCore/FS_impl.h"
 #include "xrCore/Threading/TaskManager.hpp"
+#include "xrCore/command_line_key.h"
 
 #include "Include/editor/ide.hpp"
 
@@ -44,6 +45,8 @@ constexpr size_t MAX_WINDOW_EVENTS = 32;
 
 bool g_bLoaded = false;
 ref_light precache_light = 0;
+
+static command_line_key<bool> center_screen("-center_screen", "center_screen", false);
 
 bool CRenderDevice::RenderBegin()
 {
@@ -442,7 +445,7 @@ void CRenderDevice::Run()
     UpdateWindowProps();
     SDL_ShowWindow(m_sdlWnd);
     SDL_RaiseWindow(m_sdlWnd);
-    if (GEnv.isDedicatedServer || strstr(Core.Params, "-center_screen"))
+    if (GEnv.isDedicatedServer || center_screen.OptionValue())
         SDL_SetWindowPosition(m_sdlWnd, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 
     // Message cycle

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -45,7 +45,7 @@ constexpr size_t MAX_WINDOW_EVENTS = 32;
 bool g_bLoaded = false;
 ref_light precache_light = 0;
 
-static command_line_key<bool> center_screen("-center_screen", "center_screen", false);
+static command_line_key<bool> center_screen("center_screen", "center_screen", false);
 
 bool CRenderDevice::RenderBegin()
 {

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -22,7 +22,6 @@
 
 #include "xrCore/FS_impl.h"
 #include "xrCore/Threading/TaskManager.hpp"
-#include "xrCore/command_line_key.h"
 
 #include "Include/editor/ide.hpp"
 

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -43,7 +43,7 @@ ENGINE_API bool ClearSkyMode = false;
 ENGINE_API bool ShadowOfChernobylMode = false;
 
 static command_line_key<bool> unlock_game_mode("-unlock_game_mode", "unlock_game_mode", false);
-static command_line_key<pstr> ltx_flag("-ltx", "ltx", "");
+static command_line_key<pcstr> ltx_flag("-ltx", "ltx", "");
 static command_line_key<bool> captureInput("-i", "Capture input", false);
 static command_line_key<bool> gl_flag("-rgl", "opengl renderer", false);
 static command_line_key<bool> r4_flag("-r4", "r4 renderer", false);
@@ -58,7 +58,7 @@ static command_line_key<bool> slowdown2x_flag("-slowdown2x", "slowdown2x", false
 #endif
 
 
-extern command_line_key<pstr> fsltx_path;
+extern command_line_key<pcstr> fsltx_path;
 extern command_line_key<bool> shoc_flag, soc_flag, cs_flag, cop_flag;
 
 namespace

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -41,19 +41,19 @@ ENGINE_API bool CallOfPripyatMode = false;
 ENGINE_API bool ClearSkyMode = false;
 ENGINE_API bool ShadowOfChernobylMode = false;
 
-static command_line_key<bool> unlock_game_mode("-unlock_game_mode", "unlock_game_mode", false);
-static command_line_key<pcstr> ltx_flag("-ltx", "ltx", "");
-static command_line_key<bool> captureInput("-i", "Capture input", false);
-static command_line_key<bool> gl_flag("-rgl", "opengl renderer", false);
-static command_line_key<bool> r4_flag("-r4", "r4 renderer", false);
-static command_line_key<bool> r3_flag("-r3", "r3 renderer", false);
-static command_line_key<bool> r25_flag("-r2.5", "r2.5 renderer", false);
-static command_line_key<bool> r2a_flag("-r2a", "r2a renderer", false);
-static command_line_key<bool> r2_flag("-r2", "r2 renderer", false);
-static command_line_key<bool> r1_flag("-r1", "r1 renderer", false);
+static command_line_key<bool> unlock_game_mode("unlock_game_mode", "unlock_game_mode", false);
+static command_line_key<pcstr> ltx_flag("ltx", "ltx", "");
+static command_line_key<bool> captureInput("i", "Capture input", false);
+static command_line_key<bool> gl_flag("rgl", "opengl renderer", false);
+static command_line_key<bool> r4_flag("r4", "r4 renderer", false);
+static command_line_key<bool> r3_flag("r3", "r3 renderer", false);
+static command_line_key<bool> r25_flag("r2.5", "r2.5 renderer", false);
+static command_line_key<bool> r2a_flag("r2a", "r2a renderer", false);
+static command_line_key<bool> r2_flag("r2", "r2 renderer", false);
+static command_line_key<bool> r1_flag("r1", "r1 renderer", false);
 #ifdef DEBUG
-static command_line_key<bool> slowdown_flag("-slowdown", "slowdown", false);
-static command_line_key<bool> slowdown2x_flag("-slowdown2x", "slowdown2x", false);
+static command_line_key<bool> slowdown_flag("slowdown", "slowdown", false);
+static command_line_key<bool> slowdown2x_flag("slowdown2x", "slowdown2x", false);
 #endif
 
 

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -28,7 +28,6 @@
 #include "xr_ioc_cmd.h"
 
 #include "xrCore/Threading/TaskManager.hpp"
-#include "xrCore/command_line_key.h"
 
 // global variables
 ENGINE_API CInifile* pGameIni = nullptr;

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -58,8 +58,8 @@ static command_line_key<bool> slowdown2x_flag("-slowdown2x", "slowdown2x", false
 #endif
 
 
-extern command_line_key<pcstr> fsltx_path;
-extern command_line_key<bool> shoc_flag, soc_flag, cs_flag, cop_flag;
+extern XRCORE_API command_line_key<pcstr> fsltx_path;
+extern XRCORE_API command_line_key<bool> shoc_flag, soc_flag, cs_flag, cop_flag;
 
 namespace
 {

--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -187,7 +187,7 @@ ENGINE_API void InitConsole()
 
 ENGINE_API void InitInput()
 {
-    pInput = xr_new<CInput>(captureInput.OptionValue());
+    pInput = xr_new<CInput>(!captureInput.OptionValue() && !GEnv.isEditor);
 }
 
 ENGINE_API void destroyInput() { xr_delete(pInput); }

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -12,7 +12,6 @@
 #endif
 #include "xrEngine/main.h"
 #include "xrEngine/splash.h"
-#include "xrCore/command_line_key.h"
 #include <SDL.h>
 
 //#define PROFILE_TASK_SYSTEM

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -30,10 +30,10 @@ XR_EXPORT u32 NvOptimusEnablement = 0x00000001; // NVIDIA Optimus
 XR_EXPORT u32 AmdPowerXpressRequestHighPerformance = 0x00000001; // PowerXpress or Hybrid Graphics
 }
 
-static command_line_key<bool> clhelp("-help", "print this help and exit", false);
-static command_line_key<bool> no_splash("-nosplash", "no splash screen", false);
-static command_line_key<bool> splash_notop("-splashnotop", "splash no top", false);
-static command_line_key<bool> sv_dedicated("-dedicated", "run dedicated server", false);
+static command_line_key<bool> clhelp("help", "print this help and exit", false);
+static command_line_key<bool> no_splash("nosplash", "no splash screen", false);
+static command_line_key<bool> splash_notop("splashnotop", "splash no top", false);
+static command_line_key<bool> sv_dedicated("dedicated", "run dedicated server", false);
 
 extern XRCORE_API command_line_key<pcstr> fsltx_path;
 

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -37,7 +37,7 @@ static command_line_key<bool> no_splash("-nosplash", "no splash screen", false);
 static command_line_key<bool> splash_notop("-splashnotop", "splash no top", false);
 static command_line_key<bool> sv_dedicated("-dedicated", "run dedicated server", false);
 
-extern command_line_key<pcstr> fsltx_path;
+extern XRCORE_API command_line_key<pcstr> fsltx_path;
 
 bool HandleArguments(int argc, char *argv[])
 {
@@ -125,17 +125,13 @@ int StackoverflowFilter(const int exceptionCode)
 int APIENTRY WinMain(HINSTANCE inst, HINSTANCE prevInst, char* commandLine, int cmdShow)
 {
     int result = 0;
-    int argc;
-    char **argv;
     // BugTrap can't handle stack overflow exception, so handle it here
     __try
     {
-        argv = CommandLineToArgvW(commandLine, &argc);
-        if (HandleArguments(argc, argv))
+        if (HandleArguments(__argc, __argv))
             result = entry_point(commandLine);
         else
             result = EXIT_FAILURE;
-        LocalFree(argv);
     }
     __except (StackoverflowFilter(GetExceptionCode()))
     {

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -1,4 +1,3 @@
-
 #include "stdafx.h"
 #include "resource.h"
 #if defined(XR_PLATFORM_WINDOWS)

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -126,11 +126,11 @@ int APIENTRY WinMain(HINSTANCE inst, HINSTANCE prevInst, char* commandLine, int 
 {
     int result = 0;
     int argc;
-    char **argv
+    char **argv;
     // BugTrap can't handle stack overflow exception, so handle it here
     __try
     {
-        argv = CommandLineToArgvW(commandLine, &argc);
+        argv = CommandLineToArgv(commandLine, &argc);
         if (HandleArguments(argc, argv))
             result = entry_point(commandLine);
         else

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -130,7 +130,7 @@ int APIENTRY WinMain(HINSTANCE inst, HINSTANCE prevInst, char* commandLine, int 
     // BugTrap can't handle stack overflow exception, so handle it here
     __try
     {
-        argv = CommandLineToArgv(commandLine, &argc);
+        argv = CommandLineToArgvW(commandLine, &argc);
         if (HandleArguments(argc, argv))
             result = entry_point(commandLine);
         else

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -51,7 +51,7 @@ int entry_point(pcstr commandLine)
         return 0;
     }
 
-    xrDebug::Initialize();
+    xrDebug::Initialize(commandLine);
     R_ASSERT3(SDL_Init(SDL_INIT_VIDEO) == 0, "Unable to initialize SDL", SDL_GetError());
     SDL_SetHint(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "0");
 

--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -37,7 +37,7 @@ static command_line_key<bool> no_splash("-nosplash", "no splash screen", false);
 static command_line_key<bool> splash_notop("-splashnotop", "splash no top", false);
 static command_line_key<bool> sv_dedicated("-dedicated", "run dedicated server", false);
 
-extern command_line_key<pstr> fsltx_path;
+extern command_line_key<pcstr> fsltx_path;
 
 bool HandleArguments(int argc, char *argv[])
 {


### PR DESCRIPTION
I wish to discuss these changes. New system for handling command line options.

While  transitioning to the news system, I noticed that this approach is very inconvenient when
adding command line options that are used across different subsystems.
One has to define a public variable and declare it external in other places where it's used,
keeping in mind that the unit where external declaration is used must be compiled *after* 
the unit where the variable is defined. This is not very readable and extendable, although
not many options need to be used across different modules.

Another option is to have a public variable containing a map of command line options and access it like so:
`command_line_options_map.getvalue("-myoption")`.
This could lead to some overhead.

This PR is just for discussion.