### PR TITLE
Fix 647 revised

### DIFF
--- a/cmake/FindTheora.cmake
+++ b/cmake/FindTheora.cmake
@@ -65,7 +65,7 @@ set(THEORAENC_NAMES theoraenc libtheoraenc)
 set(THEORAENC_NAMES_DEBUG theoraencd theoraenc_d theoraencD theoraenc_D)
 
 foreach(search ${_THEORA_SEARCHES})
-  find_path(THEORA_INCLUDE_DIR NAMES codec.h ${${search}} PATH_SUFFIXES theora)
+  find_path(THEORA_INCLUDE_DIR NAMES theora/theora.h ${${search}} PATH_SUFFIXES include)
 endforeach()
 
 # XXX: not sure if this is right. Check on macOS

--- a/src/Layers/xrRenderGL/glSH_Texture.cpp
+++ b/src/Layers/xrRenderGL/glSH_Texture.cpp
@@ -73,6 +73,13 @@ void CTexture::apply_load(u32 dwStage)
 
 void CTexture::apply_theora(u32 dwStage)
 {
+    GLenum err;
+    while((err = glGetError()) != GL_NO_ERROR)
+    {
+      // Process/log the error.
+      Msg("apply_theora entry Error: 0x%x", err);
+    }
+    
     CHK_GL(glActiveTexture(GL_TEXTURE0 + dwStage));
     CHK_GL(glBindTexture(desc, pSurface));
 
@@ -92,10 +99,17 @@ void CTexture::apply_theora(u32 dwStage)
         pTheora->DecompressFrame(pBits, 0, _pos);
         CHK_GL(glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER));
         CHK_GL(glTexSubImage2D(desc, 0, 0, 0, _w, _h, GL_BGRA, GL_UNSIGNED_BYTE, nullptr));
+        
+        err = glGetError();
+        if (err != GL_NO_ERROR)
+        {
+            Msg("apply_theora invalid glTexSubImage2D Error: 0x%x", err);
+        }
 
         // Unmap the buffer to restore normal texture functionality
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
     }
+    
 };
 
 void CTexture::apply_avi(u32 dwStage) const
@@ -111,6 +125,12 @@ void CTexture::apply_avi(u32 dwStage) const
         pAVI->GetFrame(&ptr);
         CHK_GL(glTexSubImage2D(desc, 0, 0, 0, m_width, m_height,
             GL_RGBA, GL_UNSIGNED_BYTE, ptr));
+        
+        GLenum err = glGetError();
+        if (err != GL_NO_ERROR)
+        {
+            Msg("apply_avi invalid glTexSubImage2D Error: 0x%x", err);
+        }    
     }
 #endif
 };
@@ -200,10 +220,14 @@ void CTexture::Load()
             glGenTextures(1, &pTexture);
             glBindTexture(GL_TEXTURE_2D, pTexture);
             CHK_GL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, _w, _h));
-
+            GLenum err = glGetError();
+            if (err != GL_NO_ERROR)
+            {
+                Msg("Load ogm Invalid glTexStorage2D: 0x%x", err);
+            }
             pSurface = pTexture;
             desc = GL_TEXTURE_2D;
-            GLenum err = glGetError();
+            err = glGetError();
             if (err != GL_NO_ERROR)
             {
                 Msg("Invalid video stream: 0x%x", err);
@@ -237,6 +261,12 @@ void CTexture::Load()
             glGenTextures(1, &pTexture);
             glBindTexture(GL_TEXTURE_2D, pTexture);
             CHK_GL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, pAVI->m_dwWidth, pAVI->m_dwHeight));
+            
+            GLenum err = glGetError();
+            if (err != GL_NO_ERROR)
+            {
+                Msg("Load avi Invalid glTexStorage2D: 0x%x", err);
+            }
 
             pSurface = pTexture;
             desc = GL_TEXTURE_2D;

--- a/src/Layers/xrRenderGL/glSH_Texture.cpp
+++ b/src/Layers/xrRenderGL/glSH_Texture.cpp
@@ -182,15 +182,6 @@ void CTexture::Load()
         }
         else
         {
-            // We need to flush all GL errors here.
-            // If we don't do this, we can have a false positive for the invalid
-            // video stream error below, resulting in a broken video.
-            GLenum err;
-            while((err = glGetError()) != GL_NO_ERROR)
-            {
-                // Do nothing as we don't know where the error originates.
-            }
-
             flags.MemoryUsage = pTheora->Width(true) * pTheora->Height(true) * 4;
             pTheora->Play(TRUE, Device.dwTimeContinual);
 
@@ -209,7 +200,7 @@ void CTexture::Load()
             CHK_GL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, _w, _h));
             pSurface = pTexture;
             desc = GL_TEXTURE_2D;
-            err = glGetError();
+            GLenum err = glGetError();
             if (err != GL_NO_ERROR)
             {
                 Msg("Invalid video stream: 0x%x", err);

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -175,10 +175,9 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
-                            err = glGetError();
-                            if(err !=GL_NO_ERROR)
+                            if((err = glGetError()) !=GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid compressed 2D sub texture: '%s' ", fname, err);
+                                Msg("Error: 0x%x: Invalid compressed 2D sub texture: '%s' ", err, fname);
                             }
                         }
                         else
@@ -187,10 +186,9 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
-                            err = glGetError();
-                            if(err !=GL_NO_ERROR)
+                            if((err = glGetError()) != GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid 2D sub texture: '%s'", fname, err);
+                                Msg("Error: 0x%x: Invalid 2D sub texture: '%s'", err, fname);
                             }
                         }
                         break;
@@ -204,8 +202,7 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
-                            err = glGetError();
-                            if(err != GL_NO_ERROR)
+                            if((err = glGetError()) != GL_NO_ERROR)
                             {
                                 Msg("Error: 0x%x: Invalid compressed 3D subtexture: '%s'", err, fname);
                             }             
@@ -216,8 +213,7 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
-                            err = glGetError();
-                            if(err !=GL_NO_ERROR)
+                            if((err = glGetError()) != GL_NO_ERROR)
                             {
                                 Msg("Error: 0x%x: Invalid 3D subtexture: '%s'", err, fname);
                             } 

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -82,7 +82,6 @@ GLuint CRender::texture_load(LPCSTR fRName, u32& ret_msize, GLenum& ret_desc)
     if (FS.exist(fn, "$game_saves$", fname, ".dds")) goto _DDS;
     if (FS.exist(fn, "$game_textures$", fname, ".dds")) goto _DDS;
 
-
 #ifdef _EDITOR
     ELog.Msg(mtError, "Can't find texture '%s'", fname);
     return 0;
@@ -109,7 +108,6 @@ _DDS:
         gli::texture texture = gli::load((char*)S->pointer(), img_size);
         R_ASSERT2(!texture.empty(), fn);
         
-        
         gli::gl GL(gli::gl::PROFILE_GL33);
 
         gli::gl::format const format = GL.translate(texture.format(), texture.swizzles());
@@ -126,26 +124,6 @@ _DDS:
 
         glm::tvec3<GLsizei> const tex_extent(texture.extent());
 
-        /*
-        switch (texture.target())
-        {
-        case gli::TARGET_2D:
-        case gli::TARGET_CUBE:
-            CHK_GL(glTexStorage2D(target, static_cast<GLint>(texture.levels()), format.Internal,
-                           tex_extent.x, tex_extent.y));
-            break;
-        case gli::TARGET_3D:
-        case gli::TARGET_CUBE_ARRAY:
-            CHK_GL(glTexStorage3D(target, static_cast<GLint>(texture.levels()),
-            format.Internal,
-                           tex_extent.x, tex_extent.y, tex_extent.z));
-            break;
-        default:
-            NODEFAULT;
-            break;
-        }
-        */
-        
         GLenum err;
         switch (texture.target())
         {
@@ -153,10 +131,9 @@ _DDS:
         case gli::TARGET_CUBE:
             CHK_GL(glTexStorage2D(target, static_cast<GLint>(texture.levels()), format.Internal,
                            tex_extent.x, tex_extent.y));
-            err = glGetError();
-            if(err !=GL_NO_ERROR)
+            if((err = glGetError()) != GL_NO_ERROR)
             {
-                Msg("Invalid 2D texture: %s Error: 0x%x", fname, err);
+                Msg("Error: 0x%x: Invalid 2D texture: %s", err, fname);
             }
             break;
         case gli::TARGET_3D:
@@ -164,10 +141,9 @@ _DDS:
             CHK_GL(glTexStorage3D(target, static_cast<GLint>(texture.levels()),
             format.Internal,
                            tex_extent.x, tex_extent.y, tex_extent.z));
-            err = glGetError();
-            if(err !=GL_NO_ERROR)
+            if((err = glGetError()) != GL_NO_ERROR)
             {
-                Msg("Invalid 3D texture: %s Error: 0x%x", fname, err);
+                Msg("Error: 0x%x: Invalid 3D texture: %s", err, fname);
             }
             break;
         default:
@@ -197,6 +173,10 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
+                            if((err = glGetError()) != GL_NO_ERROR)
+                            {
+                                Msg("Error: 0x%x: Invalid compressed 2D subtexture: %s", err, fname);
+                            }
                         }
                         else
                         {
@@ -204,6 +184,10 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
+                            if((err = glGetError()) != GL_NO_ERROR)
+                            {
+                                Msg("Error: 0x%x: Invalid 2D subtexture: %s", err, fname);
+                            }
                         }
                         break;
                     }
@@ -215,6 +199,10 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
+                            if((err = glGetError()) != GL_NO_ERROR)
+                            {
+                                Msg("Error: 0x%x: Invalid compressed 3D subtexture: %s", err, fname);
+                            }             
                         }
                         else
                         {
@@ -222,6 +210,10 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
+                            if((err = glGetError()) != GL_NO_ERROR)
+                            {
+                                Msg("Error: 0x%x: Invalid 3D subtexture: %s", err, fname);
+                            } 
                         }
                         break;
                     }
@@ -231,12 +223,6 @@ _DDS:
                     }
                 }
             }
-        }
-        
-        while((err = glGetError()) != GL_NO_ERROR)
-        {
-            // log OpenGL error.
-            Msg("Invalid texture: %s,  Error: 0x%x", fname, err);
         }
         
         FS.r_close(S);

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -173,9 +173,10 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
-                            if((err = glGetError()) != GL_NO_ERROR)
+                            err = glGetError();
+                            if(err !=GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid compressed 2D subtexture: %s", err, fname);
+                                Msg("Invalid compressed 2D sub texture: '%s' Error: 0x%x", fname, err);
                             }
                         }
                         else
@@ -184,14 +185,16 @@ _DDS:
                                         0, 0, tex_level_extent.x, tex_level_extent.y,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
-                            if((err = glGetError()) != GL_NO_ERROR)
+                            err = glGetError();
+                            if(err !=GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid 2D subtexture: %s", err, fname);
+                                Msg("Invalid 2D sub texture: '%s' Error: 0x%x", fname, err);
                             }
                         }
                         break;
                     }
                     case gli::TARGET_3D:
+                    case gli::TARGET_CUBE_ARRAY:
                     {
                         if (gli::is_compressed(texture.format()))
                         {
@@ -199,7 +202,8 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.Internal, static_cast<GLsizei>(texture.size(level)),
                                         texture.data(layer, face, level)));
-                            if((err = glGetError()) != GL_NO_ERROR)
+                            err = glGetError();
+                            if(err != GL_NO_ERROR)
                             {
                                 Msg("Error: 0x%x: Invalid compressed 3D subtexture: %s", err, fname);
                             }             
@@ -210,7 +214,8 @@ _DDS:
                                         0, 0, 0, tex_level_extent.x, tex_level_extent.y, tex_level_extent.z,
                                         format.External, format.Type,
                                         texture.data(layer, face, level)));
-                            if((err = glGetError()) != GL_NO_ERROR)
+                            err = glGetError();
+                            if(err !=GL_NO_ERROR)
                             {
                                 Msg("Error: 0x%x: Invalid 3D subtexture: %s", err, fname);
                             } 

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -131,9 +131,10 @@ _DDS:
         case gli::TARGET_CUBE:
             CHK_GL(glTexStorage2D(target, static_cast<GLint>(texture.levels()), format.Internal,
                            tex_extent.x, tex_extent.y));
-            if((err = glGetError()) != GL_NO_ERROR)
+            err = glGetError();
+            if(err != GL_NO_ERROR)
             {
-                Msg("Error: 0x%x: Invalid 2D texture: %s", err, fname);
+                Msg("Error: 0x%x: Invalid 2D texture: '%s'", err, fname);
             }
             break;
         case gli::TARGET_3D:
@@ -141,9 +142,10 @@ _DDS:
             CHK_GL(glTexStorage3D(target, static_cast<GLint>(texture.levels()),
             format.Internal,
                            tex_extent.x, tex_extent.y, tex_extent.z));
-            if((err = glGetError()) != GL_NO_ERROR)
+            err = glGetError();
+            if(err != GL_NO_ERROR)
             {
-                Msg("Error: 0x%x: Invalid 3D texture: %s", err, fname);
+                Msg("Error: 0x%x: Invalid 3D texture: '%s'", err, fname);
             }
             break;
         default:
@@ -176,7 +178,7 @@ _DDS:
                             err = glGetError();
                             if(err !=GL_NO_ERROR)
                             {
-                                Msg("Invalid compressed 2D sub texture: '%s' Error: 0x%x", fname, err);
+                                Msg("Error: 0x%x: Invalid compressed 2D sub texture: '%s' ", fname, err);
                             }
                         }
                         else
@@ -188,7 +190,7 @@ _DDS:
                             err = glGetError();
                             if(err !=GL_NO_ERROR)
                             {
-                                Msg("Invalid 2D sub texture: '%s' Error: 0x%x", fname, err);
+                                Msg("Error: 0x%x: Invalid 2D sub texture: '%s'", fname, err);
                             }
                         }
                         break;
@@ -205,7 +207,7 @@ _DDS:
                             err = glGetError();
                             if(err != GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid compressed 3D subtexture: %s", err, fname);
+                                Msg("Error: 0x%x: Invalid compressed 3D subtexture: '%s'", err, fname);
                             }             
                         }
                         else
@@ -217,7 +219,7 @@ _DDS:
                             err = glGetError();
                             if(err !=GL_NO_ERROR)
                             {
-                                Msg("Error: 0x%x: Invalid 3D subtexture: %s", err, fname);
+                                Msg("Error: 0x%x: Invalid 3D subtexture: '%s'", err, fname);
                             } 
                         }
                         break;


### PR DESCRIPTION
This code adds error checking for glTexStorage functions that were causing false positives on the error stack further down the code path on Linux. The errors are now outputted to the game log, allowing the error queue to be flushed and the theora video code to be loaded without any issues.

Note: There is still an uncaught error on MacOS however both green screen issues were not related to each other. This will be fixed in a further update once the error is correctly located and dealt with.