### PR TITLE
Add method `clear_callbacks` for GameObect

### DIFF
--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -1274,6 +1274,14 @@ CGameObject::CScriptCallbackExVoid& CGameObject::callback(GameObject::ECallbackT
     return ((*m_callbacks)[type]);
 }
 
+void CGameObject::clear_callbacks() const
+{
+    for (auto& callback : *m_callbacks)
+    {
+        callback.second.clear();
+    }
+}
+
 LPCSTR CGameObject::visual_name(CSE_Abstract* server_entity)
 {
     const CSE_Visual* visual = smart_cast<const CSE_Visual*>(server_entity);

--- a/src/xrGame/GameObject.h
+++ b/src/xrGame/GameObject.h
@@ -350,6 +350,7 @@ public:
     virtual void MoveTo(const Fvector& position) override {}
     // the only usage: aimers::base::fill_bones
     virtual CScriptCallbackExVoid& callback(GameObject::ECallbackType type) const override;
+    void clear_callbacks() const;
     virtual LPCSTR visual_name(CSE_Abstract* server_entity) override;
     virtual void On_B_NotCurrentEntity() override {}
     virtual bool is_ai_obstacle() const override;

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -434,6 +434,7 @@ public:
     void SetCallback(
         GameObject::ECallbackType type, const luabind::functor<void>& functor, const luabind::adl::object& object);
     void SetCallback(GameObject::ECallbackType type);
+    void ClearCallbacks();
 
     void set_patrol_extrapolate_callback(const luabind::functor<bool>& functor);
     void set_patrol_extrapolate_callback(const luabind::functor<bool>& functor, const luabind::adl::object& object);

--- a/src/xrGame/script_game_object_script2.cpp
+++ b/src/xrGame/script_game_object_script2.cpp
@@ -125,6 +125,7 @@ class_<CScriptGameObject>& script_register_game_object1(class_<CScriptGameObject
         .def("set_callback", (void (CScriptGameObject::*)(GameObject::ECallbackType, const luabind::functor<void>&,
                                  const luabind::object&))(&CScriptGameObject::SetCallback))
         .def("set_callback", (void (CScriptGameObject::*)(GameObject::ECallbackType))(&CScriptGameObject::SetCallback))
+        .def("clear_callbacks", &CScriptGameObject::ClearCallbacks) //Graff46
 
         .def("set_patrol_extrapolate_callback",
             (void (CScriptGameObject::*)())(&CScriptGameObject::set_patrol_extrapolate_callback))

--- a/src/xrGame/script_game_object_use.cpp
+++ b/src/xrGame/script_game_object_use.cpp
@@ -172,6 +172,7 @@ void CScriptGameObject::SetCallback(
 }
 
 void CScriptGameObject::SetCallback(GameObject::ECallbackType type) { object().callback(type).clear(); }
+void CScriptGameObject::ClearCallbacks() { object().clear_callbacks(); }
 void CScriptGameObject::set_fastcall(const luabind::functor<bool>& functor, const luabind::object& object)
 {
     CPHScriptGameObjectCondition* c = xr_new<CPHScriptGameObjectCondition>(object, functor, m_game_object);


### PR DESCRIPTION
Добавлен метод `clear_callbacks` для сброса коллбеков в биндерах, чтобы не за null-ивать каждый коллбек отдельно