### PR TITLE
Fixes partial "Getting rid of Microsoft specific types" #23. LPCSTR to pcstr

### DIFF
--- a/src/editors/xrWeatherEditor/ide_impl.cpp
+++ b/src/editors/xrWeatherEditor/ide_impl.cpp
@@ -71,7 +71,7 @@ void ide_impl::on_load_finished()
 
 void ide_impl::pause() { m_window->view().pause(); }
 property_holder_base* ide_impl::create_property_holder(
-    LPCSTR display_name, property_holder_collection* collection, property_holder_holder* holder)
+    pcstr display_name, property_holder_collection* collection, property_holder_holder* holder)
 {
     return (xr_new<::property_holder>(m_engine, display_name, collection, holder));
 }

--- a/src/editors/xrWeatherEditor/ide_impl.hpp
+++ b/src/editors/xrWeatherEditor/ide_impl.hpp
@@ -55,7 +55,7 @@ public:
 
 public:
     virtual property_holder* create_property_holder(
-        LPCSTR display_name, property_holder_collection* collection, property_holder_holder* holder);
+        pcstr display_name, property_holder_collection* collection, property_holder_holder* holder);
     virtual void destroy(property_holder*& property_holder);
     virtual void environment_levels(property_holder* property_holder);
     virtual void environment_weathers(property_holder* property_holder);

--- a/src/editors/xrWeatherEditor/pch.hpp
+++ b/src/editors/xrWeatherEditor/pch.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 typedef unsigned int u32;
-typedef char const* LPCSTR;
-typedef char* LPSTR;
 
 #pragma managed(push, off)
 #include <malloc.h>
@@ -72,4 +70,4 @@ inline LPSTR to_string(System::String ^ string)
     return (result);
 }
 
-inline System::String ^ to_string(LPCSTR string) { return (gcnew System::String(string)); }
+inline System::String ^ to_string(pcstr string) { return (gcnew System::String(string)); }

--- a/src/editors/xrWeatherEditor/property_boolean_values_value.cpp
+++ b/src/editors/xrWeatherEditor/property_boolean_values_value.cpp
@@ -12,7 +12,7 @@
 using System::String;
 
 property_boolean_values_value::property_boolean_values_value(
-    boolean_getter_type const& getter, boolean_setter_type const& setter, LPCSTR values[2])
+    boolean_getter_type const& getter, boolean_setter_type const& setter, pcstr values[2])
     : inherited(getter, setter), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < 2; ++i)

--- a/src/editors/xrWeatherEditor/property_boolean_values_value.hpp
+++ b/src/editors/xrWeatherEditor/property_boolean_values_value.hpp
@@ -25,7 +25,7 @@ private:
 
 public:
     property_boolean_values_value(
-        boolean_getter_type const& getter, boolean_setter_type const& setter, LPCSTR values[2]);
+        boolean_getter_type const& getter, boolean_setter_type const& setter, pcstr values[2]);
     virtual void SetValue(Object ^ object) override;
 
 public:

--- a/src/editors/xrWeatherEditor/property_boolean_values_value_reference.cpp
+++ b/src/editors/xrWeatherEditor/property_boolean_values_value_reference.cpp
@@ -11,7 +11,7 @@
 
 using System::String;
 
-property_boolean_values_value_reference::property_boolean_values_value_reference(bool& value, LPCSTR values[2])
+property_boolean_values_value_reference::property_boolean_values_value_reference(bool& value, pcstr values[2])
     : inherited(value), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < 2; ++i)

--- a/src/editors/xrWeatherEditor/property_boolean_values_value_reference.hpp
+++ b/src/editors/xrWeatherEditor/property_boolean_values_value_reference.hpp
@@ -24,7 +24,7 @@ private:
     typedef System::Object Object;
 
 public:
-    property_boolean_values_value_reference(bool& value, LPCSTR values[2]);
+    property_boolean_values_value_reference(bool& value, pcstr values[2]);
     virtual void SetValue(Object ^ object) override;
 
 public:

--- a/src/editors/xrWeatherEditor/property_float_enum_value.hpp
+++ b/src/editors/xrWeatherEditor/property_float_enum_value.hpp
@@ -23,7 +23,7 @@ private:
     typedef property_float inherited;
     typedef System::Collections::ArrayList collection_type;
     typedef System::Object Object;
-    typedef std::pair<float, LPCSTR> pair;
+    typedef std::pair<float, pcstr> pair;
 
 public:
     property_float_enum_value(

--- a/src/editors/xrWeatherEditor/property_float_enum_value_reference.hpp
+++ b/src/editors/xrWeatherEditor/property_float_enum_value_reference.hpp
@@ -23,7 +23,7 @@ private:
     typedef property_float_reference inherited;
     typedef System::Collections::ArrayList collection_type;
     typedef System::Object Object;
-    typedef std::pair<float, LPCSTR> pair;
+    typedef std::pair<float, pcstr> pair;
 
 public:
     property_float_enum_value_reference(float& value, pair* values, u32 const& value_count);

--- a/src/editors/xrWeatherEditor/property_holder.cpp
+++ b/src/editors/xrWeatherEditor/property_holder.cpp
@@ -17,7 +17,7 @@ using XRay::Editor::property_holder_holder;
 
 typedef property_holder::collection_type collection_type;
 
-property_holder::property_holder(XRay::Editor::engine_base* engine, LPCSTR display_name, property_holder_collection* collection,
+property_holder::property_holder(XRay::Editor::engine_base* engine, pcstr display_name, property_holder_collection* collection,
     XRay::Editor::property_holder_holder* holder)
     : m_engine(engine), m_display_name(to_string(display_name)), m_collection(collection), m_holder(holder),
       m_disposing(false)

--- a/src/editors/xrWeatherEditor/property_holder.hpp
+++ b/src/editors/xrWeatherEditor/property_holder.hpp
@@ -30,7 +30,7 @@ namespace editor
 class property_holder : public XRay::Editor::property_holder_base
 {
 public:
-    property_holder(XRay::Editor::engine_base* engine, LPCSTR display_name, XRay::Editor::property_holder_collection* collection,
+    property_holder(XRay::Editor::engine_base* engine, pcstr display_name, XRay::Editor::property_holder_collection* collection,
         XRay::Editor::property_holder_holder* holder);
     virtual ~property_holder();
     void on_dispose();
@@ -40,166 +40,166 @@ public:
 public:
     virtual XRay::Editor::property_holder_holder* holder();
     virtual void clear();
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         bool const& default_value, boolean_getter_type const& getter, boolean_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         bool const& default_value, bool& value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         bool const& default_value, boolean_getter_type const& getter, boolean_setter_type const& setter,
-        LPCSTR values[2], readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
+        pcstr values[2], readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        bool const& default_value, bool& value, LPCSTR values[2], readonly_enum const& read_only,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        bool const& default_value, bool& value, pcstr values[2], readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, int& value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
         int const& min_value, int const& max_value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, int& value, int const& min_value, int const& max_value,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
-        std::pair<int, LPCSTR>* values, u32 const& value_count, readonly_enum const& read_only,
+        std::pair<int, pcstr>* values, u32 const& value_count, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        int const& default_value, int& value, std::pair<int, LPCSTR>* values, u32 const& value_count,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        int const& default_value, int& value, std::pair<int, pcstr>* values, u32 const& value_count,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
-        LPCSTR const* values, u32 const& value_count, readonly_enum const& read_only,
+        pcstr const* values, u32 const& value_count, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        int const& default_value, int& value, LPCSTR const* values, u32 const& value_count,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        int const& default_value, int& value, pcstr const* values, u32 const& value_count,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
         string_collection_getter_type const& values, string_collection_size_getter_type const& value_count,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         int const& default_value, int& value, string_collection_getter_type const& values,
         string_collection_size_getter_type const& value_count, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         float const& default_value, float& value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
         float const& min_value, float const& max_value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         float const& default_value, float& value, float const& min_value, float const& max_value,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
-        std::pair<float, LPCSTR>* values, u32 const& value_count, readonly_enum const& read_only,
+        std::pair<float, pcstr>* values, u32 const& value_count, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        float const& default_value, float& value, std::pair<float, LPCSTR>* values, u32 const& value_count,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        float const& default_value, float& value, std::pair<float, pcstr>* values, u32 const& value_count,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, string_getter_type const& getter, string_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, shared_str& value, readonly_enum const& read_only,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, shared_str& value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter,
-        LPCSTR default_extension, // ".dds",
-        LPCSTR file_mask, // "Texture files (*.dds)|*.dds",
-        LPCSTR default_folder, // "R:\\development\\priquel\\resources\\gamedata\\textures\\sky",
-        LPCSTR caption, // "Select texture..."
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, string_getter_type const& getter, string_setter_type const& setter,
+        pcstr default_extension, // ".dds",
+        pcstr file_mask, // "Texture files (*.dds)|*.dds",
+        pcstr default_folder, // "R:\\development\\priquel\\resources\\gamedata\\textures\\sky",
+        pcstr caption, // "Select texture..."
         enter_text_enum const& can_enter_text, extension_action_enum const& remove_extension,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, shared_str& value,
-        LPCSTR default_extension, // ".dds",
-        LPCSTR file_mask, // "Texture files (*.dds)|*.dds",
-        LPCSTR default_folder, // "R:\\development\\priquel\\resources\\gamedata\\textures\\sky",
-        LPCSTR caption, // "Select texture..."
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, shared_str& value,
+        pcstr default_extension, // ".dds",
+        pcstr file_mask, // "Texture files (*.dds)|*.dds",
+        pcstr default_folder, // "R:\\development\\priquel\\resources\\gamedata\\textures\\sky",
+        pcstr caption, // "Select texture..."
         enter_text_enum const& can_enter_text, extension_action_enum const& remove_extension,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter, LPCSTR const* values,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, string_getter_type const& getter, string_setter_type const& setter, pcstr const* values,
         u32 const& value_count, value_editor_enum const& value_editor, enter_text_enum const& can_enter_text,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, shared_str& value, LPCSTR const* values, u32 const& value_count,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, shared_str& value, pcstr const* values, u32 const& value_count,
         value_editor_enum const& value_editor, enter_text_enum const& can_enter_text, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, string_getter_type const& getter, string_setter_type const& setter,
         string_collection_getter_type const& values, string_collection_size_getter_type const& value_count,
         value_editor_enum const& value_editor, enter_text_enum const& can_enter_text, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-        LPCSTR default_value, shared_str& value, string_collection_getter_type const& values,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
+        pcstr default_value, shared_str& value, string_collection_getter_type const& values,
         string_collection_size_getter_type const& value_count, value_editor_enum const& value_editor,
         enter_text_enum const& can_enter_text, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::color const& default_value, color_getter_type const& getter, color_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::color const& default_value, XRay::Editor::color& result, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::vec3f const& default_value, vec3f_getter_type const& getter, vec3f_setter_type const& setter,
         readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
         password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::vec3f const& default_value, XRay::Editor::vec3f& result, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::property_holder_base* value, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         XRay::Editor::property_holder_collection* collection, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);
-    virtual XRay::Editor::property_value* add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+    virtual XRay::Editor::property_value* add_property(pcstr identifier, pcstr category, pcstr description,
         collection_getter_type const& collection_getter, readonly_enum const& read_only,
         notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
         refresh_grid_on_change_enum const& refresh_grid);

--- a/src/editors/xrWeatherEditor/property_holder_boolean.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_boolean.cpp
@@ -19,7 +19,7 @@ ref class property_converter_boolean_values;
 using Flobbster::Windows::Forms::PropertySpec;
 using System::String;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     bool const& default_value, boolean_getter_type const& getter, boolean_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -31,7 +31,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     bool const& default_value, bool& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -43,8 +43,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    bool const& default_value, boolean_getter_type const& getter, boolean_setter_type const& setter, LPCSTR values[2],
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    bool const& default_value, boolean_getter_type const& getter, boolean_setter_type const& setter, pcstr values[2],
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -56,8 +56,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    bool const& default_value, bool& value, LPCSTR values[2], readonly_enum const& read_only,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    bool const& default_value, bool& value, pcstr values[2], readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {

--- a/src/editors/xrWeatherEditor/property_holder_collection.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_collection.cpp
@@ -15,7 +15,7 @@
 using Flobbster::Windows::Forms::PropertySpec;
 using XRay::Editor::property_holder_collection;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     property_holder_collection* collection, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -27,7 +27,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     collection_getter_type const& collection_getter, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)

--- a/src/editors/xrWeatherEditor/property_holder_color.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_color.cpp
@@ -17,7 +17,7 @@ ref class property_converter_color;
 
 using Flobbster::Windows::Forms::PropertySpec;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     XRay::Editor::color const& default_value, color_getter_type const& getter, color_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -30,7 +30,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     XRay::Editor::color const& default_value, XRay::Editor::color& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)

--- a/src/editors/xrWeatherEditor/property_holder_container.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_container.cpp
@@ -13,7 +13,7 @@
 
 using Flobbster::Windows::Forms::PropertySpec;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     XRay::Editor::property_holder_base* value, readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {

--- a/src/editors/xrWeatherEditor/property_holder_float.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_float.cpp
@@ -22,7 +22,7 @@ ref class property_converter_float;
 using Flobbster::Windows::Forms::PropertySpec;
 using System::String;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -35,7 +35,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     float const& default_value, float& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -48,7 +48,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
     float const& min_value, float const& max_value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
@@ -62,7 +62,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     float const& default_value, float& value, float const& min_value, float const& max_value,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -75,9 +75,9 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     float const& default_value, float_getter_type const& getter, float_setter_type const& setter,
-    std::pair<float, LPCSTR>* values, u32 const& value_count, readonly_enum const& read_only,
+    std::pair<float, pcstr>* values, u32 const& value_count, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -89,8 +89,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    float const& default_value, float& value, std::pair<float, LPCSTR>* values, u32 const& value_count,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    float const& default_value, float& value, std::pair<float, pcstr>* values, u32 const& value_count,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {

--- a/src/editors/xrWeatherEditor/property_holder_integer.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_integer.cpp
@@ -27,7 +27,7 @@ ref class property_integer_values_value;
 using Flobbster::Windows::Forms::PropertySpec;
 using System::String;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -39,7 +39,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, int& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -51,7 +51,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
     int const& min_value, int const& max_value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
@@ -64,7 +64,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, int& value, int const& min_value, int const& max_value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -76,9 +76,9 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
-    std::pair<int, LPCSTR>* values, u32 const& value_count, readonly_enum const& read_only,
+    std::pair<int, pcstr>* values, u32 const& value_count, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -90,8 +90,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    int const& default_value, int& value, std::pair<int, LPCSTR>* values, u32 const& value_count,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    int const& default_value, int& value, std::pair<int, pcstr>* values, u32 const& value_count,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -103,9 +103,9 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
-    LPCSTR const* values, u32 const& value_count, readonly_enum const& read_only,
+    pcstr const* values, u32 const& value_count, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -117,8 +117,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    int const& default_value, int& value, LPCSTR const* values, u32 const& value_count, readonly_enum const& read_only,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    int const& default_value, int& value, pcstr const* values, u32 const& value_count, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -130,7 +130,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, integer_getter_type const& getter, integer_setter_type const& setter,
     string_collection_getter_type const& values, string_collection_size_getter_type const& value_count,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
@@ -144,7 +144,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     int const& default_value, int& value, string_collection_getter_type const& values,
     string_collection_size_getter_type const& value_count, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,

--- a/src/editors/xrWeatherEditor/property_holder_string.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_string.cpp
@@ -35,8 +35,8 @@ using System::String;
 //				gcnew System::ComponentModel::ReadOnlyAttribute(true)
 //
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, string_getter_type const& getter, string_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -47,8 +47,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, shared_str& value, readonly_enum const& read_only,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, shared_str& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -59,9 +59,9 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter, LPCSTR default_extension,
-    LPCSTR file_mask, LPCSTR default_folder, LPCSTR caption, enter_text_enum const& can_enter_text,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, string_getter_type const& getter, string_setter_type const& setter, pcstr default_extension,
+    pcstr file_mask, pcstr default_folder, pcstr caption, enter_text_enum const& can_enter_text,
     extension_action_enum const& extension_action, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -77,9 +77,9 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, shared_str& value, LPCSTR default_extension, LPCSTR file_mask, LPCSTR default_folder,
-    LPCSTR caption, enter_text_enum const& can_enter_text, extension_action_enum const& extension_action,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, shared_str& value, pcstr default_extension, pcstr file_mask, pcstr default_folder,
+    pcstr caption, enter_text_enum const& can_enter_text, extension_action_enum const& extension_action,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
 {
@@ -94,8 +94,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter, LPCSTR const* values,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, string_getter_type const& getter, string_setter_type const& setter, pcstr const* values,
     u32 const& value_count, value_editor_enum const& value_editor, enter_text_enum const& can_enter_text,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -130,8 +130,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, shared_str& value, LPCSTR const* values, u32 const& value_count,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, shared_str& value, pcstr const* values, u32 const& value_count,
     value_editor_enum const& value_editor, enter_text_enum const& can_enter_text, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)
@@ -167,8 +167,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, string_getter_type const& getter, string_setter_type const& setter,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, string_getter_type const& getter, string_setter_type const& setter,
     string_collection_getter_type const& values, string_collection_size_getter_type const& value_count,
     value_editor_enum const& value_editor, enter_text_enum const& can_enter_text, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
@@ -204,8 +204,8 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
-    LPCSTR default_value, shared_str& value, string_collection_getter_type const& values,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
+    pcstr default_value, shared_str& value, string_collection_getter_type const& values,
     string_collection_size_getter_type const& value_count, value_editor_enum const& value_editor,
     enter_text_enum const& can_enter_text, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,

--- a/src/editors/xrWeatherEditor/property_holder_vec3f.cpp
+++ b/src/editors/xrWeatherEditor/property_holder_vec3f.cpp
@@ -17,7 +17,7 @@ ref class property_converter_vec3f;
 using Flobbster::Windows::Forms::PropertySpec;
 using System::String;
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     XRay::Editor::vec3f const& default_value, vec3f_getter_type const& getter, vec3f_setter_type const& setter,
     readonly_enum const& read_only, notify_parent_on_change_enum const& notify_parent,
     password_char_enum const& password, refresh_grid_on_change_enum const& refresh_grid)
@@ -30,7 +30,7 @@ XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, L
     return (nullptr);
 }
 
-XRay::Editor::property_value* property_holder::add_property(LPCSTR identifier, LPCSTR category, LPCSTR description,
+XRay::Editor::property_value* property_holder::add_property(pcstr identifier, pcstr category, pcstr description,
     XRay::Editor::vec3f const& default_value, XRay::Editor::vec3f& value, readonly_enum const& read_only,
     notify_parent_on_change_enum const& notify_parent, password_char_enum const& password,
     refresh_grid_on_change_enum const& refresh_grid)

--- a/src/editors/xrWeatherEditor/property_integer_enum_value.hpp
+++ b/src/editors/xrWeatherEditor/property_integer_enum_value.hpp
@@ -23,7 +23,7 @@ private:
     typedef property_integer inherited;
     typedef System::Collections::ArrayList collection_type;
     typedef System::Object Object;
-    typedef std::pair<int, LPCSTR> pair;
+    typedef std::pair<int, pcstr> pair;
 
 public:
     property_integer_enum_value(

--- a/src/editors/xrWeatherEditor/property_integer_enum_value_reference.hpp
+++ b/src/editors/xrWeatherEditor/property_integer_enum_value_reference.hpp
@@ -21,7 +21,7 @@ private:
     typedef property_integer_reference inherited;
     typedef System::Collections::ArrayList collection_type;
     typedef System::Object Object;
-    typedef std::pair<int, LPCSTR> pair;
+    typedef std::pair<int, pcstr> pair;
 
 public:
     property_integer_enum_value_reference(int& value, pair* values, u32 const& value_count);

--- a/src/editors/xrWeatherEditor/property_integer_values_value.cpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value.cpp
@@ -14,7 +14,7 @@ using System::Object;
 using System::Collections::IList;
 
 property_integer_values_value::property_integer_values_value(
-    integer_getter_type const& getter, integer_setter_type const& setter, LPCSTR const* values, u32 const& value_count)
+    integer_getter_type const& getter, integer_setter_type const& setter, pcstr const* values, u32 const& value_count)
     : inherited(getter, setter), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < value_count; ++i)

--- a/src/editors/xrWeatherEditor/property_integer_values_value.hpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value.hpp
@@ -27,7 +27,7 @@ private:
 
 public:
     property_integer_values_value(integer_getter_type const& getter, integer_setter_type const& setter,
-        LPCSTR const* values, u32 const& value_count);
+        pcstr const* values, u32 const& value_count);
     virtual Object ^ GetValue() override;
     virtual void SetValue(Object ^ object) override;
     virtual IList ^ collection();

--- a/src/editors/xrWeatherEditor/property_integer_values_value_getter.cpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value_getter.cpp
@@ -57,7 +57,7 @@ void property_integer_values_value_getter::SetValue(Object ^ object)
 IList ^ property_integer_values_value_getter::collection()
 {
     ArrayList ^ collection = gcnew ArrayList();
-    LPCSTR const* values = (*m_collection_getter)();
+    pcstr const* values = (*m_collection_getter)();
     for (u32 i = 0, n = (*m_collection_size_getter)(); i < n; ++i)
         collection->Add(to_string(values[i]));
 

--- a/src/editors/xrWeatherEditor/property_integer_values_value_reference.cpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value_reference.cpp
@@ -14,7 +14,7 @@ using System::Object;
 using System::Collections::IList;
 
 property_integer_values_value_reference::property_integer_values_value_reference(
-    int& value, LPCSTR const* values, u32 const& value_count)
+    int& value, pcstr const* values, u32 const& value_count)
     : inherited(value), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < value_count; ++i)

--- a/src/editors/xrWeatherEditor/property_integer_values_value_reference.hpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value_reference.hpp
@@ -23,7 +23,7 @@ private:
     typedef System::Collections::IList IList;
 
 public:
-    property_integer_values_value_reference(int& value, LPCSTR const* values, u32 const& value_count);
+    property_integer_values_value_reference(int& value, pcstr const* values, u32 const& value_count);
     virtual Object ^ GetValue() override;
     virtual void SetValue(Object ^ object) override;
     virtual IList ^ collection();

--- a/src/editors/xrWeatherEditor/property_integer_values_value_reference_getter.cpp
+++ b/src/editors/xrWeatherEditor/property_integer_values_value_reference_getter.cpp
@@ -57,7 +57,7 @@ void property_integer_values_value_reference_getter::SetValue(Object ^ object)
 IList ^ property_integer_values_value_reference_getter::collection()
 {
     ArrayList ^ collection = gcnew ArrayList();
-    LPCSTR const* values = (*m_collection_getter)();
+    pcstr const* values = (*m_collection_getter)();
     for (u32 i = 0, n = (*m_collection_size_getter)(); i < n; ++i)
         collection->Add(to_string(values[i]));
 

--- a/src/editors/xrWeatherEditor/property_string_values_value.cpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value.cpp
@@ -10,7 +10,7 @@
 #include "property_string_values_value.hpp"
 
 property_string_values_value::property_string_values_value(
-    string_getter_type const& getter, string_setter_type const& setter, LPCSTR const* values, u32 const& value_count)
+    string_getter_type const& getter, string_setter_type const& setter, pcstr const* values, u32 const& value_count)
     : inherited(getter, setter), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < value_count; ++i)

--- a/src/editors/xrWeatherEditor/property_string_values_value.hpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value.hpp
@@ -25,7 +25,7 @@ public:
 
 public:
     property_string_values_value(string_getter_type const& getter, string_setter_type const& setter,
-        LPCSTR const* values, u32 const& value_count);
+        pcstr const* values, u32 const& value_count);
 
     virtual collection_type ^ values() { return m_collection; };
 

--- a/src/editors/xrWeatherEditor/property_string_values_value_getter.cpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value_getter.cpp
@@ -32,7 +32,7 @@ property_string_values_value_getter::!property_string_values_value_getter()
 
 collection_type ^ property_string_values_value_getter::values()
 {
-    LPCSTR const* values = (*m_collection_getter)();
+    pcstr const* values = (*m_collection_getter)();
     collection_type ^ collection = gcnew collection_type();
     for (u32 i = 0, n = (*m_collection_size_getter)(); i < n; ++i)
         collection->Enqueue(to_string(values[i]));

--- a/src/editors/xrWeatherEditor/property_string_values_value_shared_str.cpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value_shared_str.cpp
@@ -10,7 +10,7 @@
 #include "property_string_values_value_shared_str.hpp"
 
 property_string_values_value_shared_str::property_string_values_value_shared_str(
-    XRay::Editor::engine_base* engine, shared_str& value, LPCSTR const* values, u32 const& value_count)
+    XRay::Editor::engine_base* engine, shared_str& value, pcstr const* values, u32 const& value_count)
     : inherited(engine, value), m_collection(gcnew collection_type())
 {
     for (u32 i = 0; i < value_count; ++i)

--- a/src/editors/xrWeatherEditor/property_string_values_value_shared_str.hpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value_shared_str.hpp
@@ -22,7 +22,7 @@ private:
 
 public:
     property_string_values_value_shared_str(
-        XRay::Editor::engine_base* engine, shared_str& value, LPCSTR const* values, u32 const& value_count);
+        XRay::Editor::engine_base* engine, shared_str& value, pcstr const* values, u32 const& value_count);
 
     virtual collection_type ^ values() { return m_collection; };
 

--- a/src/editors/xrWeatherEditor/property_string_values_value_shared_str_getter.cpp
+++ b/src/editors/xrWeatherEditor/property_string_values_value_shared_str_getter.cpp
@@ -32,7 +32,7 @@ property_string_values_value_shared_str_getter::!property_string_values_value_sh
 
 collection_type ^ property_string_values_value_shared_str_getter::values()
 {
-    LPCSTR const* values = (*m_collection_getter)();
+    pcstr const* values = (*m_collection_getter)();
     collection_type ^ collection = gcnew collection_type();
     for (u32 i = 0, n = (*m_collection_size_getter)(); i < n; ++i)
         collection->Enqueue(to_string(values[i]));

--- a/src/editors/xrWeatherEditor/window_weather_editor.cpp
+++ b/src/editors/xrWeatherEditor/window_weather_editor.cpp
@@ -123,11 +123,11 @@ void window_weather_editor::fill_weathers()
 
     WeathersComboBox->Items->Clear();
 
-    LPCSTR const* weathers_ids = (*m_weathers_getter)();
+    pcstr const* weathers_ids = (*m_weathers_getter)();
     for (u32 i = 0, n = (*m_weathers_size_getter)(); i < n; ++i)
         WeathersComboBox->Items->Add(to_string(weathers_ids[i]));
 
-    LPCSTR current_weather_id = m_engine.weather();
+    pcstr current_weather_id = m_engine.weather();
     int index = WeathersComboBox->Items->IndexOf(to_string(current_weather_id));
     if ((index == -1) && WeathersComboBox->Items->Count)
         index = 0;
@@ -142,11 +142,11 @@ void window_weather_editor::fill_weathers()
     fill_frames(current_weather_id);
 }
 
-void window_weather_editor::fill_frames(LPCSTR current_weather_id)
+void window_weather_editor::fill_frames(pcstr current_weather_id)
 {
     FramesComboBox->Items->Clear();
 
-    LPCSTR const* frames_ids = (*m_frames_getter)(current_weather_id);
+    pcstr const* frames_ids = (*m_frames_getter)(current_weather_id);
     for (u32 i = 0, n = (*m_frames_size_getter)(current_weather_id); i < n; ++i)
         FramesComboBox->Items->Add(to_string(frames_ids[i]));
 

--- a/src/editors/xrWeatherEditor/window_weather_editor.h
+++ b/src/editors/xrWeatherEditor/window_weather_editor.h
@@ -671,7 +671,7 @@ public:
     void fill_weathers();
 
 private:
-    void fill_frames(LPCSTR current_weather_id);
+    void fill_frames(pcstr current_weather_id);
     void update_frame();
     void save();
     void load();

--- a/src/editors/xrWeatherEngine/engine_impl.cpp
+++ b/src/editors/xrWeatherEngine/engine_impl.cpp
@@ -71,15 +71,15 @@ bool engine_impl::quit_requested() const
     return SDL_QuitRequested();
 }
 
-void engine_impl::value(LPCSTR value, shared_str& result) { result = value; }
-LPCSTR engine_impl::value(shared_str const& value) { return (value.c_str()); }
+void engine_impl::value(pcstr value, shared_str& result) { result = value; }
+pcstr engine_impl::value(shared_str const& value) { return (value.c_str()); }
 
 CEnvironment* engine_impl::environment()
 {
     return xr_new<editor::environment::manager>();
 }
 
-void engine_impl::weather(LPCSTR value)
+void engine_impl::weather(pcstr value)
 {
     if (!g_pGamePersistent)
         return;
@@ -101,7 +101,7 @@ void engine_impl::weather(LPCSTR value)
     g_pGamePersistent->Environment().SelectEnvs(game_time);
 }
 
-LPCSTR engine_impl::weather()
+pcstr engine_impl::weather()
 {
     if (!g_pGamePersistent)
         return ("");
@@ -109,7 +109,7 @@ LPCSTR engine_impl::weather()
     return (g_pGamePersistent->Environment().GetWeather().c_str());
 }
 
-void engine_impl::current_weather_frame(LPCSTR frame_id)
+void engine_impl::current_weather_frame(pcstr frame_id)
 {
     if (!g_pGamePersistent)
         return;
@@ -148,7 +148,7 @@ void engine_impl::current_weather_frame(LPCSTR frame_id)
         }
 }
 
-LPCSTR engine_impl::current_weather_frame()
+pcstr engine_impl::current_weather_frame()
 {
     if (!g_pGamePersistent)
         return ("");

--- a/src/editors/xrWeatherEngine/engine_impl.hpp
+++ b/src/editors/xrWeatherEngine/engine_impl.hpp
@@ -34,17 +34,17 @@ private:
     virtual void disconnect();
     bool quit_requested() const override;
 
-    virtual void value(LPCSTR value, shared_str& result);
-    virtual LPCSTR value(shared_str const& value);
+    virtual void value(pcstr value, shared_str& result);
+    virtual pcstr value(shared_str const& value);
 
     // manager
     CEnvironment* environment() override;
 
-    virtual void weather(LPCSTR value);
-    virtual LPCSTR weather();
+    virtual void weather(pcstr value);
+    virtual pcstr weather();
 
-    virtual void current_weather_frame(LPCSTR frame_id);
-    virtual LPCSTR current_weather_frame();
+    virtual void current_weather_frame(pcstr frame_id);
+    virtual pcstr current_weather_frame();
 
     virtual void track_frame(float const& time);
     virtual float track_frame();

--- a/src/editors/xrWeatherEngine/property_collection.hpp
+++ b/src/editors/xrWeatherEngine/property_collection.hpp
@@ -38,8 +38,8 @@ public:
     virtual property_holder* create();
 
 public:
-    bool unique_id(LPCSTR id) const;
-    shared_str generate_unique_id(LPCSTR prefix) const;
+    bool unique_id(pcstr id) const;
+    shared_str generate_unique_id(pcstr prefix) const;
 
 private:
     inline void make_state_changed();
@@ -56,9 +56,9 @@ private:
 private:
     struct unique_id_predicate
     {
-        LPCSTR m_id;
+        pcstr m_id;
 
-        inline unique_id_predicate(LPCSTR id);
+        inline unique_id_predicate(pcstr id);
         inline bool operator()(typename container_type::value_type const& value) const;
     };
 

--- a/src/editors/xrWeatherEngine/property_collection_inline.hpp
+++ b/src/editors/xrWeatherEngine/property_collection_inline.hpp
@@ -95,7 +95,7 @@ SPECIALIZATION
 void PROPERTY_COLLECTION::destroy(XRay::Editor::property_holder_base* holder) { delete_data(holder->holder()); }
 
 SPECIALIZATION
-inline PROPERTY_COLLECTION::unique_id_predicate::unique_id_predicate(LPCSTR id) : m_id(id) {}
+inline PROPERTY_COLLECTION::unique_id_predicate::unique_id_predicate(pcstr id) : m_id(id) {}
 
 SPECIALIZATION
 inline bool PROPERTY_COLLECTION::unique_id_predicate::operator()(typename container_type::value_type const& value) const
@@ -104,13 +104,13 @@ inline bool PROPERTY_COLLECTION::unique_id_predicate::operator()(typename contai
 }
 
 SPECIALIZATION
-bool PROPERTY_COLLECTION::unique_id(LPCSTR id) const
+bool PROPERTY_COLLECTION::unique_id(pcstr id) const
 {
     return (std::find_if(m_container.begin(), m_container.end(), unique_id_predicate(id)) == m_container.end());
 }
 
 SPECIALIZATION
-shared_str PROPERTY_COLLECTION::generate_unique_id(LPCSTR prefix) const
+shared_str PROPERTY_COLLECTION::generate_unique_id(pcstr prefix) const
 {
     for (u32 i = 0;; ++i)
     {


### PR DESCRIPTION
Fixes using LPCSTR to pcstr in src/editors