### PR TITLE
[LuaJIT] LuaJIT garbage collection is now done by timeout (more stabl…

### DIFF
--- a/src/xrGame/Level.h
+++ b/src/xrGame/Level.h
@@ -71,6 +71,7 @@ public:
         CStatTimer Vis; // visibility detection - total
         CStatTimer VisQuery; // visibility detection - portal traversal and frustum culling
         CStatTimer VisRayTests; // visibility detection - ray casting
+        CStatTimer LuaGC; // LuaJIT Garbage collector
 
         AIStatistics() { FrameStart(); }
         void FrameStart()
@@ -82,6 +83,7 @@ public:
             Vis.FrameStart();
             VisQuery.FrameStart();
             VisRayTests.FrameStart();
+            LuaGC.FrameStart();
         }
 
         void FrameEnd()
@@ -93,6 +95,7 @@ public:
             Vis.FrameEnd();
             VisQuery.FrameEnd();
             VisRayTests.FrameEnd();
+            LuaGC.FrameEnd();
         }
     };
     AIStatistics AIStats;


### PR DESCRIPTION
По мотивам старых патчей на LuaJIT запилил сборщик мусора по таймауту. Всё, что остается сверху от 16 мс на кадр - отдается сборщику мусора. Получилось избавиться от пилорамы на графике FPS - теперь просадки стали почти неразличимы. К сожалению, на переход оффлайн->онлайн не повлияло, всё так же присутствует замирание. Зато во время боев значительно повысилась плавность прицеливания.