### PR TITLE
Fixed crash when trying to pass nil to `alife():release(...)`

### DIFF
--- a/src/xrGame/alife_simulator_script.cpp
+++ b/src/xrGame/alife_simulator_script.cpp
@@ -252,6 +252,9 @@ void CALifeSimulator__release(CALifeSimulator* self, CSE_Abstract* object, bool)
     //	self->release						(object,true);
 
     THROW(object);
+    if (!object)
+        return;
+
     CSE_ALifeObject* alife_object = smart_cast<CSE_ALifeObject*>(object);
     THROW(alife_object);
     if (!alife_object->m_bOnline)


### PR DESCRIPTION
Исправляет надоедливый вылет ещё с ванили.