### PR TITLE
Fix incorrect display of the hotkey on the item icon in the multiplayer trade menu

### DIFF
--- a/src/xrGame/ui/UIMpTradeWnd_items.cpp
+++ b/src/xrGame/ui/UIMpTradeWnd_items.cpp
@@ -861,7 +861,7 @@ void CUICellItemTradeMenuDraw::OnDraw(CUICellItem* cell)
             acc = 1;
         string64 buff;
 
-        xr_sprintf(buff, " %d", acc - SDL_SCANCODE_ESCAPE);
+        xr_sprintf(buff, " %d", acc - SDL_SCANCODE_1 + 1); //записать в buf клавишу акселератор для cell
         CGameFont* pFont = UI().Font().pFontLetterica16Russian;
         pFont->SetAligment(CGameFont::alCenter);
         pFont->SetColor(color_rgba(135, 123, 116, 255));


### PR DESCRIPTION
Fix incorrect display of the hotkey on the item icon in the multiplayer trade menu
![image](https://user-images.githubusercontent.com/45823818/200141523-96e42a20-efad-4261-b1bc-eae9fdea277a.png)

Resovle #1127 issue
