### PR TITLE
Added cubemap loading to texture storage

### DIFF
--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -141,6 +141,7 @@ _DDS:
             }
             break;
         case gli::TARGET_3D:
+        case gli::TARGET_CUBE_ARRAY:
             glTexStorage3D(target, static_cast<GLint>(texture.levels()), format.Internal,
                            tex_extent.x, tex_extent.y, tex_extent.z);
             err = glGetError();

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -202,6 +202,7 @@ _DDS:
                         break;
                     }
                     case gli::TARGET_3D:
+                    case gli::TARGET_CUBE_ARRAY:
                     {
                         if (gli::is_compressed(texture.format()))
                         {


### PR DESCRIPTION
Added a cubemap case statement for texture storage.

Cubemaps are good for skyboxes.

https://learnopengl.com/Advanced-OpenGL/Cubemaps