### PR TITLE
Fix spawn loadouts for NPC

### DIFF
--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -43,10 +43,14 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         {
             // If level=<lname> then only spawn items if object on that level
             if (strstr(V, "level=") != nullptr)
+            {
                 if (strstr(V, lname) != nullptr)
                     OnlyOne.push_back(k);
+            }
             else
+            {
                 OnlyOne.push_back(k);
+            }
         }
 
         if (!OnlyOne.empty())


### PR DESCRIPTION
bugfix: If a loadout section will not contain `level=` property then weapon will not be spawned