### PR TITLE
Поправил инициатора хита при коллизии

### DIFF
--- a/src/xrGame/PHCollisionDamageReceiver.cpp
+++ b/src/xrGame/PHCollisionDamageReceiver.cpp
@@ -50,7 +50,7 @@ void CPHCollisionDamageReceiver::CollisionHit(u16 source_id, u16 bone_id, float 
     SHit HS;
 
     HS.GenHeader(GE_HIT, ph->ID()); //	ph->u_EventGen(P,GE_HIT,ph->ID());
-    HS.whoID = ph->ID(); //	P.w_u16		(ph->ID());
+    HS.whoID = source_id; //	P.w_u16		(ph->ID());
     HS.weaponID = source_id; //	P.w_u16		(source_id);
     HS.dir = dir; //	P.w_dir		(dir);
     HS.power = power; //	P.w_float	(power);


### PR DESCRIPTION
Раньше иницитором хита при коллизии был сам объект (его id), а непосредственно инициатор (его id)  записывался в `weaponID`. Теперь id инициатора и `weaponID` будут id настоящего инициатора