### PR TITLE
Fixes partial "Getting rid of Microsoft specific types" #23. LPCSTR to pcstr

### DIFF
--- a/src/Common/object_cloner.h
+++ b/src/Common/object_cloner.h
@@ -28,7 +28,7 @@ struct CCloner
         }
     };
 
-    IC static void clone(LPCSTR _1, LPCSTR& _2) { _2 = _1; }
+    IC static void clone(pcstr _1, pcstr& _2) { _2 = _1; }
     IC static void clone(pstr _1, pstr& _2) { _2 = xr_strdup(_1); }
     IC static void clone(const shared_str& _1, shared_str& _2) { _2 = _1; }
     template <typename T1, typename T2>
@@ -174,7 +174,7 @@ struct CCloner
     }
 };
 
-IC void clone(LPCSTR p0, pstr& p1) { p1 = xr_strdup(p0); }
+IC void clone(pcstr p0, pstr& p1) { p1 = xr_strdup(p0); }
 template <typename T>
 IC void clone(const T& p0, T& p1)
 {

--- a/src/Common/object_comparer.h
+++ b/src/Common/object_comparer.h
@@ -30,7 +30,7 @@ struct CComparer
         }
     };
 
-    IC static bool compare(LPCSTR s1, LPCSTR s2, const P& p) { return p(s1, s2); }
+    IC static bool compare(pcstr s1, pcstr s2, const P& p) { return p(s1, s2); }
     IC static bool compare(pstr s1, pstr s2, const P& p) { return p(s1, s2); }
     IC static bool compare(const shared_str& s1, const shared_str& s2, const P& p) { return p(s1, s2); }
     template <typename T1, typename T2>
@@ -152,13 +152,13 @@ struct CComparer
 };
 
 template <typename P>
-IC bool compare(LPCSTR p0, pstr p1, const P& p)
+IC bool compare(pcstr p0, pstr p1, const P& p)
 {
     return p(p0, p1);
 }
 
 template <typename P>
-IC bool compare(pstr p0, LPCSTR p1, const P& p)
+IC bool compare(pstr p0, pcstr p1, const P& p)
 {
     return p(p0, p1);
 }
@@ -182,10 +182,10 @@ struct comparer
         return P<T>()(a1, a2);
     }
     IC bool operator()() const { return P<bool>()(false, true); }
-    IC bool operator()(LPCSTR s1, LPCSTR s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
+    IC bool operator()(pcstr s1, pcstr s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
     IC bool operator()(pstr s1, pstr s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
-    IC bool operator()(LPCSTR s1, pstr s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
-    IC bool operator()(pstr s1, LPCSTR s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
+    IC bool operator()(pcstr s1, pstr s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
+    IC bool operator()(pstr s1, pcstr s2) const { return (P<int>()(xr_strcmp(s1, s2), 0)); }
 };
 };
 };

--- a/src/Common/object_loader.h
+++ b/src/Common/object_loader.h
@@ -129,7 +129,7 @@ struct CLoader
         }
     };
 
-    static void load_data(LPCSTR& data, M& stream, const P& p) { NODEFAULT; }
+    static void load_data(pcstr& data, M& stream, const P& p) { NODEFAULT; }
     static void load_data(pstr& data, M& stream, const P& p)
     {
         shared_str S;
@@ -150,7 +150,7 @@ struct CLoader
     {
         if (p(data, const_cast<typename object_type_traits::remove_const<T1>::type&>(data.first), true))
         {
-            const bool value = object_type_traits::is_same<T1, LPCSTR>::value;
+            const bool value = object_type_traits::is_same<T1, pcstr>::value;
             VERIFY(!value);
             load_data(const_cast<typename object_type_traits::remove_const<T1>::type&>(data.first), stream, p);
         }

--- a/src/Common/object_saver.h
+++ b/src/Common/object_saver.h
@@ -79,7 +79,7 @@ struct CSaver
     };
 
     IC static void save_data(pstr data, M& stream, const P& /*p*/) { stream.w_stringZ(data); }
-    IC static void save_data(LPCSTR data, M& stream, const P& /*p*/) { stream.w_stringZ(data); }
+    IC static void save_data(pcstr data, M& stream, const P& /*p*/) { stream.w_stringZ(data); }
     IC static void save_data(const shared_str& data, M& stream, const P& /*p*/) { stream.w_stringZ(data); }
     IC static void save_data(const xr_string& data, M& stream, const P& /*p*/) { stream.w_stringZ(data.c_str()); }
     template <typename T1, typename T2>


### PR DESCRIPTION
Fixes using LPCSTR to pcstr in src/Common