### PR TITLE
Fixed use external gpu (maybe any Linux and Windows AMD/NVIDIA drivers)

### DIFF
--- a/src/xrEngine/main.cpp
+++ b/src/xrEngine/main.cpp
@@ -26,6 +26,12 @@
 
 #include "xrCore/Threading/TaskManager.hpp"
 
+extern "C"
+{
+__declspec(dllexport) DWORD NvOptimusEnablement = 1;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 // global variables
 ENGINE_API CInifile* pGameIni = nullptr;
 ENGINE_API bool g_bBenchmark = false;


### PR DESCRIPTION
@Xottab-DUTY,
Usage defined paramaters in drivers AMD and NVIDIA.
These parameters inform AMD and NVIDIA driver that it is necessary to use 'maximum performance' profile, which includes use discrete videocard in app.

### Tested on Ubuntu 22.04 Wayland