### PR TITLE
Fix LUA_STUDIO debugger ifdefs

### DIFF
--- a/src/xrScriptEngine/ScriptEngineScript.cpp
+++ b/src/xrScriptEngine/ScriptEngineScript.cpp
@@ -32,7 +32,7 @@ void ErrorLog(pcstr caMessage)
     if (GEnv.ScriptEngine->debugger())
         GEnv.ScriptEngine->debugger()->Write(caMessage);
 #endif
-#ifdef DEBUG
+#if defined(USE_DEBUGGER) && defined(USE_LUA_STUDIO)
     bool lua_studio_connected = !!GEnv.ScriptEngine->debugger();
     if (!lua_studio_connected)
         R_ASSERT2(0, caMessage);

--- a/src/xrScriptEngine/script_engine.cpp
+++ b/src/xrScriptEngine/script_engine.cpp
@@ -549,7 +549,7 @@ struct raii_guard : private Noncopyable
 
     ~raii_guard()
     {
-#ifdef DEBUG
+#if defined(USE_DEBUGGER) && defined(USE_LUA_STUDIO)
         const bool lua_studio_connected = !!m_script_engine->debugger();
         if (!lua_studio_connected)
 #endif


### PR DESCRIPTION
I have been trying to compile a Debug build of xray-16 on my computer and I was unable to because of a few things in this commit.

I think maybe it was because of a dirty cmake state, but I don't see how `ScheduledBase` could ever compile with `MASTER_GOLD` being set, because `Registered` is never defined.

Is a `Debug` and `MASTER_GOLD` combination an expected combination?
