### PR TITLE
Added  -DMEMORY_ALLOCATOR=standard flag

### DIFF
--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -27,9 +27,11 @@ build() {
 #  rm -f -R bin
    mkdir -p bin
    cd bin
-   cmake .. -DCMAKE_BUILD_TYPE=Release \
+   cmake .. \
+   -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=/usr \
-   -DCMAKE_INSTALL_LIBDIR=lib
+   -DCMAKE_INSTALL_LIBDIR=lib \
+   -DMEMORY_ALLOCATOR=standard
    make
 }
 


### PR DESCRIPTION
Due to failing mimalloc let cmake use  -DMEMORY_ALLOCATOR=standard