### PR TITLE
[xrRender] Fixed game crash when rendering wallmarks 

### DIFF
--- a/src/Layers/xrRender/WallmarksEngine.cpp
+++ b/src/Layers/xrRender/WallmarksEngine.cpp
@@ -31,7 +31,7 @@ struct wm_slot
 const float W_DIST_FADE = 15.f;
 const float W_DIST_FADE_SQR = W_DIST_FADE * W_DIST_FADE;
 const float I_DIST_FADE_SQR = 1.f / W_DIST_FADE_SQR;
-const int MAX_TRIS = 1024;
+const int MAX_TRIS = 1024*16; //Prevent crash when explode on burer
 
 IC bool operator==(const CWallmarksEngine::wm_slot* slot, const ref_shader& shader) { return slot->shader == shader; }
 CWallmarksEngine::wm_slot* CWallmarksEngine::FindSlot(const ref_shader& shader)


### PR DESCRIPTION
from an underbarrel grenade launcher (out-of-bounds vertex array)

Detected with adress saitizer. If you iterate over vertices, you go to the next vertex without checking its existence (just using a increment of a vertex pointer). This worked fine for bullet hits, but caused a crash when using a grenade launcher (maybe more bones are affected for rendering?). In any case, the blood spatters in bullet hits are drawn, and in case of grenade hits there is no point in even drawing them - they are completely overlapped by the effects of the explosion.