### PR TITLE
fix ArchLinux build errors with newer default CFLAGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ CMakeFiles/
 
 # exclude doxygen output
 doc/doxygen/html/*
+
+# exclude PKGBUILD output
+ArchLinux/pkg
+ArchLinux/src
+ArchLinux/*.tar.zst

--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -6,7 +6,7 @@
 #To build the package, open a terminal, go to the xray-16/ArchLinux directory and run the makepkg -fi command
 #where the options are -f to overwrite the package if it was built before that -i install the package after the build.
 pkgname=openxray-dev                                    
-pkgver=1.6.02_
+pkgver=1.6.02_ba04387e6
 pkgrel=1          
 pkgdesc="Unofficial X-Ray Engine Linux port by OpenXRay team (Originally developed by GSC Game World)"                                          
 arch=('x86_64') 
@@ -29,7 +29,9 @@ build() {
    cd bin
    cmake .. -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/usr \
-   -DCMAKE_INSTALL_LIBDIR=lib
+   -DCMAKE_INSTALL_LIBDIR=lib \
+   -DCMAKE_C_FLAGS="-Wno-format -Wno-error=format-security" \
+   -DCMAKE_CXX_FLAGS="-Wno-format -Wno-error=format-security"
    make
 }
 

--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -6,7 +6,7 @@
 #To build the package, open a terminal, go to the xray-16/ArchLinux directory and run the makepkg -fi command
 #where the options are -f to overwrite the package if it was built before that -i install the package after the build.
 pkgname=openxray-dev                                    
-pkgver=1.6.02_ba04387e6
+pkgver=1.6.02_
 pkgrel=1          
 pkgdesc="Unofficial X-Ray Engine Linux port by OpenXRay team (Originally developed by GSC Game World)"                                          
 arch=('x86_64') 
@@ -29,9 +29,7 @@ build() {
    cd bin
    cmake .. -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/usr \
-   -DCMAKE_INSTALL_LIBDIR=lib \
-   -DCMAKE_C_FLAGS="-Wno-format -Wno-error=format-security" \
-   -DCMAKE_CXX_FLAGS="-Wno-format -Wno-error=format-security"
+   -DCMAKE_INSTALL_LIBDIR=lib
    make
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes -Wl,--no-undefined -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes -Wl,--no-undefined -fvisibility=hidden -Wno-format -Wno-error=format-security")
 
 #set(SANITIZE_FLAGS "-fsanitize=address  -fsanitize=leak -fno-omit-frame-pointer -g -fsanitize=undefined -fno-sanitize=vptr")
 #if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Recent default [flag changes](https://gitlab.archlinux.org/archlinux/rfcs/-/blob/master/rfcs/0003-buildflags.rst#specification) by ArchLinux broke the build. Ideally it points to bad potential bugs but disabling the flags restores the ability to build for now.