### PR TITLE
Replaced C format concat to modern C++ std::to_string()

### DIFF
--- a/src/Layers/xrRenderPC_GL/gl_rendertarget_build_textures.cpp
+++ b/src/Layers/xrRenderPC_GL/gl_rendertarget_build_textures.cpp
@@ -132,11 +132,10 @@ void CRenderTarget::build_textures()
         // Surfaces
         for (u32 it1 = 0; it1 < TEX_jitter_count - 1; it1++)
         {
-            string_path name;
-            xr_sprintf(name, "%s%d", r2_jitter, it1);
+            std::string name(r2_jitter + std::to_string(it1));
             CHK_GL(glBindTexture(GL_TEXTURE_2D, t_noise_surf[it1]));
             CHK_GL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8, TEX_jitter, TEX_jitter));
-            t_noise[it1] = RImplementation.Resources->_CreateTexture(name);
+            t_noise[it1] = RImplementation.Resources->_CreateTexture(name.c_str());
             t_noise[it1]->surface_set(GL_TEXTURE_2D, t_noise_surf[it1]);
         }
 
@@ -168,11 +167,10 @@ void CRenderTarget::build_textures()
 
         // generate HBAO jitter texture (last)
         int it = TEX_jitter_count - 1;
-        string_path name;
-        xr_sprintf(name, "%s%d", r2_jitter, it);
+        std::string name(r2_jitter + std::to_string(it));
         CHK_GL(glBindTexture(GL_TEXTURE_2D, t_noise_surf[it]));
         CHK_GL(glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA32F, TEX_jitter, TEX_jitter));
-        t_noise[it] = RImplementation.Resources->_CreateTexture(name);
+        t_noise[it] = RImplementation.Resources->_CreateTexture(name.c_str());
         t_noise[it]->surface_set(GL_TEXTURE_2D, t_noise_surf[it]);
 
         // Fill it,

--- a/src/Layers/xrRenderPC_GL/rgl_shaders.cpp
+++ b/src/Layers/xrRenderPC_GL/rgl_shaders.cpp
@@ -217,12 +217,12 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
     shader_name_holder sh_name;
 
     // Don't move these variables to lower scope!
-    string32 c_smapsize;
-    string32 c_gloss;
-    string32 c_sun_shafts;
-    string32 c_ssao;
-    string32 c_sun_quality;
-    string32 c_water_reflection;
+    std::string c_smapsize;
+    std::string c_gloss;
+    std::string c_sun_shafts;
+    std::string c_ssao;
+    std::string c_sun_quality;
+    std::string c_water_reflection;
 
     // TODO: OGL: Implement these parameters.
     UNUSED(pFunctionName);
@@ -239,9 +239,9 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
 
     // Shadow map size
     {
-        xr_itoa(m_SMAPSize, c_smapsize, 10);
-        options.add("SMAP_size", c_smapsize);
-        sh_name.append(c_smapsize);
+        c_smapsize = std::to_string(m_SMAPSize);
+        options.add("SMAP_size", c_smapsize.c_str());
+        sh_name.append(c_smapsize.c_str());
     }
 
     // FP16 Filter
@@ -282,8 +282,8 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
 
     // Force gloss
     {
-        xr_sprintf(c_gloss, "%f", o.forcegloss_v);
-        appendShaderOption(o.forcegloss, "FORCE_GLOSS", c_gloss);
+        c_gloss = std::to_string(o.forcegloss_v);
+        appendShaderOption(o.forcegloss, "FORCE_GLOSS", c_gloss.c_str());
     }
 
     // Force skinw
@@ -347,8 +347,8 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
     // Water reflections
     if (RImplementation.o.advancedpp && ps_r_water_reflection)
     {
-        xr_sprintf(c_water_reflection, "%d", ps_r_water_reflection);
-        options.add("SSR_QUALITY", c_water_reflection);
+        c_water_reflection = std::to_string(ps_r_water_reflection);
+        options.add("SSR_QUALITY", c_water_reflection.c_str());
         sh_name.append(ps_r_water_reflection);
         const bool sshHalfDepth = ps_r2_ls_flags_ext.test(R3FLAGEXT_SSR_HALF_DEPTH);
         appendShaderOption(sshHalfDepth, "SSR_HALF_DEPTH", "1");
@@ -375,8 +375,8 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
     // Sun shafts
     if (RImplementation.o.advancedpp && ps_r_sun_shafts)
     {
-        xr_sprintf(c_sun_shafts, "%d", ps_r_sun_shafts);
-        options.add("SUN_SHAFTS_QUALITY", c_sun_shafts);
+        c_sun_shafts = std::to_string(ps_r_sun_shafts);
+        options.add("SUN_SHAFTS_QUALITY", c_sun_shafts.c_str());
         sh_name.append(ps_r_sun_shafts);
     }
     else
@@ -384,8 +384,8 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
 
     if (RImplementation.o.advancedpp && ps_r_ssao)
     {
-        xr_sprintf(c_ssao, "%d", ps_r_ssao);
-        options.add("SSAO_QUALITY", c_ssao);
+        c_ssao = std::to_string(ps_r_ssao);
+        options.add("SSAO_QUALITY", c_ssao.c_str());
         sh_name.append(ps_r_ssao);
     }
     else
@@ -394,8 +394,8 @@ HRESULT CRender::shader_compile(pcstr name, IReader* fs, pcstr pFunctionName,
     // Sun quality
     if (RImplementation.o.advancedpp && ps_r_sun_quality)
     {
-        xr_sprintf(c_sun_quality, "%d", ps_r_sun_quality);
-        options.add("SUN_QUALITY", c_sun_quality);
+        c_sun_quality = std::to_string(ps_r_sun_quality);
+        options.add("SUN_QUALITY", c_sun_quality.c_str());
         sh_name.append(ps_r_sun_quality);
     }
     else

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_build_textures.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_build_textures.cpp
@@ -122,9 +122,8 @@ void CRenderTarget::build_textures()
 
         for (int it1 = 0; it1 < TEX_jitter_count - 1; it1++)
         {
-            string_path name;
-            xr_sprintf(name, "%s%d", r2_jitter, it1);
-            t_noise[it1] = RImplementation.Resources->_CreateTexture(name);
+            std::string name(r2_jitter + std::to_string(it1));
+            t_noise[it1] = RImplementation.Resources->_CreateTexture(name.c_str());
 
             R_CHK(D3DXCreateTexture(
                 HW.pDevice, TEX_jitter, TEX_jitter, 1, 0, D3DFMT_Q8W8V8U8, D3DPOOL_SYSTEMMEM, &temp_noise_surf[it1]));
@@ -200,9 +199,8 @@ void CRenderTarget::build_textures()
         HW.pDevice->UpdateTexture(temp_noise_surf[it], t_noise_surf[it]);
         _RELEASE(temp_noise_surf[it]);
         
-        string_path name;
-        xr_sprintf(name, "%s%d", r2_jitter, it);
-        t_noise[it] = RImplementation.Resources->_CreateTexture(name);
+        std::string name(r2_jitter + std::to_string(it));
+        t_noise[it] = RImplementation.Resources->_CreateTexture(name.c_str());
         t_noise[it]->surface_set(t_noise_surf[it]);
         _RELEASE(t_noise_surf[it]);
     }

--- a/src/Layers/xrRenderPC_R2/r2_shaders.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_shaders.cpp
@@ -104,22 +104,22 @@ HRESULT CRender::shader_compile(
     int def_it = 0;
     
     // Don't move these variables to lower scope!
-    string32 c_smapsize;
-    string32 c_gloss;
-    string32 c_sun_shafts;
-    string32 c_ssao;
-    string32 c_sun_quality;
+    std::string c_smapsize;
+    std::string c_gloss;
+    std::string c_sun_shafts;
+    std::string c_ssao;
+    std::string c_sun_quality;
 
     char sh_name[MAX_PATH] = "";
     u32 len = 0;
     // options
     {
-        xr_sprintf(c_smapsize, "%04d", u32(m_SMAPSize));
+        c_smapsize = std::to_string(m_SMAPSize);
         defines[def_it].Name = "SMAP_size";
-        defines[def_it].Definition = c_smapsize;
+        defines[def_it].Definition = c_smapsize.c_str();
         def_it++;
-        xr_strcat(sh_name, c_smapsize);
-        len += xr_strlen(c_smapsize);
+        xr_strcat(sh_name, c_smapsize.c_str());
+        len += c_smapsize.length();
     }
 
     if (o.fp16_filter)
@@ -232,9 +232,9 @@ HRESULT CRender::shader_compile(
 
     if (o.forcegloss)
     {
-        xr_sprintf(c_gloss, "%f", o.forcegloss_v);
+        c_gloss = std::to_string(o.forcegloss_v);
         defines[def_it].Name = "FORCE_GLOSS";
-        defines[def_it].Definition = c_gloss;
+        defines[def_it].Definition = c_gloss.c_str();
         def_it++;
     }
     sh_name[len] = '0' + char(o.forcegloss);
@@ -384,9 +384,9 @@ HRESULT CRender::shader_compile(
 
     if (RImplementation.o.advancedpp && ps_r_sun_shafts)
     {
-        xr_sprintf(c_sun_shafts, "%d", ps_r_sun_shafts);
+        c_sun_shafts = std::to_string(ps_r_sun_shafts);
         defines[def_it].Name = "SUN_SHAFTS_QUALITY";
-        defines[def_it].Definition = c_sun_shafts;
+        defines[def_it].Definition = c_sun_shafts.c_str();
         def_it++;
         sh_name[len] = '0' + char(ps_r_sun_shafts);
         ++len;
@@ -399,9 +399,9 @@ HRESULT CRender::shader_compile(
 
     if (RImplementation.o.advancedpp && ps_r_ssao)
     {
-        xr_sprintf(c_ssao, "%d", ps_r_ssao);
+        c_ssao = std::to_string(ps_r_ssao);
         defines[def_it].Name = "SSAO_QUALITY";
-        defines[def_it].Definition = c_ssao;
+        defines[def_it].Definition = c_ssao.c_str();
         def_it++;
         sh_name[len] = '0' + char(ps_r_ssao);
         ++len;
@@ -414,9 +414,9 @@ HRESULT CRender::shader_compile(
 
     if (RImplementation.o.advancedpp && ps_r_sun_quality)
     {
-        xr_sprintf(c_sun_quality, "%d", ps_r_sun_quality);
+        c_sun_quality = std::to_string(ps_r_sun_quality);
         defines[def_it].Name = "SUN_QUALITY";
-        defines[def_it].Definition = c_sun_quality;
+        defines[def_it].Definition = c_sun_quality.c_str();
         def_it++;
         sh_name[len] = '0' + char(ps_r_sun_quality);
         ++len;

--- a/src/Layers/xrRender_R2/r2_rendertarget.cpp
+++ b/src/Layers/xrRender_R2/r2_rendertarget.cpp
@@ -298,9 +298,8 @@ CRenderTarget::CRenderTarget()
         rt_Base.resize(HW.BackBufferCount);
         for (u32 i = 0; i < HW.BackBufferCount; i++)
         {
-            string32 temp;
-            xr_sprintf(temp, "%s%d", r2_RT_base, i);
-            rt_Base[i].create(temp, w, h, HW.Caps.fTarget, 1, { CRT::CreateBase });
+            std::string temp(r2_RT_base + std::to_string(i));
+            rt_Base[i].create(temp.c_str(), w, h, HW.Caps.fTarget, 1, { CRT::CreateBase });
         }
         rt_Base_Depth.create(r2_RT_base_depth, w, h, HW.Caps.fDepth, 1, { CRT::CreateBase });
 
@@ -707,9 +706,8 @@ CRenderTarget::CRenderTarget()
         // create pool
         for (u32 it = 0; it < HW.Caps.iGPUNum * 2; it++)
         {
-            string256 name;
-            xr_sprintf(name, "%s_%d", r2_RT_luminance_pool, it);
-            rt_LUM_pool[it].create(name, 1, 1, D3DFMT_R32F);
+            std::string name(r2_RT_luminance_pool + std::to_string(it));
+            rt_LUM_pool[it].create(name.c_str(), 1, 1, D3DFMT_R32F);
 #ifdef USE_DX9
             u_setrt(rt_LUM_pool[it], 0, 0, 0);
 #endif


### PR DESCRIPTION
@Xottab-DUTY, Implementation `std::to_string()` works faster with different types than `sprintf()`
Also, C++ standard requires use of it, readability and fixing code also becomes easier.

References:
https://www.zverovich.net/2020/06/13/fast-int-to-string-revisited.html