### PR TITLE
Reject item in active slot on death in TDM

### DIFF
--- a/src/xrGame/game_sv_teamdeathmatch.cpp
+++ b/src/xrGame/game_sv_teamdeathmatch.cpp
@@ -736,7 +736,7 @@ void game_sv_TeamDeathmatch::OnDetachItem(CSE_ActorMP* actor, CSE_Abstract* item
             DestroyGameItem(it);
 
         for (auto& it : to_reject)
-            DestroyGameItem(it);
+            RejectGameItem(it);
     }
 }
 


### PR DESCRIPTION
There is a mistake in commit 7c99022f47d32a1b6216466815551f1cfe88f700 in game_sv_teamdeathmatch.cpp file. When you die in TDM, your item in the active slot is destroyed, but it shouldn't be, according to Call of Pripyat multiplayer.