### PR TITLE
[Feature] optional console command to normalize mouse sens for weapons and upgrades

### DIFF
--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -110,6 +110,8 @@ int g_inv_highlight_equipped = 0;
 //-Alundaio
 
 int g_first_person_death = 0;
+int g_normalize_mouse_sens = 0;
+int g_normalize_upgrade_mouse_sens = 0;
 
 void register_mp_console_commands();
 //-----------------------------------------------------------
@@ -2121,6 +2123,8 @@ void CCC_RegisterCommands()
     CMD4(CCC_Integer, "g_inv_highlight_equipped", &g_inv_highlight_equipped, 0, 1);
     CMD4(CCC_Integer, "g_first_person_death", &g_first_person_death, 0, 1);
     CMD4(CCC_Integer, "g_unload_ammo_after_pick_up", &g_auto_ammo_unload, 0, 1);
+    CMD4(CCC_Integer, "g_normalize_mouse_sens", &g_normalize_mouse_sens, 0, 1);
+    CMD4(CCC_Integer, "g_normalize_upgrade_mouse_sens", &g_normalize_upgrade_mouse_sens, 0, 1);
 
     CMD1(CCC_CleanupTasks, "dbg_cleanup_tasks");
 

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -31,6 +31,7 @@
 constexpr pcstr INV_NAME_KEY = "inv_name";
 constexpr pcstr INV_NAME_SHORT_KEY = "inv_name_short";
 constexpr pcstr DESCRIPTION_KEY = "description";
+extern int g_normalize_mouse_sens;
 
 net_updateInvData* CInventoryItem::NetSync()
 {
@@ -86,8 +87,6 @@ CInventoryItem::~CInventoryItem()
     }
 #endif // #ifndef MASTER_GOLD
 }
-
-extern int g_normalize_mouse_sens;
 
 void CInventoryItem::Load(LPCSTR section)
 {

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -87,6 +87,8 @@ CInventoryItem::~CInventoryItem()
 #endif // #ifndef MASTER_GOLD
 }
 
+extern int g_normalize_mouse_sens;
+
 void CInventoryItem::Load(LPCSTR section)
 {
     CHitImmunity::LoadImmunities(pSettings->r_string(section, "immunities_sect"), pSettings);
@@ -125,7 +127,7 @@ void CInventoryItem::Load(LPCSTR section)
     {
         m_flags.set(FRuckDefault, pSettings->read_if_exists<bool>(section, "default_to_ruck", true));
         m_flags.set(FAllowSprint, pSettings->read_if_exists<bool>(section, "sprint_allowed", true));
-        m_fControlInertionFactor = pSettings->read_if_exists<float>(section, "control_inertion_factor", 1.0f);
+        m_fControlInertionFactor = g_normalize_mouse_sens ? 1.0f : pSettings->read_if_exists<float>(section, "control_inertion_factor", 1.0f);
     }
     m_icon_name = READ_IF_EXISTS(pSettings, r_string, section, "icon_name", NULL);
 }

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -155,6 +155,8 @@ void CInventoryItem::net_Spawn_install_upgrades(Upgrades_type saved_upgrades) //
 
 bool CInventoryItem::install_upgrade(LPCSTR section) { return install_upgrade_impl(section, false); }
 bool CInventoryItem::verify_upgrade(LPCSTR section) { return install_upgrade_impl(section, true); }
+
+extern int g_normalize_upgrade_mouse_sens;
 bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
 {
     bool result = process_if_exists(section, "cost", &CInifile::r_u32, m_cost, test);
@@ -179,8 +181,9 @@ bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
         }
         result |= result2;
 
-        result |=
-            process_if_exists(section, "control_inertion_factor", &CInifile::r_float, m_fControlInertionFactor, test);
+        if (!g_normalize_upgrade_mouse_sens)
+            result |=
+                process_if_exists(section, "control_inertion_factor", &CInifile::r_float, m_fControlInertionFactor, test);
     }
 
     pcstr str;

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -156,6 +156,7 @@ void CInventoryItem::net_Spawn_install_upgrades(Upgrades_type saved_upgrades) //
 bool CInventoryItem::install_upgrade(LPCSTR section) { return install_upgrade_impl(section, false); }
 bool CInventoryItem::verify_upgrade(LPCSTR section) { return install_upgrade_impl(section, true); }
 
+extern int g_normalize_mouse_sens;
 extern int g_normalize_upgrade_mouse_sens;
 bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
 {
@@ -184,6 +185,23 @@ bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
         if (!g_normalize_upgrade_mouse_sens)
             result |=
                 process_if_exists(section, "control_inertion_factor", &CInifile::r_float, m_fControlInertionFactor, test);
+
+        bool needsNormalizedUpgradeSens = g_normalize_mouse_sens && !g_normalize_upgrade_mouse_sens;
+        if (needsNormalizedUpgradeSens)
+        {
+            if (m_fControlInertionFactor < 0.f)
+            {
+                float upgr_factor = pSettings->read_if_exists<float>(section, "control_inertion_factor", 1.0f);
+                if (abs(upgr_factor) > 1)
+                    upgr_factor /= 4;
+                else if (abs(upgr_factor) >= 0.5)
+                    upgr_factor /= 3;
+                else if (abs(upgr_factor) > 0.1)
+                    upgr_factor /= 2;
+
+                m_fControlInertionFactor = 1.f + upgr_factor;
+            }
+        }
     }
 
     pcstr str;

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -200,6 +200,7 @@ bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
                     upgr_factor /= 2;
 
                 m_fControlInertionFactor = 1.f + upgr_factor;
+                clamp(m_fControlInertionFactor, 0.1f, 1.f);
             }
         }
     }

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -20,6 +20,9 @@
 #include "Level.h"
 #include "WeaponMagazinedWGrenade.h"
 
+extern int g_normalize_mouse_sens;
+extern int g_normalize_upgrade_mouse_sens;
+
 bool CInventoryItem::has_upgrade_group(const shared_str& upgrade_group_id)
 {
     auto it = m_upgrades.cbegin();
@@ -156,8 +159,6 @@ void CInventoryItem::net_Spawn_install_upgrades(Upgrades_type saved_upgrades) //
 bool CInventoryItem::install_upgrade(LPCSTR section) { return install_upgrade_impl(section, false); }
 bool CInventoryItem::verify_upgrade(LPCSTR section) { return install_upgrade_impl(section, true); }
 
-extern int g_normalize_mouse_sens;
-extern int g_normalize_upgrade_mouse_sens;
 bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
 {
     bool result = process_if_exists(section, "cost", &CInifile::r_u32, m_cost, test);
@@ -183,10 +184,11 @@ bool CInventoryItem::install_upgrade_impl(LPCSTR section, bool test)
         result |= result2;
 
         if (!g_normalize_upgrade_mouse_sens)
-            result |=
-                process_if_exists(section, "control_inertion_factor", &CInifile::r_float, m_fControlInertionFactor, test);
+        {
+            result |= process_if_exists(section, "control_inertion_factor", &CInifile::r_float, m_fControlInertionFactor, test);
+        }
 
-        bool needsNormalizedUpgradeSens = g_normalize_mouse_sens && !g_normalize_upgrade_mouse_sens;
+        const bool needsNormalizedUpgradeSens = g_normalize_mouse_sens && !g_normalize_upgrade_mouse_sens;
         if (needsNormalizedUpgradeSens)
         {
             if (m_fControlInertionFactor < 0.f)


### PR DESCRIPTION
**g_normalize_mouse_sens (0, 1)**
If set to 1, all weapons will have the same mouse sensitivity; upgrades will still modify sensitivity (scaled down to avoid negative sensitivity).

**g_normalize_upgrade_mouse_sens (0, 1)**
If set to 1, upgrades will not effect mouse sensitivity.