### PR TITLE
Allow to change color of upgrade icon by config.

### DIFF
--- a/src/xrGame/inventory_upgrade_property.cpp
+++ b/src/xrGame/inventory_upgrade_property.cpp
@@ -27,8 +27,7 @@ void Property::construct(shared_str const& property_id, Manager& manager_r)
 
     m_name = StringTable().translate(pSettings->r_string(id(), "name"));
     m_icon._set(pSettings->r_string(id(), "icon"));
-    Fvector3 color = READ_IF_EXISTS(pSettings, r_fvector3, id(), "color", Fvector3().set(255, 255, 255));
-    m_color = color_rgba(color.x, color.y, color.z, 255);
+    m_color = READ_IF_EXISTS(pSettings, r_color, id(), "color", color_rgba(255, 255, 255, 255));
 
     // functor
     LPCSTR functor_str = pSettings->r_string(id(), "functor");

--- a/src/xrGame/inventory_upgrade_property.cpp
+++ b/src/xrGame/inventory_upgrade_property.cpp
@@ -27,6 +27,8 @@ void Property::construct(shared_str const& property_id, Manager& manager_r)
 
     m_name = StringTable().translate(pSettings->r_string(id(), "name"));
     m_icon._set(pSettings->r_string(id(), "icon"));
+    Fvector3 color = READ_IF_EXISTS(pSettings, r_fvector3, id(), "color", Fvector3().set(255, 255, 255));
+    m_color = color_rgba(color.x, color.y, color.z, 255);
 
     // functor
     LPCSTR functor_str = pSettings->r_string(id(), "functor");

--- a/src/xrGame/inventory_upgrade_property.h
+++ b/src/xrGame/inventory_upgrade_property.h
@@ -31,6 +31,7 @@ public:
     IC shared_str const& id() const;
     IC LPCSTR id_str() const;
     IC LPCSTR icon_name() const;
+    IC u32    icon_color() const;
     IC LPCSTR name() const;
 
     IC FunctorParams_type const& functor_params() const;
@@ -43,6 +44,7 @@ protected:
 
     shared_str m_name;
     shared_str m_icon;
+    u32        m_color;
 
     StrFunctor m_desc;
     FunctorParams_type m_functor_params;

--- a/src/xrGame/inventory_upgrade_property_inline.h
+++ b/src/xrGame/inventory_upgrade_property_inline.h
@@ -16,6 +16,7 @@ namespace upgrade
 IC const shared_str& Property::id() const { return m_id; }
 IC LPCSTR Property::id_str() const { return m_id.c_str(); }
 IC LPCSTR Property::icon_name() const { return m_icon.c_str(); }
+IC u32    Property::icon_color() const { return m_color; }
 IC LPCSTR Property::name() const { return m_name.c_str(); }
 IC Property::FunctorParams_type const& Property::functor_params() const { return m_functor_params; }
 } // namespace upgrade

--- a/src/xrGame/ui/UIInvUpgradeProperty.cpp
+++ b/src/xrGame/ui/UIInvUpgradeProperty.cpp
@@ -47,6 +47,7 @@ bool UIProperty::init_property(shared_str const& property_id)
         return false;
     }
     m_ui_icon->InitTexture(get_property()->icon_name());
+    m_ui_icon->SetTextureColor(get_property()->icon_color());
     return true;
 }
 


### PR DESCRIPTION
In vanilla we have only color from a texture and it doesn't change.
![pic 1](https://user-images.githubusercontent.com/47980896/217556057-4136da68-1428-4150-ae95-30263e31be96.png)
![pic 2](https://user-images.githubusercontent.com/47980896/217556193-9b92534b-07c6-4d50-b8e4-9951f3c3ae9d.png)

I just added ability to change color by config. So, you can to use a white icon and colorize this by configs and XML.
![pic 3](https://user-images.githubusercontent.com/47980896/217556441-bf40422b-6b1a-425c-b318-9364df5378da.png)
![pic 4](https://user-images.githubusercontent.com/47980896/217556483-402ec510-4ee5-43ef-9b60-b8c3bd51487c.png)
Here is an example of using this:
```ini
[prop_scope_4x]
name     = st_prop_scope_4x
icon     = ui_wp_propery_09
functor  = inventory_upgrades.property_functor_b
params   = rpm, hit_impulse
color	 = 255, 0, 255
```
`color	 = 255, 0, 255`