### PR TITLE
Re-fix resource linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_PDB_OUTPUT_DIRECTORY ${COMPILE_OUTPUT_FOLDER})
 set(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY ${COMPILE_OUTPUT_FOLDER})
 
 # Set the shared object search path for the installation
-set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_FULL_LIBDIR})
 
 # Set the shared object search path for the build tree
 # On Linux/BSD we can use $ORIGIN to search for modules next to the executable

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -853,24 +853,45 @@ void CLocatorAPI::setup_fs_path(pcstr fs_name)
                 pref_path = SDL_GetPrefPath("GSC Game World", "S.T.A.L.K.E.R. - Call of Pripyat");
 
             /* A final decision must be made regarding the changed resources. Since only OpenGL shaders remain mandatory for Linux for the entire trilogy,
-             * I propose adding shaders from /usr/share/openxray/gamedata/shaders so that we remove unnecessary questions from users who want to start
+             * I propose adding shaders from <CMAKE_INSTALL_FULL_DATAROOTDIR>/openxray/gamedata/shaders so that we remove unnecessary questions from users who want to start
              * the game using resources not from the proposed ~/.local/share/GSC Game World/Game in this case, this section of code can be safely removed */
             chdir(pref_path);
-            string_path tmp;
+            constexpr pcstr install_dir = MACRO_TO_STRING(CMAKE_INSTALL_FULL_DATAROOTDIR);
+            string_path tmp, tmp_link;
             xr_sprintf(tmp, "%sfsgame.ltx", pref_path);
             struct stat statbuf;
             ZeroMemory(&statbuf, sizeof(statbuf));
-            int res = lstat(tmp, &statbuf);
-            if (-1 == res || !S_ISLNK(statbuf.st_mode))
-                symlink("/usr/share/openxray/fsgame.ltx", tmp);
+            /* First check if following symlinks returns success.
+             * If it doesn't, additionally check if not following symlinks is successful (catches symlink itself being broken),
+             * -> delete the symlink if it is broken.
+             * Then, make a new symlink to our resources.
+             * TODO This doesn't account for other stat errors (EACCES, ENAMETOOLONG, ENOENT caused by missing path component) */
+            int res = stat(tmp, &statbuf);
+            if (res != 0)
+            {
+                ZeroMemory(&statbuf, sizeof(statbuf));
+                res = lstat(tmp, &statbuf);
+                if (res == 0)
+                    xr_unlink(tmp);
+                xr_sprintf(tmp_link, "%s/openxray/fsgame.ltx", install_dir);
+                symlink(tmp_link, tmp);
+            }
             xr_sprintf(tmp, "%sgamedata/shaders/gl", pref_path);
             ZeroMemory(&statbuf, sizeof(statbuf));
-            res = lstat(tmp, &statbuf);
-            if (-1 == res || !S_ISLNK(statbuf.st_mode))
+            res = stat(tmp, &statbuf);
+            if (res != 0)
             {
-                mkdir("gamedata", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-                mkdir("gamedata/shaders", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-                symlink("/usr/share/openxray/gamedata/shaders/gl", tmp);
+                ZeroMemory(&statbuf, sizeof(statbuf));
+                res = lstat(tmp, &statbuf);
+                if (res == 0)
+                    xr_unlink(tmp);
+                else
+                {
+                    mkdir("gamedata", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+                    mkdir("gamedata/shaders", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+                }
+                xr_sprintf(tmp_link, "%s/openxray/gamedata/shaders/gl", install_dir);
+                symlink(tmp_link, tmp);
             }
 
             SDL_strlcpy(full_current_directory, pref_path, sizeof full_current_directory);


### PR DESCRIPTION
Some corrections to #739:

1. `CMAKE_INSTALL_RPATH` is concatenated from `CMAKE_INSTALL_PREFIX` variable and `/lib`. This should instead use the `CMAKE_INSTALL_FULL_LIBDIR` variable.
2. Re-apply the resource linking fixes from #798, which seem to have been unintentionally dropped in a merge conflict resolve.
  (recap: Use `CMAKE_INSTALL_FULL_DATAROOTDIR` instead of hardcoding `/usr/share`, detect & replace bad symlinks)

1\. is untested but seems correct to me. 2. was previously merged, I've just re-applied the changes with some minimal changes.

Fixes #1298.