### PR TITLE
Fixed: using %c[color] tag with multibyte font causing unexpected line ending

### DIFF
--- a/src/xrUICore/Lines/UILines.cpp
+++ b/src/xrUICore/Lines/UILines.cpp
@@ -121,7 +121,12 @@ void CUILines::ParseText(bool force)
                 {
                     bNewLines = TRUE;
                     *pszTemp = '\0';
-                    ptmp_line->AddSubLine(pszSearch, tcolor);
+                    CUISubLine subline;
+                    subline.m_text = pszSearch;
+                    subline.m_color = tcolor;
+                    subline.m_last_in_line = true;
+                    //ptmp_line->AddSubLine(pszSearch, tcolor);
+                    ptmp_line->AddSubLine(&subline);
                     pszSearch = pszTemp + 2;
                 }
                 ptmp_line->AddSubLine(pszSearch, tcolor);
@@ -163,8 +168,9 @@ void CUILines::ParseText(bool force)
         {
             for (int i = 0; i < vsz; i++)
             {
-                const char* pszText = line->m_subLines[i].m_text.c_str();
-                const u32 tcolor = line->m_subLines[i].m_color;
+                CUISubLine* pSubLine = &line->m_subLines[i];
+                const char* pszText = pSubLine->m_text.c_str();
+                const u32 tcolor = pSubLine->m_color;
                 u16 uFrom = 0, uPartLen = 0;
                 VERIFY(pszText);
                 u16 nMarkers = m_pFont->SplitByWidth(aMarkers, UBUFFER_SIZE, fTargetWidth, pszText);
@@ -185,8 +191,11 @@ void CUILines::ParseText(bool force)
                 }
                 strncpy_s(szTempLine, pszText + uFrom, MAX_MB_CHARS);
                 tmp_line.AddSubLine(szTempLine, tcolor);
-                m_lines.push_back(tmp_line);
-                tmp_line.Clear();
+                if (pSubLine->m_last_in_line || i == (vsz -1))
+                {
+                    m_lines.push_back(tmp_line);
+                    tmp_line.Clear();
+                }
             }
         }
     }


### PR DESCRIPTION
here's something useful :
https://github.com/themrdemonized/STALKER-Anomaly-modded-exes/issues/6
hope helps!

Before the patch:
![image](https://user-images.githubusercontent.com/2989212/227627741-d4f5b33d-aec1-48d2-b097-8519cc4030c7.png)

After the patch:
![image](https://user-images.githubusercontent.com/2989212/227627769-8594e3fb-b08e-425c-aee9-dd9356e76d7e.png)

Compare with English:
![image](https://user-images.githubusercontent.com/2989212/227627804-3431af44-e02d-4d6a-be08-b98788dd89c2.png)
