### PR TITLE
Optional using of middle_color for UIProgressBar.

### DIFF
--- a/src/xrUICore/ProgressBar/UIProgressBar.cpp
+++ b/src/xrUICore/ProgressBar/UIProgressBar.cpp
@@ -11,6 +11,7 @@ CUIProgressBar::CUIProgressBar()
 
     m_bBackgroundPresent = false;
     m_bUseColor = false;
+    m_bUseMiddleColor = false;
     m_bUseGradient = true;
 
     AttachChild(&m_UIBackgroundItem);
@@ -61,7 +62,10 @@ void CUIProgressBar::UpdateProgressBar()
         if ( m_bUseGradient )
         {
             Fcolor curr;
-            curr.lerp(m_minColor, m_middleColor, m_maxColor, fCurrentLength);
+            if (m_bUseMiddleColor)
+                curr.lerp(m_minColor, m_middleColor, m_maxColor, fCurrentLength);
+            else
+                curr.lerp(m_minColor, m_maxColor, fCurrentLength);
             m_UIProgressItem.SetTextureColor(curr.get());
         }
         else

--- a/src/xrUICore/ProgressBar/UIProgressBar.h
+++ b/src/xrUICore/ProgressBar/UIProgressBar.h
@@ -33,6 +33,7 @@ protected:
 
 public:
     bool m_bUseColor;
+    bool m_bUseMiddleColor; // Hrust: optional middle color for CS/SoC compatibility, without middle color it doesn't looks correctly
     bool m_bUseGradient; //Alundaio: if false then use only solid color with m_maxColor
     Fcolor m_minColor;
     Fcolor m_middleColor;

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -527,7 +527,11 @@ bool CUIXmlInitBase::InitProgressBar(CUIXml& xml_doc, LPCSTR path, int index, CU
         pWnd->m_minColor = GetColor(xml_doc, buf, index, 0xff);
 
         strconcat(sizeof(buf), buf, path, ":middle_color");
-        pWnd->m_middleColor = GetColor(xml_doc, buf, index, 0xff);
+        if (xml_doc.NavigateToNode(buf, 0))
+        {
+            pWnd->m_middleColor = GetColor(xml_doc, buf, index, 0xff);
+            pWnd->m_bUseMiddleColor = true;
+        }
 
         strconcat(sizeof(buf), buf, path, ":max_color");
         pWnd->m_maxColor = GetColor(xml_doc, buf, index, 0xff);


### PR DESCRIPTION
Just compare these screenshots. Vanilla CoP, without `middle_color` in XML(top bar):
![image](https://user-images.githubusercontent.com/47980896/217790209-491c5dbf-cd30-44e9-a33d-5f0bacc63262.png)
That commit fixes that behaviour:
![image](https://user-images.githubusercontent.com/47980896/217791661-15e79424-53fd-4cbb-8693-5047d63a3031.png)

In CS/SoC mode we have a some problem, because `middle_color` was added only in CoP. Solved.