### PR TITLE
Attach fixed

### DIFF
--- a/src/Layers/xrRender/SkeletonRigid.cpp
+++ b/src/Layers/xrRender/SkeletonRigid.cpp
@@ -226,11 +226,13 @@ void CKinematics::Bone_GetAnimPos(Fmatrix& pos, u16 id, u8 mask_channel, bool ig
 {
     R_ASSERT(id < LL_BoneCount());
     CBoneInstance bi = LL_GetBoneInstance(id);
+    Fvector last_c = bi.mTransform.c;
     BoneChain_Calculate(&LL_GetData(id), bi, mask_channel, ignore_callbacks);
 #ifndef MASTER_GOLD
     R_ASSERT(_valid(bi.mTransform));
 #endif
     pos.set(bi.mTransform);
+    pos.c.set(last_c);
 }
 
 void CKinematics::Bone_Calculate(CBoneData* bd, Fmatrix* parent)

--- a/src/xrGame/attachment_owner.cpp
+++ b/src/xrGame/attachment_owner.cpp
@@ -69,8 +69,9 @@ void AttachmentCallback(IKinematics* tpKinematics)
     xr_vector<CAttachableItem*>::const_iterator E = attachment_owner->attached_objects().end();
     for (; I != E; ++I)
     {
-        (*I)->item().object().XFORM().mul_43(
-            kinematics->LL_GetBoneInstance((*I)->bone_id()).mTransform, (*I)->offset());
+        Fmatrix bone_mtx;
+        kinematics->Bone_GetAnimPos(bone_mtx, (*I)->bone_id(), u8(-1), false);
+        (*I)->item().object().XFORM().mul_43(bone_mtx, (*I)->offset());
         (*I)->item().object().XFORM().mulA_43(game_object->XFORM());
     }
 }


### PR DESCRIPTION
Поправил аттачи предметов (фонарика). Теперь присоединенные объекты будут "намертво" присоединены, без отставаний в движении и тд.
Использовать при необходимости, т. к. в цикле обновлений аттач объектов дополнительно рассчитывается матрица костей. Предполагаю внести данные правки под дефайн или в отдельную ветку.
Автор кода правки: @v2v3v4
Проверено - работает.