### PR TITLE
Layers/xrRender/ParticleGroup.h: use C++11 to initialize elements in the constructor

### DIFF
--- a/src/Layers/xrRender/ParticleGroup.cpp
+++ b/src/Layers/xrRender/ParticleGroup.cpp
@@ -483,9 +483,6 @@ u32 CParticleGroup::SItem::ParticlesCount()
 CParticleGroup::CParticleGroup()
 {
     m_RT_Flags.zero();
-    m_Def = nullptr;
-    m_CurrentTime = 0.f;
-    m_InitialPosition.set(0, 0, 0);
 }
 
 CParticleGroup::~CParticleGroup()

--- a/src/Layers/xrRender/ParticleGroup.cpp
+++ b/src/Layers/xrRender/ParticleGroup.cpp
@@ -483,6 +483,8 @@ u32 CParticleGroup::SItem::ParticlesCount()
 CParticleGroup::CParticleGroup()
 {
     m_RT_Flags.zero();
+    m_Def = nullptr;
+    m_CurrentTime = 0.f;
     m_InitialPosition.set(0, 0, 0);
 }
 

--- a/src/Layers/xrRender/ParticleGroup.h
+++ b/src/Layers/xrRender/ParticleGroup.h
@@ -73,8 +73,8 @@ public:
 class ECORE_API CParticleGroup : public dxParticleCustom
 {
     const CPGDef* m_Def{};
-    float m_CurrentTime;
-    Fvector m_InitialPosition;
+    float m_CurrentTime{};
+    Fvector m_InitialPosition{};
 
 public:
     using VisualVec = xr_vector<dxRender_Visual*>;

--- a/src/Layers/xrRender/ParticleGroup.h
+++ b/src/Layers/xrRender/ParticleGroup.h
@@ -72,7 +72,7 @@ public:
 
 class ECORE_API CParticleGroup : public dxParticleCustom
 {
-    const CPGDef* m_Def;
+    CPGDef* m_Def;
     float m_CurrentTime;
     Fvector m_InitialPosition;
 

--- a/src/Layers/xrRender/ParticleGroup.h
+++ b/src/Layers/xrRender/ParticleGroup.h
@@ -72,7 +72,7 @@ public:
 
 class ECORE_API CParticleGroup : public dxParticleCustom
 {
-    CPGDef* m_Def;
+    const CPGDef* m_Def{};
     float m_CurrentTime;
     Fvector m_InitialPosition;
 


### PR DESCRIPTION


![image](https://user-images.githubusercontent.com/21138600/209479924-ce24f6f6-45ad-4801-97af-1cf2d5c78e18.png)

Difference constructor classes with CParticleEffect

![image](https://user-images.githubusercontent.com/21138600/209479890-f4d76525-9b30-438f-888d-da4cd6200a1f.png)
