### PR TITLE
xrRender_R4: fix for unbound sampler in UI draw

### DIFF
--- a/src/Layers/xrRender/blenders/Blender_Screen_SET.cpp
+++ b/src/Layers/xrRender/blenders/Blender_Screen_SET.cpp
@@ -202,7 +202,7 @@ void CBlender_Screen_SET::CompileProgrammed(CBlender_Compile& C)
     }
 
     VERIFY2(C.L_textures.size() > 0, "Not enough textures");
-    const u32 stage = C.SampledImage("s_base", "s_base", C.L_textures[0]);
+    const u32 stage = C.SampledImage("smp_base", "s_base", C.L_textures[0]);
     if (oClamp.value)
     {
         C.i_Address(stage, D3DTADDRESS_CLAMP);


### PR DESCRIPTION
D3D11 WARNING: ID3D11DeviceContext::Draw: The Pixel Shader unit expects a Sampler to be set at Slot 0, but none is bound. This is perfectly valid, as a NULL Sampler maps to default Sampler state. However, the developer may not want to rely on the defaults.  [ EXECUTION WARNING #352: DEVICE_DRAW_SAMPLER_NOT_SET]