### PR TITLE
xrRender: optimizations and speedup (1/3)

### DIFF
--- a/src/Include/xrRender/RenderVisual.h
+++ b/src/Include/xrRender/RenderVisual.h
@@ -12,7 +12,7 @@ class IRenderVisual
 public:
     virtual ~IRenderVisual() { ; }
     virtual vis_data& getVisData() = 0;
-    virtual u32 getType() = 0;
+    virtual u32 getType() const = 0;
 
 #ifdef DEBUG
     virtual shared_str getDebugName() = 0;

--- a/src/Layers/xrRender/D3DXRenderBase.h
+++ b/src/Layers/xrRender/D3DXRenderBase.h
@@ -65,7 +65,7 @@ public:
     enum
     {
         eRDSG_MAIN, // shadred with forward
-#if 0//RENDER != R_R1
+#if RENDER != R_R1
         eRDSG_RAIN,
         eRDSG_SHADOW_0, // cascade#0 or shadowed light use
         eRDSG_SHADOW_1, // cascade#1 or shadowed light use

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -77,7 +77,7 @@ public:
     //	virtual IParticleCustom*	dcast_ParticleCustom		()				{ return 0;	}
 
     virtual vis_data& getVisData() { return vis; }
-    virtual u32 getType() { return Type; }
+    u32 getType() const override { return Type; }
     dxRender_Visual();
     virtual ~dxRender_Visual();
 };

--- a/src/Layers/xrRender/FBasicVisual.h
+++ b/src/Layers/xrRender/FBasicVisual.h
@@ -65,7 +65,7 @@ public:
     vis_data vis; // visibility-data
     ref_shader shader; // pipe state, shared
 
-    virtual void Render(float /*LOD*/) {} // LOD - Level Of Detail  [0..1], Ignored
+    virtual void Render(float /*LOD*/, bool use_fast_geo) {} // LOD - Level Of Detail  [0..1], Ignored
     virtual void Load(const char* N, IReader* data, u32 dwFlags);
     virtual void Release(); // Shared memory release
     virtual void Copy(dxRender_Visual* from);

--- a/src/Layers/xrRender/FLOD.cpp
+++ b/src/Layers/xrRender/FLOD.cpp
@@ -80,7 +80,7 @@ void FLOD::Copy(dxRender_Visual* pFrom)
     lod_factor = F->lod_factor;
     CopyMemory(facets, F->facets, sizeof(facets));
 }
-void FLOD::Render(float /*LOD*/)
+void FLOD::Render(float /*LOD*/, bool use_fast_geo)
 {
     /*
     Fvector				Ldir;

--- a/src/Layers/xrRender/FLOD.h
+++ b/src/Layers/xrRender/FLOD.h
@@ -36,7 +36,7 @@ public:
     float lod_factor;
 
 public:
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
 };

--- a/src/Layers/xrRender/FProgressive.cpp
+++ b/src/Layers/xrRender/FProgressive.cpp
@@ -65,10 +65,10 @@ void FProgressive::Load(const char* N, IReader* data, u32 dwFlags)
 #endif
 }
 
-void FProgressive::Render(float LOD)
+void FProgressive::Render(float LOD, bool use_fast_geo)
 {
 #if RENDER != R_R1
-    if (m_fast && RImplementation.active_phase() == CRender::PHASE_SMAP)
+    if (m_fast && use_fast_geo)
     {
         int lod_id = iFloor((1.f - clampr(LOD, 0.f, 1.f)) * float(xSWI->count - 1) + 0.5f);
         VERIFY(lod_id >= 0 && lod_id < int(xSWI->count));

--- a/src/Layers/xrRender/FProgressive.h
+++ b/src/Layers/xrRender/FProgressive.h
@@ -19,7 +19,7 @@ protected:
 public:
     FProgressive();
     virtual ~FProgressive();
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], -1 = Ignored
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], -1 = Ignored
     virtual void Load(const char* N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();

--- a/src/Layers/xrRender/FSkinned.cpp
+++ b/src/Layers/xrRender/FSkinned.cpp
@@ -37,7 +37,7 @@ void CSkeletonX_ST::Copy(dxRender_Visual* P)
     _Copy((CSkeletonX*)X);
 }
 //////////////////////////////////////////////////////////////////////
-void CSkeletonX_PM::Render(float LOD)
+void CSkeletonX_PM::Render(float LOD, bool use_fast_geo)
 {
     int lod_id = inherited1::last_lod;
     if (LOD >= 0.f)
@@ -50,7 +50,7 @@ void CSkeletonX_PM::Render(float LOD)
     FSlideWindow& SW = nSWI.sw[lod_id];
     _Render(rm_geom, SW.num_verts, SW.offset, SW.num_tris);
 }
-void CSkeletonX_ST::Render(float /*LOD*/) { _Render(rm_geom, vCount, 0, dwPrimitives); }
+void CSkeletonX_ST::Render(float /*LOD*/, bool use_fast_geo) { _Render(rm_geom, vCount, 0, dwPrimitives); }
 //////////////////////////////////////////////////////////////////////
 void CSkeletonX_PM::Release() { inherited1::Release(); }
 void CSkeletonX_ST::Release() { inherited1::Release(); }

--- a/src/Layers/xrRender/FSkinned.h
+++ b/src/Layers/xrRender/FSkinned.h
@@ -42,7 +42,7 @@ class CSkeletonX_ST : public Fvisual, public CSkeletonX_ext
 public:
     CSkeletonX_ST() {}
     virtual ~CSkeletonX_ST() {}
-    virtual void Render(float LOD);
+    virtual void Render(float LOD, bool use_fast_geo) override;
     virtual void Load(const char* N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();
@@ -66,7 +66,7 @@ class CSkeletonX_PM : public FProgressive, public CSkeletonX_ext
 public:
     CSkeletonX_PM() {}
     virtual ~CSkeletonX_PM() {}
-    virtual void Render(float LOD);
+    virtual void Render(float LOD, bool use_fast_geo) override;
     virtual void Load(const char* N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();

--- a/src/Layers/xrRender/FTreeVisual.cpp
+++ b/src/Layers/xrRender/FTreeVisual.cpp
@@ -115,7 +115,7 @@ struct FTreeVisual_setup
     }
 };
 
-void FTreeVisual::Render(float /*LOD*/)
+void FTreeVisual::Render(float /*LOD*/, bool use_fast_geo)
 {
     static FTreeVisual_setup tvs;
     if (tvs.dwFrame != Device.dwFrame)
@@ -177,9 +177,9 @@ FTreeVisual_ST::FTreeVisual_ST(void) {}
 FTreeVisual_ST::~FTreeVisual_ST(void) {}
 void FTreeVisual_ST::Release() { inherited::Release(); }
 void FTreeVisual_ST::Load(const char* N, IReader* data, u32 dwFlags) { inherited::Load(N, data, dwFlags); }
-void FTreeVisual_ST::Render(float LOD)
+void FTreeVisual_ST::Render(float LOD, bool use_fast_geo)
 {
-    inherited::Render(LOD);
+    inherited::Render(LOD, use_fast_geo);
     RCache.set_Geometry(rm_geom);
     RCache.Render(D3DPT_TRIANGLELIST, vBase, 0, vCount, iBase, dwPrimitives);
     RCache.stat.r.s_flora.add(vCount);
@@ -204,9 +204,9 @@ void FTreeVisual_PM::Load(const char* N, IReader* data, u32 dwFlags)
         pSWI = RImplementation.getSWI(ID);
     }
 }
-void FTreeVisual_PM::Render(float LOD)
+void FTreeVisual_PM::Render(float LOD, bool use_fast_geo)
 {
-    inherited::Render(LOD);
+    inherited::Render(LOD, use_fast_geo);
     int lod_id = last_lod;
     if (LOD >= 0.f)
     {

--- a/src/Layers/xrRender/FTreeVisual.h
+++ b/src/Layers/xrRender/FTreeVisual.h
@@ -21,7 +21,7 @@ protected:
     Fmatrix xform;
 
 public:
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();
@@ -38,7 +38,7 @@ public:
     FTreeVisual_ST(void);
     virtual ~FTreeVisual_ST(void);
 
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();
@@ -60,7 +60,7 @@ public:
     FTreeVisual_PM(void);
     virtual ~FTreeVisual_PM(void);
 
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();

--- a/src/Layers/xrRender/FVisual.cpp
+++ b/src/Layers/xrRender/FVisual.cpp
@@ -166,13 +166,13 @@ void Fvisual::Load(const char* N, IReader* data, u32 dwFlags)
         rm_geom.create(vFormat, *p_rm_Vertices, *p_rm_Indices);
 }
 
-void Fvisual::Render(float)
+void Fvisual::Render(float, bool use_fast_geo)
 {
 #if RENDER == R_R1
     if (m_fast && ps_r1_force_geomx)
 #else
     if (m_fast &&
-        (ps_r1_force_geomx || RImplementation.active_phase() == CRender::PHASE_SMAP && !RCache.is_TessEnabled()))
+        (ps_r1_force_geomx || use_fast_geo && !RCache.is_TessEnabled()))
 #endif
     {
         RCache.set_Geometry(m_fast->rm_geom);

--- a/src/Layers/xrRender/FVisual.h
+++ b/src/Layers/xrRender/FVisual.h
@@ -17,7 +17,7 @@ public:
     IRender_Mesh* m_fast;
 
 public:
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();

--- a/src/Layers/xrRender/LightTrack.cpp
+++ b/src/Layers/xrRender/LightTrack.cpp
@@ -451,14 +451,15 @@ void CROS_impl::prepare_lights(Fvector& position, IRenderable* O)
         // Select nearest lights
         Fvector bb_size = {radius, radius, radius};
 
+        static xr_vector<ISpatial*> lstSpatial;
 #if RENDER != R_R1
-        g_SpatialSpace->q_box(RImplementation.dsgraph.lstSpatial, 0, STYPE_LIGHTSOURCEHEMI, position, bb_size);
+        g_SpatialSpace->q_box(lstSpatial, 0, STYPE_LIGHTSOURCEHEMI, position, bb_size);
 #else
-        g_SpatialSpace->q_box(RImplementation.dsgraph.lstSpatial, 0, STYPE_LIGHTSOURCE, position, bb_size);
+        g_SpatialSpace->q_box(lstSpatial, 0, STYPE_LIGHTSOURCE, position, bb_size);
 #endif
-        for (u32 o_it = 0; o_it < RImplementation.dsgraph.lstSpatial.size(); o_it++)
+        for (u32 o_it = 0; o_it < lstSpatial.size(); o_it++)
         {
-            ISpatial* spatial = RImplementation.dsgraph.lstSpatial[o_it];
+            ISpatial* spatial = lstSpatial[o_it];
             light* source = (light*)(spatial->dcast_Light());
             VERIFY(source); // sanity check
             float R = radius + source->range;

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -642,7 +642,7 @@ void CParticleEffect::ParticleRenderStream(FVF::LIT* pv, u32 count, PAPI::Partic
     }
 }
 
-void CParticleEffect::Render(float)
+void CParticleEffect::Render(float, bool use_fast_geo)
 {
 #ifdef _GPA_ENABLED
     TAL_SCOPED_TASK_NAMED("CParticleEffect::Render()");
@@ -728,7 +728,7 @@ IC void FillSprite(FVF::LIT*& pv, const Fvector& pos, const Fvector& dir, const 
 }
 
 extern ENGINE_API float psHUD_FOV;
-void CParticleEffect::Render(float)
+void CParticleEffect::Render(float, bool)
 {
     u32 dwOffset, dwCount;
     // Get a pointer to the particles in gp memory

--- a/src/Layers/xrRender/ParticleEffect.h
+++ b/src/Layers/xrRender/ParticleEffect.h
@@ -57,7 +57,7 @@ public:
     void OnFrame(u32 dt);
 
     u32 RenderTO();
-    virtual void Render(float LOD);
+    virtual void Render(float LOD, bool use_fast_geo) override;
 
 private:
     void ParticleRenderStream(FVF::LIT* pv, u32 count, PAPI::Particle* particles);

--- a/src/Layers/xrRender/WallmarksEngine.cpp
+++ b/src/Layers/xrRender/WallmarksEngine.cpp
@@ -306,9 +306,6 @@ void CWallmarksEngine::AddStaticWallmark(
 void CWallmarksEngine::AddSkeletonWallmark(
     const Fmatrix* xf, CKinematics* obj, ref_shader& sh, const Fvector& start, const Fvector& dir, float size)
 {
-    if (::RImplementation.active_phase() != CRender::PHASE_NORMAL)
-        return;
-
     // optimization cheat: don't allow wallmarks more than 50 m from viewer/actor
     // XXX: Make console command for this
     if (xf->c.distance_to_sqr(Device.vCameraPosition) > _sqr(50.f))
@@ -322,9 +319,6 @@ void CWallmarksEngine::AddSkeletonWallmark(
 
 void CWallmarksEngine::AddSkeletonWallmark(intrusive_ptr<CSkeletonWallmark> wm)
 {
-    if (::RImplementation.active_phase() != CRender::PHASE_NORMAL)
-        return;
-
     lock.Enter();
     // search if similar wallmark exists
     wm_slot* slot = FindSlot(wm->Shader());
@@ -364,7 +358,7 @@ ICF u32 FlushStream(
     return w_count / 3;
 }
 
-void CWallmarksEngine::Render()
+void CWallmarksEngine::Render(u32 context_id)
 {
     //	if (marks.empty())			return;
     // Projection and xform
@@ -488,7 +482,8 @@ void CWallmarksEngine::Render()
     lock.Leave(); // Physics may add wallmarks in parallel with rendering
 
     // Level-wmarks
-    RImplementation.dsgraph.render_wmarks();
+    auto& dsgraph = RImplementation.get_context(context_id);
+    dsgraph.render_wmarks();
     RImplementation.BasicStats.Wallmarks.End();
 
     // Projection

--- a/src/Layers/xrRender/WallmarksEngine.cpp
+++ b/src/Layers/xrRender/WallmarksEngine.cpp
@@ -358,7 +358,7 @@ ICF u32 FlushStream(
     return w_count / 3;
 }
 
-void CWallmarksEngine::Render(u32 context_id)
+void CWallmarksEngine::Render()
 {
     //	if (marks.empty())			return;
     // Projection and xform
@@ -482,7 +482,7 @@ void CWallmarksEngine::Render(u32 context_id)
     lock.Leave(); // Physics may add wallmarks in parallel with rendering
 
     // Level-wmarks
-    auto& dsgraph = RImplementation.get_context(context_id);
+    auto& dsgraph = RImplementation.get_imm_context();
     dsgraph.render_wmarks();
     RImplementation.BasicStats.Wallmarks.End();
 

--- a/src/Layers/xrRender/WallmarksEngine.h
+++ b/src/Layers/xrRender/WallmarksEngine.h
@@ -71,7 +71,7 @@ public:
         const Fmatrix* xf, CKinematics* obj, ref_shader& sh, const Fvector& start, const Fvector& dir, float size);
 
     // render
-    void Render();
+    void Render(u32 context_id);
 
     void clear();
 };

--- a/src/Layers/xrRender/WallmarksEngine.h
+++ b/src/Layers/xrRender/WallmarksEngine.h
@@ -71,7 +71,7 @@ public:
         const Fmatrix* xf, CKinematics* obj, ref_shader& sh, const Fvector& start, const Fvector& dir, float size);
 
     // render
-    void Render(u32 context_id);
+    void Render();
 
     void clear();
 };

--- a/src/Layers/xrRender/light.cpp
+++ b/src/Layers/xrRender/light.cpp
@@ -36,7 +36,7 @@ light::light() : SpatialBase(g_SpatialSpace)
     vis.query_order = 0;
     vis.visible = true;
     vis.pending = false;
-    for (int id = 0; id < 3; ++id)
+    for (int id = 0; id < R__NUM_CONTEXTS; ++id)
         svis[id].id = id;
 #endif // (RENDER==R_R2) || (RENDER==R_R3) || (RENDER==R_R4) || (RENDER==R_GL)
 }

--- a/src/Layers/xrRender/light.cpp
+++ b/src/Layers/xrRender/light.cpp
@@ -36,6 +36,8 @@ light::light() : SpatialBase(g_SpatialSpace)
     vis.query_order = 0;
     vis.visible = true;
     vis.pending = false;
+    for (int id = 0; id < 3; ++id)
+        svis[id].id = id;
 #endif // (RENDER==R_R2) || (RENDER==R_R3) || (RENDER==R_R4) || (RENDER==R_GL)
 }
 
@@ -210,7 +212,8 @@ void light::spatial_move()
 #if (RENDER == R_R2) || (RENDER == R_R3) || (RENDER == R_R4) || (RENDER == R_GL)
     if (flags.bActive)
         gi_generate();
-    svis.invalidate();
+    for (int id = 0; id < ARRAYSIZE(svis); ++id)
+        svis[id].invalidate();
 #endif // (RENDER==R_R2) || (RENDER==R_R3) || (RENDER==R_R4) || (RENDER == R_GL)
 }
 

--- a/src/Layers/xrRender/light.cpp
+++ b/src/Layers/xrRender/light.cpp
@@ -212,7 +212,7 @@ void light::spatial_move()
 #if (RENDER == R_R2) || (RENDER == R_R3) || (RENDER == R_R4) || (RENDER == R_GL)
     if (flags.bActive)
         gi_generate();
-    for (int id = 0; id < ARRAYSIZE(svis); ++id)
+    for (int id = 0; id < R__NUM_CONTEXTS; ++id)
         svis[id].invalidate();
 #endif // (RENDER==R_R2) || (RENDER==R_R3) || (RENDER==R_R4) || (RENDER == R_GL)
 }

--- a/src/Layers/xrRender/light.h
+++ b/src/Layers/xrRender/light.h
@@ -47,7 +47,7 @@ public:
     xr_vector<light_indirect> indirect;
     u32 indirect_photons;
 
-    smapvis svis[3]; // used for 6-cubemap faces
+    smapvis svis[R__NUM_CONTEXTS]; // used for 6-cubemap faces
 
     ref_shader s_spot;
     ref_shader s_point;

--- a/src/Layers/xrRender/light.h
+++ b/src/Layers/xrRender/light.h
@@ -47,7 +47,7 @@ public:
     xr_vector<light_indirect> indirect;
     u32 indirect_photons;
 
-    smapvis svis; // used for 6-cubemap faces
+    smapvis svis[3]; // used for 6-cubemap faces
 
     ref_shader s_spot;
     ref_shader s_point;

--- a/src/Layers/xrRender/light.h
+++ b/src/Layers/xrRender/light.h
@@ -80,7 +80,7 @@ public:
             s32 minX, maxX;
             s32 minY, maxY;
             BOOL transluent;
-        } D;
+        } D[3]; // TODO: proper cascades max
         struct _P
         {
             Fmatrix world;

--- a/src/Layers/xrRender/light.h
+++ b/src/Layers/xrRender/light.h
@@ -80,7 +80,7 @@ public:
             s32 minX, maxX;
             s32 minY, maxY;
             BOOL transluent;
-        } D[3]; // TODO: proper cascades max
+        } D[R__NUM_SUN_CASCADES];
         struct _P
         {
             Fmatrix world;

--- a/src/Layers/xrRender/light_smapvis.cpp
+++ b/src/Layers/xrRender/light_smapvis.cpp
@@ -21,7 +21,7 @@ void smapvis::invalidate()
 }
 void smapvis::begin()
 {
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
+    auto& dsgraph = RImplementation.get_context(id);
     dsgraph.clear_Counters();
     switch (state)
     {
@@ -43,7 +43,7 @@ void smapvis::begin()
 }
 void smapvis::end()
 {
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
+    auto& dsgraph = RImplementation.get_context(id);
 
     // Gather stats
     u32 ts, td;
@@ -120,17 +120,16 @@ void smapvis::resetoccq()
 
 void smapvis::mark()
 {
-    const auto context_id = CRender::eRDSG_SHADOW_0 + id;
-    auto& dsgraph = RImplementation.get_context(context_id);
+    auto& dsgraph = RImplementation.get_context(id);
     RImplementation.Stats.ic_culled += invisible.size();
     u32 marker = dsgraph.marker + 1; // we are called befor marker increment
     for (u32 it = 0; it < invisible.size(); it++)
-        invisible[it]->vis.marker[context_id] = marker; // this effectively disables processing
+        invisible[it]->vis.marker[id] = marker; // this effectively disables processing
 }
 
 void smapvis::rfeedback_static(dxRender_Visual* V)
 {
     testQ_V = V;
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
+    auto& dsgraph = RImplementation.get_context(id);
     dsgraph.set_Feedback(0, 0);
 }

--- a/src/Layers/xrRender/light_smapvis.cpp
+++ b/src/Layers/xrRender/light_smapvis.cpp
@@ -124,7 +124,7 @@ void smapvis::mark(u32 context_id)
     RImplementation.Stats.ic_culled += invisible.size();
     u32 marker = dsgraph.marker + 1; // we are called befor marker increment
     for (u32 it = 0; it < invisible.size(); it++)
-        invisible[it]->vis.marker = marker; // this effectively disables processing
+        invisible[it]->vis.marker[context_id] = marker; // this effectively disables processing
 }
 
 void smapvis::rfeedback_static(u32 context_id, dxRender_Visual* V)

--- a/src/Layers/xrRender/light_smapvis.cpp
+++ b/src/Layers/xrRender/light_smapvis.cpp
@@ -19,9 +19,9 @@ void smapvis::invalidate()
     frame_sleep = Device.dwFrame + ps_r__LightSleepFrames;
     invisible.clear();
 }
-void smapvis::begin(u32 context_id)
+void smapvis::begin()
 {
-    auto& dsgraph = RImplementation.get_context(context_id);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
     dsgraph.clear_Counters();
     switch (state)
     {
@@ -32,18 +32,18 @@ void smapvis::begin(u32 context_id)
         // mark already known to be invisible visuals, set breakpoint
         testQ_V = 0;
         testQ_id = 0;
-        mark(context_id);
+        mark();
         dsgraph.set_Feedback(this, test_current);
         break;
     case state_usingTC:
         // just mark
-        mark(context_id);
+        mark();
         break;
     }
 }
-void smapvis::end(u32 context_id)
+void smapvis::end()
 {
-    auto& dsgraph = RImplementation.get_context(context_id);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
 
     // Gather stats
     u32 ts, td;
@@ -118,8 +118,9 @@ void smapvis::resetoccq()
     flushoccq();
 }
 
-void smapvis::mark(u32 context_id)
+void smapvis::mark()
 {
+    const auto context_id = CRender::eRDSG_SHADOW_0 + id;
     auto& dsgraph = RImplementation.get_context(context_id);
     RImplementation.Stats.ic_culled += invisible.size();
     u32 marker = dsgraph.marker + 1; // we are called befor marker increment
@@ -127,9 +128,9 @@ void smapvis::mark(u32 context_id)
         invisible[it]->vis.marker[context_id] = marker; // this effectively disables processing
 }
 
-void smapvis::rfeedback_static(u32 context_id, dxRender_Visual* V)
+void smapvis::rfeedback_static(dxRender_Visual* V)
 {
     testQ_V = V;
-    auto& dsgraph = RImplementation.get_context(context_id);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + id);
     dsgraph.set_Feedback(0, 0);
 }

--- a/src/Layers/xrRender/light_smapvis.h
+++ b/src/Layers/xrRender/light_smapvis.h
@@ -17,19 +17,20 @@ public:
     dxRender_Visual* testQ_V;
     u32 testQ_id;
     u32 testQ_frame;
+    int id{-1};
 
 public:
     smapvis();
     ~smapvis();
 
     void invalidate();
-    void begin(u32 context_id); // should be called before 'marker++' and before graph-build
-    void end(u32 context_id);
-    void mark(u32 context_id);
+    void begin(); // should be called before 'marker++' and before graph-build
+    void end();
+    void mark();
     void flushoccq(); // should be called when no rendering of light is supposed
 
     void resetoccq();
 
     IC bool sleep() { return Device.dwFrame > frame_sleep; }
-    virtual void rfeedback_static(u32 context_id, dxRender_Visual* V) override;
+    virtual void rfeedback_static(dxRender_Visual* V) override;
 };

--- a/src/Layers/xrRender/light_smapvis.h
+++ b/src/Layers/xrRender/light_smapvis.h
@@ -23,13 +23,13 @@ public:
     ~smapvis();
 
     void invalidate();
-    void begin(); // should be called before 'marker++' and before graph-build
-    void end();
-    void mark();
+    void begin(u32 context_id); // should be called before 'marker++' and before graph-build
+    void end(u32 context_id);
+    void mark(u32 context_id);
     void flushoccq(); // should be called when no rendering of light is supposed
 
     void resetoccq();
 
     IC bool sleep() { return Device.dwFrame > frame_sleep; }
-    virtual void rfeedback_static(dxRender_Visual* V);
+    virtual void rfeedback_static(u32 context_id, dxRender_Visual* V) override;
 };

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -695,8 +695,6 @@ void R_dsgraph_structure::build_subspace()
 {
     marker++; // !!! critical here
 
-    VERIFY(o.sector_id != IRender_Sector::INVALID_SECTOR_ID);
-
     if (o.precise_portals && RImplementation.rmPortals)
     {
         // Check if camera is too near to some portal - if so force DualRender

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -209,7 +209,7 @@ void R_dsgraph_structure::insert_static(dxRender_Visual* pVisual)
 #endif
 
     if (val_feedback && counter_S == val_feedback_breakp)
-        val_feedback->rfeedback_static(context_id, pVisual);
+        val_feedback->rfeedback_static(pVisual);
 
     counter_S++;
 

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -2,7 +2,7 @@
 
 #include "FHierrarhyVisual.h"
 #include "SkeletonCustom.h"
-#include "xrCore/FMesh.hpp"
+#include "xrCore/Threading/ParallelFor.hpp"
 #include "xrEngine/CustomHUD.h"
 #include "xrEngine/IRenderable.h"
 #include "xrEngine/xr_object.h"
@@ -719,181 +719,209 @@ void R_dsgraph_structure::build_subspace()
     PortalTraverser.traverse(Sectors[o.sector_id], o.view_frustum, o.view_pos, o.xform, o.portal_traverse_flags);
 
     // Determine visibility for static geometry hierrarhy
+    static xr_vector<Task*> static_geo_tasks;
+    static_geo_tasks.resize(PortalTraverser.r_sectors.size());
+
     if (psDeviceFlags.test(rsDrawStatic))
     {
         for (u32 s_it = 0; s_it < PortalTraverser.r_sectors.size(); s_it++)
         {
-            CSector* sector = (CSector*)PortalTraverser.r_sectors[s_it];
+            CSector* sector = PortalTraverser.r_sectors[s_it];
             dxRender_Visual* root = sector->root();
+            VERIFY(root->getType() == MT_HIERRARHY);
+
+            const auto &children = static_cast<FHierrarhyVisual*>(root)->children;
+
             for (u32 v_it = 0; v_it < sector->r_frustums.size(); v_it++)
             {
-                const auto& view = sector->r_frustums[v_it];
-                add_static(root, view, view.getMask());
+                const auto traverse_children = [&, this](const TaskRange<size_t>& range)
+                {
+                    for (size_t id = range.cbegin(); id != range.cend(); ++id)
+                    {
+                        const auto& view = sector->r_frustums[v_it];
+                        add_static(children[id], view, view.getMask());
+                    }
+                };
+
+                if (0 && o.mt_calculate) // NOTE: this code doesn't work until visuals maps are separated by worker ID.
+                {
+                    static_geo_tasks[s_it] = &xr_parallel_for(TaskRange<size_t>(0, children.size()), false, traverse_children);
+                }
+                else
+                {
+                    traverse_children(TaskRange<size_t>(0, children.size()));
+                }
             }
         }
     }
 
     const bool collect_dynamic_any = (o.spatial_types != 0) && psDeviceFlags.test(rsDrawDynamic);
-    if (!collect_dynamic_any)
-    {
-        return;
-    }
 
-    // Traverse object database
-    g_SpatialSpace->q_frustum(lstRenderables, o.spatial_traverse_flags, o.spatial_types, o.view_frustum);
-
-    if (o.spatial_traverse_flags & ISpatial_DB::O_ORDERED) // this should be inside of query functions
+    if (collect_dynamic_any)
     {
-        // Exact sorting order (front-to-back)
-        std::sort(lstRenderables.begin(), lstRenderables.end(), [&](ISpatial* s1, ISpatial* s2)
+        // Traverse object database
+        g_SpatialSpace->q_frustum(lstRenderables, o.spatial_traverse_flags, o.spatial_types, o.view_frustum);
+
+        if (o.spatial_traverse_flags & ISpatial_DB::O_ORDERED) // this should be inside of query functions
         {
-            const float d1 = s1->GetSpatialData().sphere.P.distance_to_sqr(o.view_pos);
-            const float d2 = s2->GetSpatialData().sphere.P.distance_to_sqr(o.view_pos);
-            return d1 < d2;
-        });
-    }
+            // Exact sorting order (front-to-back)
+            std::sort(lstRenderables.begin(), lstRenderables.end(), [&](ISpatial* s1, ISpatial* s2)
+                {
+                    const float d1 = s1->GetSpatialData().sphere.P.distance_to_sqr(o.view_pos);
+                    const float d2 = s2->GetSpatialData().sphere.P.distance_to_sqr(o.view_pos);
+                    return d1 < d2;
+                });
+        }
 
-    u32 uID_LTRACK = 0xffffffff;
-    if (o.is_main_pass) // temporary
-    {
-        if (o.phase == CRender::PHASE_NORMAL)
+        u32 uID_LTRACK = 0xffffffff;
+        if (o.is_main_pass) // temporary
         {
-            RImplementation.uLastLTRACK++;
-            if (!lstRenderables.empty())
-                uID_LTRACK = RImplementation.uLastLTRACK % lstRenderables.size();
-
-            // update light-vis for current entity / actor
-            IGameObject* O = g_pGameLevel->CurrentViewEntity();
-            if (O)
+            if (o.phase == CRender::PHASE_NORMAL)
             {
-                CROS_impl* R = (CROS_impl*)O->ROS();
-                if (R)
-                    R->update(O);
+                RImplementation.uLastLTRACK++;
+                if (!lstRenderables.empty())
+                    uID_LTRACK = RImplementation.uLastLTRACK % lstRenderables.size();
+
+                // update light-vis for current entity / actor
+                IGameObject* O = g_pGameLevel->CurrentViewEntity();
+                if (O)
+                {
+                    CROS_impl* R = (CROS_impl*)O->ROS();
+                    if (R)
+                        R->update(O);
+                }
             }
         }
-    }
 
-    const bool collect_lights = o.spatial_types & STYPE_LIGHTSOURCE;
+        const bool collect_lights = o.spatial_types & STYPE_LIGHTSOURCE;
 
-    // Determine visibility for dynamic part of scene
-    for (u32 o_it = 0; o_it < lstRenderables.size(); o_it++)
-    {
-        ISpatial* spatial = lstRenderables[o_it];
-        if (o.is_main_pass)
+        // Determine visibility for dynamic part of scene
+        for (u32 o_it = 0; o_it < lstRenderables.size(); o_it++)
         {
-            const auto& entity_pos = spatial->spatial_sector_point();
-            const auto sector_id = detect_sector(entity_pos);
-            spatial->spatial_updatesector(sector_id);
-        }
-        const auto& data = spatial->GetSpatialData();
-        const auto& [type, sphere, sector_id] = std::tuple(data.type, data.sphere, data.sector_id);
-        if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
-            continue; // disassociated from S/P structure
-        auto* sector = Sectors[sector_id];
-
-        if (collect_lights && (type & STYPE_LIGHTSOURCE))
-        {
-            // lightsource
-            light* L = (light*)spatial->dcast_Light();
-            VERIFY(L);
-            float lod = L->get_LOD();
-            if (lod > EPS_L)
-            {
-                // TODO: check for HOM flag
-                vis_data& vis = L->get_homdata();
-                if (RImplementation.HOM.visible(vis))
-                    RImplementation.Lights.add_light(L);
-            }
-            continue;
-        }
-
-        if (PortalTraverser.i_marker != sector->r_marker)
-            continue; // inactive (untouched) sector
-        for (u32 v_it = 0; v_it < sector->r_frustums.size(); v_it++)
-        {
-            const CFrustum& view = sector->r_frustums[v_it];
-            if (!view.testSphere_dirty(spatial->GetSpatialData().sphere.P, spatial->GetSpatialData().sphere.R))
-                continue;
-
+            ISpatial* spatial = lstRenderables[o_it];
             if (o.is_main_pass)
             {
-                if (type & STYPE_RENDERABLE)
+                const auto& entity_pos = spatial->spatial_sector_point();
+                const auto sector_id = detect_sector(entity_pos);
+                spatial->spatial_updatesector(sector_id);
+            }
+            const auto& data = spatial->GetSpatialData();
+            const auto& [type, sphere, sector_id] = std::tuple(data.type, data.sphere, data.sector_id);
+            if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
+                continue; // disassociated from S/P structure
+            auto* sector = Sectors[sector_id];
+
+            if (collect_lights && (type & STYPE_LIGHTSOURCE))
+            {
+                // lightsource
+                light* L = (light*)spatial->dcast_Light();
+                VERIFY(L);
+                float lod = L->get_LOD();
+                if (lod > EPS_L)
+                {
+                    // TODO: check for HOM flag
+                    vis_data& vis = L->get_homdata();
+                    if (RImplementation.HOM.visible(vis))
+                        RImplementation.Lights.add_light(L);
+                }
+                continue;
+            }
+
+            if (PortalTraverser.i_marker != sector->r_marker)
+                continue; // inactive (untouched) sector
+            for (u32 v_it = 0; v_it < sector->r_frustums.size(); v_it++)
+            {
+                const CFrustum& view = sector->r_frustums[v_it];
+                if (!view.testSphere_dirty(spatial->GetSpatialData().sphere.P, spatial->GetSpatialData().sphere.R))
+                    continue;
+
+                if (o.is_main_pass)
+                {
+                    if (type & STYPE_RENDERABLE)
+                    {
+                        // renderable
+                        IRenderable* renderable = spatial->dcast_Renderable();
+                        VERIFY(renderable);
+
+                        // Occlusion
+                        //	casting is faster then using getVis method
+                        vis_data& v_orig = ((dxRender_Visual*)renderable->GetRenderData().visual)->vis;
+                        vis_data v_copy = v_orig;
+                        v_copy.box.xform(renderable->GetRenderData().xform);
+                        BOOL bVisible = RImplementation.HOM.visible(v_copy);
+                        memcpy(v_orig.marker, v_copy.marker, sizeof(v_copy.marker));
+                        v_orig.accept_frame = v_copy.accept_frame;
+                        v_orig.hom_frame = v_copy.hom_frame;
+                        v_orig.hom_tested = v_copy.hom_tested;
+                        if (!bVisible)
+                            break; // exit loop on frustums
+
+                        // update light-vis for selected entity
+                        if (o_it == uID_LTRACK && renderable->renderable_ROS())
+                        {
+                            // track lighting environment
+                            CROS_impl* T = (CROS_impl*)renderable->renderable_ROS();
+                            T->update(renderable);
+                        }
+
+                        // Rendering
+                        renderable->renderable_Render(context_id, renderable);
+                    }
+                    break; // exit loop on frustums
+                }
+                else
                 {
                     // renderable
                     IRenderable* renderable = spatial->dcast_Renderable();
-                    VERIFY(renderable);
+                    if (nullptr == renderable)
+                        continue; // unknown, but renderable object (r1_glow???)
 
-                    // Occlusion
-                    //	casting is faster then using getVis method
-                    vis_data& v_orig = ((dxRender_Visual*)renderable->GetRenderData().visual)->vis;
-                    vis_data v_copy = v_orig;
-                    v_copy.box.xform(renderable->GetRenderData().xform);
-                    BOOL bVisible = RImplementation.HOM.visible(v_copy);
-                    memcpy(v_orig.marker, v_copy.marker, sizeof(v_copy.marker));
-                    v_orig.accept_frame = v_copy.accept_frame;
-                    v_orig.hom_frame = v_copy.hom_frame;
-                    v_orig.hom_tested = v_copy.hom_tested;
-                    if (!bVisible)
-                        break; // exit loop on frustums
-
-                    // update light-vis for selected entity
-                    if (o_it == uID_LTRACK && renderable->renderable_ROS())
-                    {
-                        // track lighting environment
-                        CROS_impl* T = (CROS_impl*)renderable->renderable_ROS();
-                        T->update(renderable);
-                    }
-
-                    // Rendering
-                    renderable->renderable_Render(context_id, renderable);
+                    renderable->renderable_Render(context_id, nullptr);
                 }
-                break; // exit loop on frustums
             }
-            else
-            {
-                // renderable
-                IRenderable* renderable = spatial->dcast_Renderable();
-                if (nullptr == renderable)
-                    continue; // unknown, but renderable object (r1_glow???)
+        }
 
-                renderable->renderable_Render(context_id, nullptr);
+        if (g_pGameLevel)
+        {
+#if RENDER != R_R1
+            // Actor Shadow (Sun + Light)
+            if (o.phase == CRender::PHASE_SMAP && ps_r__common_flags.test(RFLAG_ACTOR_SHADOW))
+            {
+                do
+                {
+                    IGameObject* viewEntity = g_pGameLevel->CurrentViewEntity();
+                    if (viewEntity == nullptr)
+                        break;
+                    const auto& entity_pos = viewEntity->spatial_sector_point();
+                    viewEntity->spatial_updatesector(detect_sector(entity_pos));
+                    const auto sector_id = viewEntity->GetSpatialData().sector_id;
+                    if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
+                        break; // disassociated from S/P structure
+                    CSector* sector = Sectors[sector_id];
+                    if (PortalTraverser.i_marker != sector->r_marker)
+                        break; // inactive (untouched) sector
+                    for (const CFrustum& view : sector->r_frustums)
+                    {
+                        if (!view.testSphere_dirty(
+                            viewEntity->GetSpatialData().sphere.P, viewEntity->GetSpatialData().sphere.R))
+                            continue;
+
+                        // renderable
+                        g_hud->Render_First(context_id);
+                    }
+                } while (0);
             }
+#endif
+
+            if (o.is_main_pass)
+                g_hud->Render_Last(context_id);
         }
     }
 
-    if (g_pGameLevel)
+    // wait for static geo collecting to be done.
+    for (auto* task : static_geo_tasks)
     {
-#if RENDER != R_R1
-        // Actor Shadow (Sun + Light)
-        if (o.phase == CRender::PHASE_SMAP && ps_r__common_flags.test(RFLAG_ACTOR_SHADOW))
-        {
-            do
-            {
-                IGameObject* viewEntity = g_pGameLevel->CurrentViewEntity();
-                if (viewEntity == nullptr)
-                    break;
-                const auto& entity_pos = viewEntity->spatial_sector_point();
-                viewEntity->spatial_updatesector(detect_sector(entity_pos));
-                const auto sector_id = viewEntity->GetSpatialData().sector_id;
-                if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
-                    break; // disassociated from S/P structure
-                CSector* sector = Sectors[sector_id];
-                if (PortalTraverser.i_marker != sector->r_marker)
-                    break; // inactive (untouched) sector
-                for (const CFrustum& view : sector->r_frustums)
-                {
-                    if (!view.testSphere_dirty(
-                        viewEntity->GetSpatialData().sphere.P, viewEntity->GetSpatialData().sphere.R))
-                        continue;
-
-                    // renderable
-                    g_hud->Render_First(context_id);
-                }
-            } while (0);
-        }
-#endif
-
-        if (o.is_main_pass)
-            g_hud->Render_Last(context_id);
+        if (task)
+            TaskScheduler->Wait(*task);
     }
 }

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -693,7 +693,6 @@ void R_dsgraph_structure::unload()
 // sub-space rendering - main procedure
 void R_dsgraph_structure::build_subspace()
 {
-    PIX_EVENT(r_dsgraph_render_subspace);
     marker++; // !!! critical here
 
     VERIFY(o.sector_id != IRender_Sector::INVALID_SECTOR_ID);

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -65,7 +65,7 @@ void R_dsgraph_structure::render_graph(u32 _priority)
                 // --#SM+#-- Обновляем шейдерные данные модели [update shader values for this model]
                 // RCache.hemi.c_update(item.pVisual);
 
-                item.pVisual->Render(LOD);
+                item.pVisual->Render(LOD, o.phase == CRender::PHASE_SMAP);
             }
             items.clear();
 
@@ -105,7 +105,7 @@ void R_dsgraph_structure::render_graph(u32 _priority)
                 // --#SM+#-- Обновляем шейдерные данные модели [update shader values for this model]
                 // RCache.hemi.c_update(item.pVisual);
 
-                item.pVisual->Render(LOD);
+                item.pVisual->Render(LOD, o.phase == CRender::PHASE_SMAP);
             }
             items.clear();
         }
@@ -208,7 +208,7 @@ void __fastcall render_item(const T& item)
     hud_transform_helper::apply_custom_state();
     //--#SM+#-- Обновляем шейдерные данные модели [update shader values for this model]
     //RCache.hemi.c_update(V);
-    V->Render(calcLOD(item.first, V->vis.sphere.R));
+    V->Render(calcLOD(item.first, V->vis.sphere.R), RImplementation.active_phase() == CRender::PHASE_SMAP);
 }
 
 template<class T>
@@ -389,7 +389,7 @@ void R_dsgraph_structure::render_R1_box(IRender_Sector::sector_id_t sector_id, F
                 for (u32 pass = 0; pass < E2->passes.size(); pass++)
                 {
                     RCache.set_Element(E2, pass);
-                    V->Render(-1.f);
+                    V->Render(-1.f, o.phase == CRender::PHASE_SMAP);
                 }
             }
         }

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -6,7 +6,7 @@
 class R_feedback
 {
 public:
-    virtual void rfeedback_static(u32 context_id, dxRender_Visual* V) = 0;
+    virtual void rfeedback_static(dxRender_Visual* V) = 0;
 };
 
 struct R_dsgraph_structure

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -97,7 +97,7 @@ struct R_dsgraph_structure
     void reset()
     {
         //marker = 0;
-        //context_id = INVALID_CONTEXT_ID;
+        context_id = INVALID_CONTEXT_ID;
 
         o.query_box_side = EPS_L * 20;
         o.use_hom = false;

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -35,6 +35,7 @@ struct R_dsgraph_structure
         bool use_hom{ false };
         bool precise_portals{ false };
         bool is_main_pass{ false };
+        bool mt_calculate{ false };
     } o;
 
     // Dynamic scene graph

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -12,6 +12,11 @@ public:
 struct R_dsgraph_structure
 {
     static constexpr auto INVALID_CONTEXT_ID = static_cast<u32>(-1);
+#if RENDER == R_R1
+    static constexpr auto IMM_CTX_ID = 0; // TODO: to remove this ugly #ifdef we need to introduce per-render configuration
+#else
+    static constexpr auto IMM_CTX_ID = R__NUM_PARALLEL_CONTEXTS; // the next after pooled
+#endif
 
     R_feedback* val_feedback{}; // feedback for geometry being rendered
     u32 val_feedback_breakp{}; // breakpoint

--- a/src/Layers/xrRender/r__dsgraph_structure.h
+++ b/src/Layers/xrRender/r__dsgraph_structure.h
@@ -6,15 +6,18 @@
 class R_feedback
 {
 public:
-    virtual void rfeedback_static(dxRender_Visual* V) = 0;
+    virtual void rfeedback_static(u32 context_id, dxRender_Visual* V) = 0;
 };
 
 struct R_dsgraph_structure
 {
+    static constexpr auto INVALID_CONTEXT_ID = static_cast<u32>(-1);
+
     R_feedback* val_feedback{}; // feedback for geometry being rendered
     u32 val_feedback_breakp{}; // breakpoint
     xr_vector<Fbox3>* val_recorder; // coarse structure recorder
     u32 marker{};
+    u32 context_id{ INVALID_CONTEXT_ID };
 
     struct options_t
     {
@@ -93,6 +96,9 @@ struct R_dsgraph_structure
 
     void reset()
     {
+        //marker = 0;
+        //context_id = INVALID_CONTEXT_ID;
+
         o.query_box_side = EPS_L * 20;
         o.use_hom = false;
         o.precise_portals = false;

--- a/src/Layers/xrRender/r__pixel_calculator.cpp
+++ b/src/Layers/xrRender/r__pixel_calculator.cpp
@@ -49,7 +49,7 @@ r_aabb_ssa r_pixel_calculator::calculate(dxRender_Visual* V)
     r_aabb_ssa result = {0};
     float area = float(_sqr(rt_dimensions));
 
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     //
     u32 id[6];

--- a/src/Layers/xrRender/r__pixel_calculator.cpp
+++ b/src/Layers/xrRender/r__pixel_calculator.cpp
@@ -49,6 +49,8 @@ r_aabb_ssa r_pixel_calculator::calculate(dxRender_Visual* V)
     r_aabb_ssa result = {0};
     float area = float(_sqr(rt_dimensions));
 
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     //
     u32 id[6];
     for (u32 face = 0; face < 6; face++)
@@ -72,11 +74,11 @@ r_aabb_ssa r_pixel_calculator::calculate(dxRender_Visual* V)
         // render-0
         Device.Clear(); // clear-ZB
         RCache.set_Shader(V->shader);
-        V->Render(1.f, RImplementation.active_phase() == CRender::PHASE_SMAP);
+        V->Render(1.f, dsgraph.o.phase == CRender::PHASE_SMAP);
 
         // render-1
         RImplementation.HWOCC.occq_begin(id[face]);
-        V->Render(1.f, RImplementation.active_phase() == CRender::PHASE_SMAP);
+        V->Render(1.f, dsgraph.o.phase == CRender::PHASE_SMAP);
         RImplementation.HWOCC.occq_end(id[face]);
     }
 

--- a/src/Layers/xrRender/r__pixel_calculator.cpp
+++ b/src/Layers/xrRender/r__pixel_calculator.cpp
@@ -72,11 +72,11 @@ r_aabb_ssa r_pixel_calculator::calculate(dxRender_Visual* V)
         // render-0
         Device.Clear(); // clear-ZB
         RCache.set_Shader(V->shader);
-        V->Render(1.f);
+        V->Render(1.f, RImplementation.active_phase() == CRender::PHASE_SMAP);
 
         // render-1
         RImplementation.HWOCC.occq_begin(id[face]);
-        V->Render(1.f);
+        V->Render(1.f, RImplementation.active_phase() == CRender::PHASE_SMAP);
         RImplementation.HWOCC.occq_end(id[face]);
     }
 

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -236,6 +236,9 @@ float dm_current_fade = 47.5; //float(2*dm_current_size)-.5f;
 float ps_current_detail_density = 0.6f;
 float ps_current_detail_height = 1.f;
 
+int ps_r2_mt_calculate = 0;
+int ps_r2_mt_render = 0;
+
 xr_token ext_quality_token[] = {{"qt_off", 0}, {"qt_low", 1}, {"qt_medium", 2},
     {"qt_high", 3}, {"qt_extreme", 4}, {nullptr, 0}};
 //-AVO
@@ -974,6 +977,9 @@ void xrRender_initconsole()
     CMD1(CCC_memory_stats, "render_memory_stats");
 
     //CMD3(CCC_Mask, "r2_sun_ignore_portals", &ps_r2_ls_flags, R2FLAG_SUN_IGNORE_PORTALS);
+
+    CMD4(CCC_Integer, "r2_mt_calculate",    &ps_r2_mt_calculate, 0, 1);
+    CMD4(CCC_Integer, "r2_mt_render",       &ps_r2_mt_render,    0, 1);
 }
 
 #endif

--- a/src/Layers/xrRenderDX11/3DFluid/dx113DFluidVolume.cpp
+++ b/src/Layers/xrRenderDX11/3DFluid/dx113DFluidVolume.cpp
@@ -85,7 +85,7 @@ void dx113DFluidVolume::Load(LPCSTR /*N*/, IReader* data, u32 /*dwFlags*/)
     */
 }
 
-void dx113DFluidVolume::Render(float /*LOD*/) // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
+void dx113DFluidVolume::Render(float /*LOD*/, bool use_fast_geo) // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
 {
     //	Render debug box
     //	Do it BEFORE update since update resets shaders and other pipeline settings

--- a/src/Layers/xrRenderDX11/3DFluid/dx113DFluidVolume.h
+++ b/src/Layers/xrRenderDX11/3DFluid/dx113DFluidVolume.h
@@ -12,7 +12,7 @@ public:
     virtual ~dx113DFluidVolume();
 
     virtual void Load(LPCSTR N, IReader* data, u32 dwFlags);
-    virtual void Render(float LOD); // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
+    virtual void Render(float LOD, bool use_fast_geo) override; // LOD - Level Of Detail  [0.0f - min, 1.0f - max], Ignored ?
     virtual void Copy(dxRender_Visual* pFrom);
     virtual void Release();
 

--- a/src/Layers/xrRenderPC_GL/gl_rendertarget_accum_direct.cpp
+++ b/src/Layers/xrRenderPC_GL/gl_rendertarget_accum_direct.cpp
@@ -179,7 +179,7 @@ void CRenderTarget::accum_direct(u32 sub_phase)
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, RImplementation.r_sun.sun->X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -475,7 +475,7 @@ void CRenderTarget::accum_direct_cascade(u32 sub_phase, Fmatrix& xform, Fmatrix&
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -887,7 +887,7 @@ void CRenderTarget::accum_direct_f(u32 sub_phase)
         {
             FPU::m64r();
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias

--- a/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
@@ -275,9 +275,10 @@ void CRenderTarget::phase_combine()
     // u_setrt(rt_Generic_1,0,0,get_base_zb());
 
     // Distortion filter
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
-        if ((0 == RImplementation.dsgraph.mapDistort.size()) && !_menu_pp)
+        if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)
             bDistort = FALSE;
         if (bDistort)
         {
@@ -287,7 +288,7 @@ void CRenderTarget::phase_combine()
             RCache.set_CullMode(CULL_CCW);
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
-            RImplementation.dsgraph.render_distort();
+            dsgraph.render_distort();
             if (g_pGamePersistent)
                 g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }

--- a/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
@@ -289,8 +289,6 @@ void CRenderTarget::phase_combine()
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
             dsgraph.render_distort();
-            if (g_pGamePersistent)
-                g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }
     }
 

--- a/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_GL/gl_rendertarget_phase_combine.cpp
@@ -275,7 +275,7 @@ void CRenderTarget::phase_combine()
     // u_setrt(rt_Generic_1,0,0,get_base_zb());
 
     // Distortion filter
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
         if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)

--- a/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
+++ b/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
@@ -904,7 +904,7 @@ void render_sun_old::render_sun_near()
         hull.compute_caster_model(cull_planes, sun->direction);
 #ifdef _DEBUG
         for (u32 it = 0; it < cull_planes.size(); it++)
-            Target->dbg_addplane(cull_planes[it], 0xffffffff);
+            RImplementation.Target->dbg_addplane(cull_planes[it], 0xffffffff);
 #endif
 
         // COP - 100 km away
@@ -1119,9 +1119,9 @@ void render_sun::calculate_task(Task&, void*)
     // Also compute virtual light position and sector it is inside
     xr_vector<Fplane> cull_planes;
 
-    CFrustum cull_frustum[3];
-    Fvector3 cull_COP[3];
-    Fmatrix cull_xform[3];
+    CFrustum cull_frustum[R__NUM_SUN_CASCADES];
+    Fvector3 cull_COP[R__NUM_SUN_CASCADES];
+    Fmatrix cull_xform[R__NUM_SUN_CASCADES];
     for (u32 cascade_ind = 0; cascade_ind < m_sun_cascades.size(); ++cascade_ind)
     {
         FPU::m64r();

--- a/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
+++ b/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
@@ -1051,7 +1051,7 @@ void render_sun::init()
     /// 	m_sun_cascades[m_sun_cascades.size()-1].size = 80;
 }
 
-void render_sun::calculate()
+void render_sun::calculate_task(Task&, void*)
 {
     bool b_need_to_render_sunshafts = RImplementation.Target->need_to_render_sunshafts();
     bool last_cascade_chain_mode = m_sun_cascades.back().reset_chain;

--- a/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
+++ b/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
@@ -349,10 +349,9 @@ glm::vec2 BuildTSMProjectionMatrix_caster_depth_bounds(glm::mat4& lightSpaceBasi
     return glm::vec2(min_z, max_z);
 }
 
-void CRender::render_sun()
+void render_sun_old::render_sun()
 {
     PIX_EVENT(render_sun);
-    light* fuckingsun = (light*)Lights.sun._get();
     glm::mat4 m_LightViewProj;
 
     // calculate view-frustum bounds in world space
@@ -388,10 +387,10 @@ void CRender::render_sun()
                     hull.polys.back().points.push_back(pt);
             }
         }
-        hull.compute_caster_model(cull_planes, fuckingsun->direction);
+        hull.compute_caster_model(cull_planes, sun->direction);
 
         // COP - 100 km away
-        cull_COP.mad(Device.vCameraPosition, fuckingsun->direction, -tweak_COP_initial_offs);
+        cull_COP.mad(Device.vCameraPosition, sun->direction, -tweak_COP_initial_offs);
 
         // Create frustum for query
         cull_frustum._clear();
@@ -402,8 +401,8 @@ void CRender::render_sun()
         // view: auto find 'up' and 'right' vectors
         glm::mat4 mdir_View, mdir_Project;
         glm::vec3 L_dir, L_up, L_right, L_pos;
-        L_pos = glm::vec3(fuckingsun->position.x, fuckingsun->position.y, fuckingsun->position.z);
-        L_dir = glm::normalize(glm::vec3(fuckingsun->direction.x, fuckingsun->direction.y, fuckingsun->direction.z));
+        L_pos = glm::vec3(sun->position.x, sun->position.y, sun->position.z);
+        L_dir = glm::normalize(glm::vec3(sun->direction.x, sun->direction.y, sun->direction.z));
         L_up = glm::vec3(0.f, 1.f, 0.f);
         if (_abs(glm::dot(L_up, L_dir)) > .99f) L_up = glm::vec3(0.f, 0.f, 1.f);
         L_right = glm::normalize(glm::cross(L_up, L_dir));
@@ -430,15 +429,15 @@ void CRender::render_sun()
     }
 
     // Begin SMAP-render
-    xr_vector<Fbox3>& s_receivers = main_coarse_structure;
+    xr_vector<Fbox3>& s_receivers = RImplementation.main_coarse_structure;
     s_casters.reserve(s_receivers.size());
 
-    auto& dsgraph = get_context(eRDSG_SHADOW_0);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0);
     {
-        //		fuckingsun->svis.begin					();
-        dsgraph.o.phase = PHASE_SMAP;
-        dsgraph.r_pmask(true, o.Tshadows);
-        dsgraph.o.sector_id = largest_sector_id;
+        //		sun->svis.begin					();
+        dsgraph.o.phase = CRender::PHASE_SMAP;
+        dsgraph.r_pmask(true, RImplementation.o.Tshadows);
+        dsgraph.o.sector_id = RImplementation.get_largest_sector();
         dsgraph.o.xform = *(Fmatrix*)glm::value_ptr(cull_xform);
         dsgraph.o.view_pos = cull_COP;
         dsgraph.o.view_frustum = cull_frustum;
@@ -462,7 +461,7 @@ void CRender::render_sun()
     //	Prepare to interact with D3DX code
     const glm::mat4 m_View = glm::make_mat4x4(&Device.mView.m[0][0]);
     const glm::mat4 m_Projection = ex_project;
-    glm::vec3 m_lightDir = -glm::vec3(fuckingsun->direction.x, fuckingsun->direction.y, fuckingsun->direction.z);
+    glm::vec3 m_lightDir = -glm::vec3(sun->direction.x, sun->direction.y, sun->direction.z);
 
     //  these are the limits specified by the physical camera
     //  gamma is the "tilt angle" between the light and the view direction.
@@ -776,7 +775,7 @@ void CRender::render_sun()
     }
 
     // Finalize & Cleanup
-    fuckingsun->X.D.combine = *(Fmatrix*)glm::value_ptr(m_LightViewProj);
+    sun->X.D[0].combine = *(Fmatrix*)glm::value_ptr(m_LightViewProj);
     s_receivers.clear();
     s_casters.clear();
 
@@ -788,16 +787,16 @@ void CRender::render_sun()
             !dsgraph.mapSorted.empty();
         if (bNormal || bSpecial)
         {
-            Target->phase_smap_direct(fuckingsun, SE_SUN_FAR);
+            RImplementation.Target->phase_smap_direct(sun, SE_SUN_FAR);
             RCache.set_xform_world(Fidentity);
             RCache.set_xform_view(Fidentity);
-            RCache.set_xform_project(fuckingsun->X.D.combine);
+            RCache.set_xform_project(sun->X.D[0].combine);
             dsgraph.render_graph(0);
-            fuckingsun->X.D.transluent = FALSE;
+            sun->X.D[0].transluent = FALSE;
             if (bSpecial)
             {
-                fuckingsun->X.D.transluent = TRUE;
-                Target->phase_smap_direct_tsh(fuckingsun, SE_SUN_FAR);
+                sun->X.D[0].transluent = TRUE;
+                RImplementation.Target->phase_smap_direct_tsh(sun, SE_SUN_FAR);
                 dsgraph.render_graph(1); // normal level, secondary priority
                 dsgraph.render_sorted(); // strict-sorted geoms
             }
@@ -806,21 +805,21 @@ void CRender::render_sun()
 
     // End SMAP-render
     {
-        //		fuckingsun->svis.end					();
+        //		sun->svis.end					();
         dsgraph.r_pmask(true, false);
     }
 
     // Accumulate
-    Target->phase_accumulator();
+    RImplementation.Target->phase_accumulator();
 
-    if (Target->use_minmax_sm_this_frame())
+    if (RImplementation.Target->use_minmax_sm_this_frame())
     {
         PIX_EVENT(SE_SUN_FAR_MINMAX_GENERATE);
-        Target->create_minmax_SM();
+        RImplementation.Target->create_minmax_SM();
     }
 
     PIX_EVENT(SE_SUN_FAR);
-    Target->accum_direct(SE_SUN_FAR);
+    RImplementation.Target->accum_direct(SE_SUN_FAR);
 
     // Restore XForms
     RCache.set_xform_world(Fidentity);
@@ -828,10 +827,8 @@ void CRender::render_sun()
     RCache.set_xform_project(Device.mProject);
 }
 
-void CRender::render_sun_near()
+void render_sun_old::render_sun_near()
 {
-    light* fuckingsun = (light*)Lights.sun._get();
-
     // calculate view-frustum bounds in world space
     glm::mat4 ex_full_inverse;
     {
@@ -868,14 +865,14 @@ void CRender::render_sun_near()
                     hull.polys.back().points.push_back(pt);
             }
         }
-        hull.compute_caster_model(cull_planes, fuckingsun->direction);
+        hull.compute_caster_model(cull_planes, sun->direction);
 #ifdef _DEBUG
         for (u32 it = 0; it < cull_planes.size(); it++)
             Target->dbg_addplane(cull_planes[it], 0xffffffff);
 #endif
 
         // COP - 100 km away
-        cull_COP.mad(Device.vCameraPosition, fuckingsun->direction, -tweak_COP_initial_offs);
+        cull_COP.mad(Device.vCameraPosition, sun->direction, -tweak_COP_initial_offs);
 
         // Create frustum for query
         cull_frustum._clear();
@@ -886,8 +883,8 @@ void CRender::render_sun_near()
         // view: auto find 'up' and 'right' vectors
         glm::mat4 mdir_View, mdir_Project;
         glm::vec3 L_dir, L_up, L_right, L_pos;
-        L_pos = glm::vec3(fuckingsun->position.x, fuckingsun->position.y, fuckingsun->position.z);
-        L_dir = glm::normalize(glm::vec3(fuckingsun->direction.x, fuckingsun->direction.y, fuckingsun->direction.z));
+        L_pos = glm::vec3(sun->position.x, sun->position.y, sun->position.z);
+        L_dir = glm::normalize(glm::vec3(sun->direction.x, sun->direction.y, sun->direction.z));
         L_right = glm::vec3(1.f, 0.f, 0.f);
         if (_abs(glm::dot(L_right, L_dir)) > .99f) L_right = glm::vec3(0.f, 0.f, 1.f);
         L_up = glm::normalize(glm::cross(L_dir, L_right));
@@ -909,7 +906,7 @@ void CRender::render_sun_near()
                                   bb.vMin.z - tweak_ortho_xform_initial_offs, bb.vMax.z);
 
         // build viewport xform
-        float view_dim = float(o.smapsize);
+        float view_dim = float(RImplementation.o.smapsize);
         glm::mat4 m_viewport =
         {
             view_dim / 2.f, 0.0f, 0.0f, 0.0f,
@@ -942,23 +939,23 @@ void CRender::render_sun_near()
             Fvector xf = wform(scissor_xf, hull.points[it]);
             scissor.modify(xf);
         }
-        s32 limit = o.smapsize - 1;
-        fuckingsun->X.D.minX = clampr(iFloor(scissor.vMin.x), 0, limit);
-        fuckingsun->X.D.maxX = clampr(iCeil(scissor.vMax.x), 0, limit);
-        fuckingsun->X.D.minY = clampr(iFloor(scissor.vMin.y), 0, limit);
-        fuckingsun->X.D.maxY = clampr(iCeil(scissor.vMax.y), 0, limit);
+        s32 limit = RImplementation.o.smapsize - 1;
+        sun->X.D[0].minX = clampr(iFloor(scissor.vMin.x), 0, limit);
+        sun->X.D[0].maxX = clampr(iCeil(scissor.vMax.x), 0, limit);
+        sun->X.D[0].minY = clampr(iFloor(scissor.vMin.y), 0, limit);
+        sun->X.D[0].maxY = clampr(iCeil(scissor.vMax.y), 0, limit);
 
         // full-xform
         FPU::m24r();
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_SHADOW_0);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0);
     {
-        //		fuckingsun->svis.begin					();
-        dsgraph.o.phase = PHASE_SMAP;
-        dsgraph.r_pmask(true, o.Tshadows);
-        dsgraph.o.sector_id = largest_sector_id;
+        //		sun->svis.begin					();
+        dsgraph.o.phase = CRender::PHASE_SMAP;
+        dsgraph.r_pmask(true, RImplementation.o.Tshadows);
+        dsgraph.o.sector_id = RImplementation.get_largest_sector();
         dsgraph.o.xform = *(Fmatrix*)glm::value_ptr(cull_xform);
         dsgraph.o.view_pos = cull_COP;
         dsgraph.o.view_frustum = cull_frustum;
@@ -968,7 +965,7 @@ void CRender::render_sun_near()
     }
 
     // Finalize & Cleanup
-    fuckingsun->X.D.combine = *(Fmatrix*)glm::value_ptr(cull_xform);
+    sun->X.D[0].combine = *(Fmatrix*)glm::value_ptr(cull_xform);
 
     // Render shadow-map
     //. !!! We should clip based on shrinked frustum (again)
@@ -978,18 +975,18 @@ void CRender::render_sun_near()
             !dsgraph.mapSorted.empty();
         if (bNormal || bSpecial)
         {
-            Target->phase_smap_direct(fuckingsun, SE_SUN_NEAR);
+            RImplementation.Target->phase_smap_direct(sun, SE_SUN_NEAR);
             RCache.set_xform_world(Fidentity);
             RCache.set_xform_view(Fidentity);
-            RCache.set_xform_project(fuckingsun->X.D.combine);
+            RCache.set_xform_project(sun->X.D[0].combine);
             dsgraph.render_graph(0);
             if (ps_r2_ls_flags.test(R2FLAG_SUN_DETAILS))
-                Details->Render();
-            fuckingsun->X.D.transluent = FALSE;
+                RImplementation.Details->Render();
+            sun->X.D[0].transluent = FALSE;
             if (bSpecial)
             {
-                fuckingsun->X.D.transluent = TRUE;
-                Target->phase_smap_direct_tsh(fuckingsun, SE_SUN_NEAR);
+                sun->X.D[0].transluent = TRUE;
+                RImplementation.Target->phase_smap_direct_tsh(sun, SE_SUN_NEAR);
                 dsgraph.render_graph(1); // normal level, secondary priority
                 dsgraph.render_sorted(); // strict-sorted geoms
             }
@@ -998,21 +995,21 @@ void CRender::render_sun_near()
 
     // End SMAP-render
     {
-        //		fuckingsun->svis.end					();
+        //		sun->svis.end					();
         dsgraph.r_pmask(true, false);
     }
 
     // Accumulate
-    Target->phase_accumulator();
+    RImplementation.Target->phase_accumulator();
 
-    if (Target->use_minmax_sm_this_frame())
+    if (RImplementation.Target->use_minmax_sm_this_frame())
     {
         PIX_EVENT(SE_SUN_NEAR_MINMAX_GENERATE);
-        Target->create_minmax_SM();
+        RImplementation.Target->create_minmax_SM();
     }
 
     PIX_EVENT(SE_SUN_NEAR);
-    Target->accum_direct(SE_SUN_NEAR);
+    RImplementation.Target->accum_direct(SE_SUN_NEAR);
 
     // Restore XForms
     RCache.set_xform_world(Fidentity);
@@ -1020,16 +1017,16 @@ void CRender::render_sun_near()
     RCache.set_xform_project(Device.mProject);
 }
 
-void CRender::render_sun_filtered() const
+void render_sun_old::render_sun_filtered() const
 {
-    if (!o.sunfilter)
+    if (!RImplementation.o.sunfilter)
         return;
-    Target->phase_accumulator();
+    RImplementation.Target->phase_accumulator();
     PIX_EVENT(SE_SUN_LUMINANCE);
-    Target->accum_direct(SE_SUN_LUMINANCE);
+    RImplementation.Target->accum_direct(SE_SUN_LUMINANCE);
 }
 
-void CRender::init_cacades()
+void render_sun::init()
 {
     u32 cascade_count = 3;
     m_sun_cascades.resize(cascade_count);
@@ -1054,24 +1051,22 @@ void CRender::init_cacades()
     /// 	m_sun_cascades[m_sun_cascades.size()-1].size = 80;
 }
 
-void CRender::render_sun_cascades()
+void render_sun::calculate()
 {
-    bool b_need_to_render_sunshafts = Target->need_to_render_sunshafts();
+    bool b_need_to_render_sunshafts = RImplementation.Target->need_to_render_sunshafts();
     bool last_cascade_chain_mode = m_sun_cascades.back().reset_chain;
     if (b_need_to_render_sunshafts)
         m_sun_cascades[m_sun_cascades.size() - 1].reset_chain = true;
 
     for (u32 i = 0; i < m_sun_cascades.size(); ++i)
-        render_sun_cascade(i);
+        calculate_cascade(i);
 
     if (b_need_to_render_sunshafts)
         m_sun_cascades[m_sun_cascades.size() - 1].reset_chain = last_cascade_chain_mode;
 }
 
-void CRender::render_sun_cascade(u32 cascade_ind)
+void render_sun::calculate_cascade(int cascade_ind)
 {
-    light* fuckingsun = (light*)Lights.sun._get();
-
     // calculate view-frustum bounds in world space
 
     // Compute volume(s) - something like a frustum for infinite directional light
@@ -1087,14 +1082,14 @@ void CRender::render_sun_cascade(u32 cascade_ind)
 
         //******************************* Need to be placed after cuboid built **************************
         // COP - 100 km away
-        cull_COP.mad(Device.vCameraPosition, fuckingsun->direction, -tweak_COP_initial_offs);
+        cull_COP.mad(Device.vCameraPosition, sun->direction, -tweak_COP_initial_offs);
 
         // Create approximate ortho-xform
         // view: auto find 'up' and 'right' vectors
         Fmatrix mdir_View, mdir_Project;
         Fvector L_dir, L_up, L_right, L_pos;
-        L_pos.set(fuckingsun->position);
-        L_dir.set(fuckingsun->direction).normalize();
+        L_pos.set(sun->position);
+        L_dir.set(sun->direction).normalize();
         L_right.set(1, 0, 0);
         if (_abs(L_right.dotproduct(L_dir)) > .99f)
             L_right.set(0, 0, 1);
@@ -1146,7 +1141,7 @@ void CRender::render_sun_cascade(u32 cascade_ind)
 
         //////////////////////////////////////////////////////////////////////////
         // build viewport xform
-        float view_dim = float(o.smapsize);
+        float view_dim = float(RImplementation.o.smapsize);
         Fmatrix m_viewport =
         {
             view_dim / 2.f, 0.0f, 0.0f, 0.0f,
@@ -1199,7 +1194,7 @@ void CRender::render_sun_cascade(u32 cascade_ind)
         static bool draw_debug = false;
         if (draw_debug && cascade_ind == 0)
             for (u32 it = 0; it < cull_planes.size(); it++)
-                Target->dbg_addplane(cull_planes[it], it * 0xFFF);
+                RImplementation.Target->dbg_addplane(cull_planes[it], it * 0xFFF);
 #endif
 
         Fvector cam_shifted = L_pos;
@@ -1255,24 +1250,25 @@ void CRender::render_sun_cascade(u32 cascade_ind)
 
         m_sun_cascades[cascade_ind].xform = cull_xform;
 
-        s32 limit = o.smapsize - 1;
-        fuckingsun->X.D.minX = 0;
-        fuckingsun->X.D.maxX = limit;
-        fuckingsun->X.D.minY = 0;
-        fuckingsun->X.D.maxY = limit;
+        s32 limit = RImplementation.o.smapsize - 1;
+        sun->X.D[cascade_ind].minX = 0;
+        sun->X.D[cascade_ind].maxX = limit;
+        sun->X.D[cascade_ind].minY = 0;
+        sun->X.D[cascade_ind].maxY = limit;
+        sun->X.D[cascade_ind].combine = cull_xform;
 
         // full-xform
         FPU::m24r();
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_SHADOW_0 + cascade_ind);
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + cascade_ind);
     dsgraph.reset(); // tmp
     {
-        //		fuckingsun->svis.begin					();
-        dsgraph.o.phase = PHASE_SMAP;
-        dsgraph.r_pmask(true, o.Tshadows);
-        dsgraph.o.sector_id = largest_sector_id;
+        //		sun->svis.begin					();
+        dsgraph.o.phase = CRender::PHASE_SMAP;
+        dsgraph.r_pmask(true, RImplementation.o.Tshadows);
+        dsgraph.o.sector_id = RImplementation.get_largest_sector();
         dsgraph.o.xform = cull_xform;
         dsgraph.o.view_frustum = cull_frustum;
         dsgraph.o.view_pos = cull_COP;
@@ -1280,68 +1276,65 @@ void CRender::render_sun_cascade(u32 cascade_ind)
         // Fill the database
         dsgraph.build_subspace();
     }
+}
 
-    // Finalize & Cleanup
-    fuckingsun->X.D.combine = cull_xform;
-
+void render_sun::render()
+{
     // Render shadow-map
     //. !!! We should clip based on shrinked frustum (again)
+    for (int cascade_ind = 0; cascade_ind < 3; ++cascade_ind) // TODO: proper max cascades
     {
+        auto& dsgraph = RImplementation.get_context(CRender::eRDSG_SHADOW_0 + cascade_ind);
+
         bool bNormal = !dsgraph.mapNormalPasses[0][0].empty() || !dsgraph.mapMatrixPasses[0][0].empty();
         bool bSpecial = !dsgraph.mapNormalPasses[1][0].empty() || !dsgraph.mapMatrixPasses[1][0].empty() ||
             !dsgraph.mapSorted.empty();
         if (bNormal || bSpecial)
         {
-            Target->phase_smap_direct(fuckingsun, SE_SUN_FAR);
+            RImplementation.Target->phase_smap_direct(sun, SE_SUN_FAR);
             RCache.set_xform_world(Fidentity);
             RCache.set_xform_view(Fidentity);
-            RCache.set_xform_project(fuckingsun->X.D.combine);
+            RCache.set_xform_project(sun->X.D[cascade_ind].combine);
             dsgraph.render_graph(0);
             if (ps_r2_ls_flags.test(R2FLAG_SUN_DETAILS))
-                Details->Render();
-            fuckingsun->X.D.transluent = FALSE;
+                RImplementation.Details->Render();
+            sun->X.D[cascade_ind].transluent = FALSE;
             if (bSpecial)
             {
-                fuckingsun->X.D.transluent = TRUE;
-                Target->phase_smap_direct_tsh(fuckingsun, SE_SUN_FAR);
+                sun->X.D[cascade_ind].transluent = TRUE;
+                RImplementation.Target->phase_smap_direct_tsh(sun, SE_SUN_FAR);
                 dsgraph.render_graph(1); // normal level, secondary priority
                 dsgraph.render_sorted(); // strict-sorted geoms
             }
         }
-    }
 
-    // End SMAP-render
-    {
-        //		fuckingsun->svis.end					();
-        dsgraph.r_pmask(true, false);
-    }
+        // Accumulate
+        RImplementation.Target->phase_accumulator();
 
-    // Accumulate
-    Target->phase_accumulator();
+        if (RImplementation.Target->use_minmax_sm_this_frame())
+        {
+            PIX_EVENT(SE_SUN_NEAR_MINMAX_GENERATE);
+            RImplementation.Target->create_minmax_SM();
+        }
 
-    if (Target->use_minmax_sm_this_frame())
-    {
-        PIX_EVENT(SE_SUN_NEAR_MINMAX_GENERATE);
-        Target->create_minmax_SM();
-    }
-
-    if (cascade_ind == 0)
-    {
-        PIX_EVENT(SE_SUN_NEAR);
-        Target->accum_direct_cascade(SE_SUN_NEAR, m_sun_cascades[cascade_ind].xform, m_sun_cascades[cascade_ind].xform,
-                                     m_sun_cascades[cascade_ind].bias);
-    }
-    else if (cascade_ind < m_sun_cascades.size() - 1)
-    {
-        PIX_EVENT(SE_SUN_MIDDLE);
-        Target->accum_direct_cascade(SE_SUN_MIDDLE, m_sun_cascades[cascade_ind].xform,
-                                     m_sun_cascades[cascade_ind - 1].xform, m_sun_cascades[cascade_ind].bias);
-    }
-    else
-    {
-        PIX_EVENT(SE_SUN_FAR);
-        Target->accum_direct_cascade(SE_SUN_FAR, m_sun_cascades[cascade_ind].xform,
-                                     m_sun_cascades[cascade_ind - 1].xform, m_sun_cascades[cascade_ind].bias);
+        if (cascade_ind == 0)
+        {
+            PIX_EVENT(SE_SUN_NEAR);
+            RImplementation.Target->accum_direct_cascade(SE_SUN_NEAR, m_sun_cascades[cascade_ind].xform, m_sun_cascades[cascade_ind].xform,
+                m_sun_cascades[cascade_ind].bias);
+        }
+        else if (cascade_ind < m_sun_cascades.size() - 1)
+        {
+            PIX_EVENT(SE_SUN_MIDDLE);
+            RImplementation.Target->accum_direct_cascade(SE_SUN_MIDDLE, m_sun_cascades[cascade_ind].xform,
+                m_sun_cascades[cascade_ind - 1].xform, m_sun_cascades[cascade_ind].bias);
+        }
+        else
+        {
+            PIX_EVENT(SE_SUN_FAR);
+            RImplementation.Target->accum_direct_cascade(SE_SUN_FAR, m_sun_cascades[cascade_ind].xform,
+                m_sun_cascades[cascade_ind - 1].xform, m_sun_cascades[cascade_ind].bias);
+        }
     }
 
     // Restore XForms

--- a/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
+++ b/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
@@ -433,8 +433,7 @@ void CRender::render_sun()
     xr_vector<Fbox3>& s_receivers = main_coarse_structure;
     s_casters.reserve(s_receivers.size());
 
-    auto& dsgraph = get_context(eRDSG_MAIN);
-    dsgraph.reset(); // tmp
+    auto& dsgraph = get_context(eRDSG_SHADOW_0);
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -954,8 +953,7 @@ void CRender::render_sun_near()
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_MAIN);
-    dsgraph.reset(); // tmp
+    auto& dsgraph = get_context(eRDSG_SHADOW_0);
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -1268,7 +1266,7 @@ void CRender::render_sun_cascade(u32 cascade_ind)
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_MAIN);
+    auto& dsgraph = get_context(eRDSG_SHADOW_0 + cascade_ind);
     dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();

--- a/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
+++ b/src/Layers/xrRenderPC_GL/r2_R_sun.cpp
@@ -433,7 +433,8 @@ void CRender::render_sun()
     xr_vector<Fbox3>& s_receivers = main_coarse_structure;
     s_casters.reserve(s_receivers.size());
 
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -953,7 +954,8 @@ void CRender::render_sun_near()
     }
 
     // Begin SMAP-render
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -1266,7 +1268,8 @@ void CRender::render_sun_cascade(u32 cascade_ind)
     }
 
     // Begin SMAP-render
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -444,8 +444,6 @@ void CRender::Calculate()
     TAL_SCOPED_TASK_NAMED("CRender::Calculate()");
 #endif // _GPA_ENABLED
 
-    auto& dsgraph = alloc_context(eRDSG_MAIN);
-
     BasicStats.Culling.Begin();
 
     // Transfer to global space to avoid deep pointer access
@@ -464,6 +462,7 @@ void CRender::Calculate()
     ViewBase.CreateFromMatrix(Device.mFullTransform, FRUSTUM_P_LRTB | FRUSTUM_P_FAR);
 
     gm_SetNearer(FALSE);
+    auto& dsgraph = get_imm_context();
     dsgraph.o.use_hom = true;
     dsgraph.o.phase = PHASE_NORMAL;
 
@@ -697,7 +696,7 @@ void CRender::Render()
     // Begin
     Target->Begin();
     o.vis_intersect = FALSE;
-    auto& dsgraph = get_context(eRDSG_MAIN);
+    auto& dsgraph = get_imm_context();
     dsgraph.o.phase = PHASE_NORMAL;
     dsgraph.render_hud(); // hud
     dsgraph.render_graph(0); // normal level
@@ -715,7 +714,7 @@ void CRender::Render()
     if (Wallmarks)
     {
         g_r = 0;
-        Wallmarks->Render(dsgraph.context_id); // wallmarks has priority as normal geometry
+        Wallmarks->Render(); // wallmarks has priority as normal geometry
     }
     dsgraph.o.use_hom = true;
     o.vis_intersect = FALSE;

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -657,6 +657,28 @@ void CRender::Calculate()
     BasicStats.Culling.End();
 }
 
+void CRender::RenderMenu()
+{
+    Target->Begin();
+
+    if (g_pGamePersistent)
+        g_pGamePersistent->OnRenderPPUI_main(); // PP-UI
+
+    // find if distortion is needed at all
+    const bool bPerform = Target->Perform();
+    const bool _menu_pp = o.distortion && (g_pGamePersistent ? g_pGamePersistent->OnRenderPPUI_query() : false);
+    if (bPerform || _menu_pp)
+    {
+        Target->phase_distortion();
+
+        if (g_pGamePersistent)
+            g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
+    
+        // combination/postprocess
+        Target->phase_combine(_menu_pp, false);
+    }
+}
+
 extern u32 g_r;
 void CRender::Render()
 {
@@ -668,12 +690,6 @@ void CRender::Render()
     {
         m_bFirstFrameAfterReset = false;
         return;
-    }
-
-    // This is an ugly workaround to prevent the context used without allocation in menus.
-    if (!dsgraph_pool[0].second)
-    {
-        alloc_context(eRDSG_MAIN);
     }
 
     g_r = 1;

--- a/src/Layers/xrRenderPC_R1/FStaticRender.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.cpp
@@ -604,7 +604,7 @@ void CRender::Calculate()
                             v_copy.box.xform(renderable->GetRenderData().xform);
                             BOOL bVisible = HOM.visible(v_copy);
                             v_orig.accept_frame = v_copy.accept_frame;
-                            v_orig.marker = v_copy.marker;
+                            memcpy(v_orig.marker, v_copy.marker, sizeof(v_copy.marker));
                             v_orig.hom_frame = v_copy.hom_frame;
                             v_orig.hom_tested = v_copy.hom_tested;
                             if (!bVisible)

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -182,8 +182,10 @@ public:
     // Main
     void BeforeRender() override;
 
-    virtual void Calculate() override;
-    virtual void Render() override;
+    void Calculate() override;
+    void Render() override;
+    void RenderMenu() override;
+
     virtual void Screenshot(ScreenshotMode mode = SM_NORMAL, LPCSTR name = nullptr) override;
     virtual void Screenshot(ScreenshotMode mode, CMemoryWriter& memory_writer) override;
     virtual void ScreenshotAsyncBegin() override;

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -95,13 +95,12 @@ private:
     void LoadSWIs(CStreamReader* fs);
 
 public:
-    ShaderElement* rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq);
-    ShaderElement* rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq);
+    ShaderElement* rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
+    ShaderElement* rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
     VertexElement* getVB_Format(int id, bool alternative = false);
     VertexStagingBuffer* getVB(int id, bool alternative = false);
     IndexStagingBuffer* getIB(int id, bool alternative = false);
     FSlideWindowItem* getSWI(int id);
-    IRender_Portal* getPortal(int id);
     IRenderVisual* model_CreatePE(LPCSTR name);
     void ApplyBlur2(FVF::TL2uv* dest, u32 size) const;
     void ApplyBlur4(FVF::TL4uv* dest, u32 w, u32 h, float k) const;
@@ -134,8 +133,8 @@ public:
     virtual IRender_Target* getTarget() override;
 
     // Main
-    void set_Object(IRenderable* O);
-    void add_Visual(IRenderable* root, IRenderVisual* V, Fmatrix& m) override; // add visual leaf (no culling performed at all)
+    void set_Object(IRenderable* O, u32 phase);
+    void add_Visual(u32 context_id, IRenderable* root, IRenderVisual* V, Fmatrix& m) override; // add visual leaf (no culling performed at all)
 
     // wallmarks
     virtual void add_StaticWallmark(ref_shader& S, const Fvector& P, float s, CDB::TRI* T, Fvector* V);

--- a/src/Layers/xrRenderPC_R1/FStaticRender.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender.h
@@ -22,7 +22,8 @@ public:
     enum
     {
         PHASE_NORMAL,
-        PHASE_POINT,
+        PHASE_SMAP,
+        PHASE_POINT = PHASE_SMAP,
         PHASE_SPOT
     };
 

--- a/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
@@ -50,8 +50,6 @@ void CRender::level_Load(IReader* fs)
     rmFar();
     rmNormal();
 
-    dsgraph.marker = 0;
-
     if (!GEnv.isDedicatedServer)
     {
         // VB,IB,SWI
@@ -128,7 +126,12 @@ void CRender::level_Unload()
     uLastLTRACK = 0;
 
     // 2.
-    dsgraph.unload();
+    for (auto& [dsgraph, is_used] : dsgraph_pool)
+    {
+        dsgraph.reset();
+        dsgraph.unload();
+        is_used = false;
+    }
 
     //*** Lights
     L_Glows->Unload();
@@ -410,9 +413,12 @@ void CRender::LoadSectors(IReader* fs)
         rmPortals = nullptr;
     }
 
-    const auto sectors_count = sectors_data.size();
-
-    dsgraph.load(sectors_data, portals_data);
+    for (auto& [dsgraph, is_used] : dsgraph_pool)
+    {
+        dsgraph.reset();
+        dsgraph.load(sectors_data, portals_data);
+        is_used = false;
+    }
 
     last_sector_id = IRender_Sector::INVALID_SECTOR_ID;
 }

--- a/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
@@ -408,13 +408,9 @@ void CRender::LoadSectors(IReader* fs)
         rmPortals = nullptr;
     }
 
-    for (int id = 0; id < eRDSG_NUM_CONTEXTS; ++id)
-    {
-        auto& [dsgraph, is_used] = dsgraph_pool[id];
-        dsgraph.reset();
-        dsgraph.load(sectors_data, portals_data);
-        is_used = false;
-    }
+    auto& dsgraph = get_imm_context();
+    dsgraph.reset();
+    dsgraph.load(sectors_data, portals_data);
 
     last_sector_id = IRender_Sector::INVALID_SECTOR_ID;
 }

--- a/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_Loader.cpp
@@ -126,12 +126,7 @@ void CRender::level_Unload()
     uLastLTRACK = 0;
 
     // 2.
-    for (auto& [dsgraph, is_used] : dsgraph_pool)
-    {
-        dsgraph.reset();
-        dsgraph.unload();
-        is_used = false;
-    }
+    cleanup_contexts();
 
     //*** Lights
     L_Glows->Unload();
@@ -413,8 +408,9 @@ void CRender::LoadSectors(IReader* fs)
         rmPortals = nullptr;
     }
 
-    for (auto& [dsgraph, is_used] : dsgraph_pool)
+    for (int id = 0; id < eRDSG_NUM_CONTEXTS; ++id)
     {
+        auto& [dsgraph, is_used] = dsgraph_pool[id];
         dsgraph.reset();
         dsgraph.load(sectors_data, portals_data);
         is_used = false;

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
@@ -253,7 +253,7 @@ void CRenderTarget::DoAsyncScreenshot() const
 
 void CRenderTarget::End()
 {
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     // find if distortion is needed at all
     const bool bPerform = Perform();

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
@@ -253,19 +253,22 @@ void CRenderTarget::DoAsyncScreenshot() const
 
 void CRenderTarget::End()
 {
-    if (g_pGamePersistent)
-        g_pGamePersistent->OnRenderPPUI_main(); // PP-UI
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
 
     // find if distortion is needed at all
     const bool bPerform = Perform();
     bool bDistort = RImplementation.o.distortion;
     const bool bCMap = NeedColorMapping();
-    const bool _menu_pp = g_pGamePersistent ? g_pGamePersistent->OnRenderPPUI_query() : false;
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
-    if (dsgraph.mapDistort.empty() && !_menu_pp)
+
+    if (dsgraph.mapDistort.empty())
         bDistort = FALSE;
     if (bDistort)
+    {
         phase_distortion();
+
+        dsgraph.render_distort();
+        dsgraph.mapDistort.clear();
+    }
 
     // combination/postprocess
     RCache.set_RT(get_base_rt());
@@ -275,6 +278,16 @@ void CRenderTarget::End()
 
     if (!bPerform)
         return;
+
+    phase_combine(bDistort, bCMap);
+}
+
+void CRenderTarget::phase_combine(bool bDistort, bool bCMap)
+{
+    RCache.set_RT(get_base_rt());
+    RCache.set_ZB(get_base_zb());
+    curWidth = Device.dwWidth;
+    curHeight = Device.dwHeight;
 
     const int gblend = clampr(iFloor((1 - param_gray) * 255.f), 0, 255);
     const int nblend = clampr(iFloor((1 - param_noise) * 255.f), 0, 255);
@@ -344,13 +357,4 @@ void CRenderTarget::phase_distortion()
     RCache.set_CullMode(CULL_CCW);
     RCache.set_ColorWriteEnable();
     RCache.ClearRT(rt_distort, color_rgba(127, 127, 127, 127));
-
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
-    if (g_pGameLevel && g_pGamePersistent && !g_pGamePersistent->OnRenderPPUI_query())
-        dsgraph.render_distort();
-    else
-        dsgraph.mapDistort.clear();
-
-    if (g_pGamePersistent)
-        g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
 }

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.cpp
@@ -261,7 +261,8 @@ void CRenderTarget::End()
     bool bDistort = RImplementation.o.distortion;
     const bool bCMap = NeedColorMapping();
     const bool _menu_pp = g_pGamePersistent ? g_pGamePersistent->OnRenderPPUI_query() : false;
-    if (RImplementation.dsgraph.mapDistort.empty() && !_menu_pp)
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    if (dsgraph.mapDistort.empty() && !_menu_pp)
         bDistort = FALSE;
     if (bDistort)
         phase_distortion();
@@ -344,10 +345,11 @@ void CRenderTarget::phase_distortion()
     RCache.set_ColorWriteEnable();
     RCache.ClearRT(rt_distort, color_rgba(127, 127, 127, 127));
 
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
     if (g_pGameLevel && g_pGamePersistent && !g_pGamePersistent->OnRenderPPUI_query())
-        RImplementation.dsgraph.render_distort();
+        dsgraph.render_distort();
     else
-        RImplementation.dsgraph.mapDistort.clear();
+        dsgraph.mapDistort.clear();
 
     if (g_pGamePersistent)
         g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
@@ -71,7 +71,6 @@ private:
 
     void calc_tc_noise(Fvector2& p0, Fvector2& p1);
     void calc_tc_duality_ss(Fvector2& r0, Fvector2& r1, Fvector2& l0, Fvector2& l1);
-    void phase_distortion();
 
 public:
     CRenderTarget();
@@ -110,4 +109,7 @@ public:
     u32 get_height() override { return curHeight; }
     u32 get_rtwidth() const { return rtWidth; }
     u32 get_rtheight() const { return rtHeight; }
+
+    void phase_distortion();
+    void phase_combine(bool bDistort, bool bCMap);
 };

--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
@@ -69,9 +69,6 @@ private:
     [[nodiscard]]
     bool Available() const { return bAvailable; }
 
-    [[nodiscard]]
-    bool Perform() const;
-
     void calc_tc_noise(Fvector2& p0, Fvector2& p1);
     void calc_tc_duality_ss(Fvector2& r0, Fvector2& r1, Fvector2& l0, Fvector2& l1);
     void phase_distortion();
@@ -83,6 +80,8 @@ public:
     void End();
 
     void DoAsyncScreenshot() const;
+    [[nodiscard]]
+    bool Perform() const;
 
     [[nodiscard]]
     ID3DRenderTargetView* get_base_rt() const { return rt_Base[HW.CurrentBackBuffer]->pRT; }

--- a/src/Layers/xrRenderPC_R1/LightPPA.cpp
+++ b/src/Layers/xrRenderPC_R1/LightPPA.cpp
@@ -19,9 +19,13 @@ const float SSM_tex_size = 32.f;
 //////////////////////////////////////////////////////////////////////////
 void cl_light_PR::setup(R_constant* C)
 {
+    // NOTE: an actual context id is required here. However, we have only main context
+    // in R1 so it is safe to go with `eRDSG_MAIN`.
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     Fvector& P = RImplementation.r1_dlight_light->position;
     float R = RImplementation.r1_dlight_light->range;
-    if (RImplementation.active_phase() == CRender::PHASE_POINT)
+    if (dsgraph.o.phase == CRender::PHASE_POINT)
         RCache.set_c(C, P.x, P.y, P.z, .5f / R);
     else
         RCache.set_c(C, P.x, P.y, P.z, 1.f / R);
@@ -145,6 +149,8 @@ void CLightR_Manager::render_point  ()
 
 void CLightR_Manager::render_point(u32 _priority)
 {
+    auto &dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     // for each light
     Fvector lc_COP = Device.vCameraPosition;
     float lc_limit = ps_r1_dlights_clip;
@@ -194,18 +200,18 @@ void CLightR_Manager::render_point(u32 _priority)
         // 3. Calculate visibility for light + build soring tree
         VERIFY(L->spatial.sector_id != IRender_Sector::INVALID_SECTOR_ID);
         if (_priority == 1)
-            RImplementation.dsgraph.r_pmask(false, true);
+            dsgraph.r_pmask(false, true);
 
-        RImplementation.dsgraph.o.sector_id = L->spatial.sector_id;
-        RImplementation.dsgraph.o.view_pos = L_pos;
-        RImplementation.dsgraph.o.xform = L_combine;
-        RImplementation.dsgraph.o.view_frustum.CreateFromMatrix(L_combine, FRUSTUM_P_ALL & (~FRUSTUM_P_NEAR));
-        RImplementation.dsgraph.o.precise_portals = true;
+        dsgraph.o.sector_id = L->spatial.sector_id;
+        dsgraph.o.view_pos = L_pos;
+        dsgraph.o.xform = L_combine;
+        dsgraph.o.view_frustum.CreateFromMatrix(L_combine, FRUSTUM_P_ALL & (~FRUSTUM_P_NEAR));
+        dsgraph.o.precise_portals = true;
 
-        RImplementation.dsgraph.build_subspace();
+        dsgraph.build_subspace();
 
         if (_priority == 1)
-            RImplementation.dsgraph.r_pmask(true, true);
+            dsgraph.r_pmask(true, true);
 
         // 4. Analyze if HUD intersects light volume
         BOOL bHUD = FALSE;
@@ -216,16 +222,18 @@ void CLightR_Manager::render_point(u32 _priority)
         // 5. Dump sorting tree
         RCache.set_Constants((R_constant_table*)nullptr);
         if (bHUD && _priority == 0)
-            g_hud->Render_Last();
-        RImplementation.dsgraph.render_graph(_priority);
+            g_hud->Render_Last(dsgraph.context_id);
+        dsgraph.render_graph(_priority);
         if (bHUD && _priority == 0)
-            RImplementation.dsgraph.render_hud();
+            dsgraph.render_hud();
     }
     // ??? grass ???
 }
 
 void CLightR_Manager::render_spot(u32 _priority)
 {
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     // for each light
     //  Msg ("l=%d",selected_spot.size());
     Fvector lc_COP = Device.vCameraPosition;
@@ -275,18 +283,18 @@ void CLightR_Manager::render_spot(u32 _priority)
         // 3. Calculate visibility for light + build soring tree
         VERIFY(L->spatial.sector_id != IRender_Sector::INVALID_SECTOR_ID);
         if (_priority == 1)
-            RImplementation.dsgraph.r_pmask(false, true);
+            dsgraph.r_pmask(false, true);
 
-        RImplementation.dsgraph.o.sector_id = L->spatial.sector_id;
-        RImplementation.dsgraph.o.view_pos = L_pos;
-        RImplementation.dsgraph.o.xform = L_combine;
-        RImplementation.dsgraph.o.view_frustum.CreateFromMatrix(L_combine, FRUSTUM_P_ALL & (~FRUSTUM_P_NEAR));
-        RImplementation.dsgraph.o.precise_portals = true;
+        dsgraph.o.sector_id = L->spatial.sector_id;
+        dsgraph.o.view_pos = L_pos;
+        dsgraph.o.xform = L_combine;
+        dsgraph.o.view_frustum.CreateFromMatrix(L_combine, FRUSTUM_P_ALL & (~FRUSTUM_P_NEAR));
+        dsgraph.o.precise_portals = true;
 
-        RImplementation.dsgraph.build_subspace();
+        dsgraph.build_subspace();
 
         if (_priority == 1)
-            RImplementation.dsgraph.r_pmask(true, true);
+            dsgraph.r_pmask(true, true);
 
         // 4. Analyze if HUD intersects light volume
         BOOL bHUD = FALSE;
@@ -299,10 +307,10 @@ void CLightR_Manager::render_spot(u32 _priority)
         //RCache.set_ClipPlanes(true,  &L_combine);
         RCache.set_Constants((R_constant_table*)nullptr);
         if (bHUD && _priority == 0)
-            g_hud->Render_Last();
-        RImplementation.dsgraph.render_graph(_priority);
+            g_hud->Render_Last(dsgraph.context_id);
+        dsgraph.render_graph(_priority);
         if (bHUD && _priority == 0)
-            RImplementation.dsgraph.render_hud();
+            dsgraph.render_hud();
         //RCache.set_ClipPlanes(false, &L_combine);
     }
     // ??? grass ???l
@@ -310,9 +318,11 @@ void CLightR_Manager::render_spot(u32 _priority)
 
 void CLightR_Manager::render(u32 _priority)
 {
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     if (selected_spot.size())
     {
-        RImplementation.dsgraph.o.phase = CRender::PHASE_SPOT;
+        dsgraph.o.phase = CRender::PHASE_SPOT;
         render_spot(_priority);
 
         if (_priority == 1)
@@ -320,7 +330,7 @@ void CLightR_Manager::render(u32 _priority)
     }
     if (selected_point.size())
     {
-        RImplementation.dsgraph.o.phase = CRender::PHASE_POINT;
+        dsgraph.o.phase = CRender::PHASE_POINT;
         render_point(_priority);
 
         if (_priority == 1)

--- a/src/Layers/xrRenderPC_R1/LightPPA.cpp
+++ b/src/Layers/xrRenderPC_R1/LightPPA.cpp
@@ -21,7 +21,7 @@ void cl_light_PR::setup(R_constant* C)
 {
     // NOTE: an actual context id is required here. However, we have only main context
     // in R1 so it is safe to go with `eRDSG_MAIN`.
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     Fvector& P = RImplementation.r1_dlight_light->position;
     float R = RImplementation.r1_dlight_light->range;
@@ -149,7 +149,7 @@ void CLightR_Manager::render_point  ()
 
 void CLightR_Manager::render_point(u32 _priority)
 {
-    auto &dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto &dsgraph = RImplementation.get_imm_context();
 
     // for each light
     Fvector lc_COP = Device.vCameraPosition;
@@ -232,7 +232,7 @@ void CLightR_Manager::render_point(u32 _priority)
 
 void CLightR_Manager::render_spot(u32 _priority)
 {
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     // for each light
     //  Msg ("l=%d",selected_spot.size());
@@ -318,7 +318,7 @@ void CLightR_Manager::render_spot(u32 _priority)
 
 void CLightR_Manager::render(u32 _priority)
 {
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     if (selected_spot.size())
     {

--- a/src/Layers/xrRenderPC_R1/LightProjector.cpp
+++ b/src/Layers/xrRenderPC_R1/LightProjector.cpp
@@ -82,7 +82,7 @@ void CLightProjector::set_object(IRenderable* O)
                 current = nullptr;
             else
             {
-                auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+                auto& dsgraph = RImplementation.get_imm_context();
                 const auto& entity_pos = spatial->spatial_sector_point();
                 spatial->spatial_updatesector(dsgraph.detect_sector(entity_pos));
                 if (spatial->GetSpatialData().sector_id == IRender_Sector::INVALID_SECTOR_ID)
@@ -187,7 +187,7 @@ void CLightProjector::calculate()
     RCache.ClearZB(RImplementation.Target->rt_temp_zb, 1.f, 0);
     RCache.set_xform_world(Fidentity);
 
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     // reallocate/reassociate structures + perform all the work
     for (u32 c_it = 0; c_it < cache.size(); c_it++)

--- a/src/Layers/xrRenderPC_R1/LightProjector.cpp
+++ b/src/Layers/xrRenderPC_R1/LightProjector.cpp
@@ -82,8 +82,9 @@ void CLightProjector::set_object(IRenderable* O)
                 current = nullptr;
             else
             {
+                auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
                 const auto& entity_pos = spatial->spatial_sector_point();
-                spatial->spatial_updatesector(RImplementation.dsgraph.detect_sector(entity_pos));
+                spatial->spatial_updatesector(dsgraph.detect_sector(entity_pos));
                 if (spatial->GetSpatialData().sector_id == IRender_Sector::INVALID_SECTOR_ID)
                 {
                     IGameObject* obj = dynamic_cast<IGameObject*>(O);
@@ -185,6 +186,8 @@ void CLightProjector::calculate()
     RCache.set_ZB(RImplementation.Target->rt_temp_zb->pRT);
     RCache.ClearZB(RImplementation.Target->rt_temp_zb, 1.f, 0);
     RCache.set_xform_world(Fidentity);
+
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
 
     // reallocate/reassociate structures + perform all the work
     for (u32 c_it = 0; c_it < cache.size(); c_it++)
@@ -321,10 +324,10 @@ void CLightProjector::calculate()
         if (spatial)
         {
             const auto& entity_pos = spatial->spatial_sector_point();
-            const auto sector_id = RImplementation.dsgraph.detect_sector(entity_pos);
+            const auto sector_id = dsgraph.detect_sector(entity_pos);
             spatial->spatial_updatesector(sector_id);
             if (spatial->GetSpatialData().sector_id != IRender_Sector::INVALID_SECTOR_ID)
-                RImplementation.dsgraph.render_R1_box(spatial->GetSpatialData().sector_id, BB, SE_R1_LMODELS);
+                dsgraph.render_R1_box(spatial->GetSpatialData().sector_id, BB, SE_R1_LMODELS);
         }
         // if (spatial)      RImplementation.r_dsgraph_render_subspace   (spatial->spatial.sector,mCombine,v_C,FALSE);
     }

--- a/src/Layers/xrRenderPC_R1/LightShadows.cpp
+++ b/src/Layers/xrRenderPC_R1/LightShadows.cpp
@@ -176,7 +176,7 @@ void CLightShadows::calculate()
     if (casters.empty())
         return;
 
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
 
     BOOL bRTS = FALSE;
     RCache.set_Z(false);

--- a/src/Layers/xrRenderPC_R1/LightShadows.cpp
+++ b/src/Layers/xrRenderPC_R1/LightShadows.cpp
@@ -176,6 +176,8 @@ void CLightShadows::calculate()
     if (casters.empty())
         return;
 
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+
     BOOL bRTS = FALSE;
     RCache.set_Z(false);
 
@@ -317,7 +319,7 @@ void CLightShadows::calculate()
                 dxRender_Visual* V = N.pVisual;
                 RCache.set_Element(V->shader->E[SE_R1_LMODELS]);
                 RCache.set_xform_world(N.Matrix);
-                V->Render(-1.0f, RImplementation.active_phase() == CRender::PHASE_SMAP);
+                V->Render(-1.0f, dsgraph.o.phase == CRender::PHASE_SMAP);
             }
 
             // register shadow and increment slot

--- a/src/Layers/xrRenderPC_R1/LightShadows.cpp
+++ b/src/Layers/xrRenderPC_R1/LightShadows.cpp
@@ -317,7 +317,7 @@ void CLightShadows::calculate()
                 dxRender_Visual* V = N.pVisual;
                 RCache.set_Element(V->shader->E[SE_R1_LMODELS]);
                 RCache.set_xform_world(N.Matrix);
-                V->Render(-1.0f);
+                V->Render(-1.0f, RImplementation.active_phase() == CRender::PHASE_SMAP);
             }
 
             // register shadow and increment slot

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_direct.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_direct.cpp
@@ -131,7 +131,7 @@ void CRenderTarget::accum_direct(u32 sub_phase)
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -354,7 +354,7 @@ void CRenderTarget::accum_direct_cascade(u32 sub_phase, Fmatrix& xform, Fmatrix&
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[sub_phase].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -667,7 +667,7 @@ void CRenderTarget::accum_direct_f(u32 sub_phase)
             Fmatrix xf_invview;
             xf_invview.invert(Device.mView);
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[0].combine);
             m_shadow.mul(xf_project, xf_invview);
 
             // tsm-bias

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
@@ -226,8 +226,6 @@ void CRenderTarget::phase_combine()
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
             dsgraph.render_distort();
-            if (g_pGamePersistent)
-                g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }
     }
 

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
@@ -214,7 +214,8 @@ void CRenderTarget::phase_combine()
     // Distortion filter
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
-        if ((0 == RImplementation.dsgraph.mapDistort.size()) && !_menu_pp)
+        auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+        if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)
             bDistort = FALSE;
         if (bDistort)
         {
@@ -224,7 +225,7 @@ void CRenderTarget::phase_combine()
             RCache.set_CullMode(CULL_CCW);
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
-            RImplementation.dsgraph.render_distort();
+            dsgraph.render_distort();
             if (g_pGamePersistent)
                 g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_combine.cpp
@@ -214,7 +214,7 @@ void CRenderTarget::phase_combine()
     // Distortion filter
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
-        auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+        auto& dsgraph = RImplementation.get_imm_context();
         if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)
             bDistort = FALSE;
         if (bDistort)

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_smap_D.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_smap_D.cpp
@@ -11,8 +11,8 @@ void CRenderTarget::phase_smap_direct(light* L, u32 sub_phase)
         // optimized clear
         const Irect rect =
         {
-            L->X.D.minX, L->X.D.minY,
-            L->X.D.maxX, L->X.D.maxY
+            L->X.D[0].minX, L->X.D[0].minY,
+            L->X.D[0].maxX, L->X.D[0].maxY
         };
         RCache.ClearZBRect(rt_smap_depth, 1.0f, 1, &rect);
     }

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_accum_direct.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_accum_direct.cpp
@@ -188,7 +188,7 @@ void CRenderTarget::accum_direct(u32 sub_phase)
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, RImplementation.r_sun.sun->X.D[0].combine); // TODO: move into render_sun
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -505,7 +505,7 @@ void CRenderTarget::accum_direct_cascade(u32 sub_phase, Fmatrix& xform, Fmatrix&
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[sub_phase].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias
@@ -954,7 +954,7 @@ void CRenderTarget::accum_direct_f(u32 sub_phase)
         {
             FPU::m64r();
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, fuckingsun->X.D.combine);
+            xf_project.mul(m_TexelAdjust, fuckingsun->X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             // tsm-bias

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -285,9 +285,10 @@ void CRenderTarget::phase_combine()
     // u_setrt(rt_Generic_1,0,0,get_base_zb());
 
     // Distortion filter
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
-        if ((0 == RImplementation.dsgraph.mapDistort.size()) && !_menu_pp)
+        if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)
             bDistort = FALSE;
         if (bDistort)
         {
@@ -297,7 +298,7 @@ void CRenderTarget::phase_combine()
             RCache.set_CullMode(CULL_CCW);
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
-            RImplementation.dsgraph.render_distort();
+            dsgraph.render_distort();
             if (g_pGamePersistent)
                 g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -285,7 +285,7 @@ void CRenderTarget::phase_combine()
     // u_setrt(rt_Generic_1,0,0,get_base_zb());
 
     // Distortion filter
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_MAIN);
+    auto& dsgraph = RImplementation.get_imm_context();
     BOOL bDistort = RImplementation.o.distortion_enabled; // This can be modified
     {
         if ((0 == dsgraph.mapDistort.size()) && !_menu_pp)

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_combine.cpp
@@ -299,8 +299,6 @@ void CRenderTarget::phase_combine()
             RCache.set_Stencil(FALSE);
             RCache.set_ColorWriteEnable();
             dsgraph.render_distort();
-            if (g_pGamePersistent)
-                g_pGamePersistent->OnRenderPPUI_PP(); // PP-UI
         }
     }
 

--- a/src/Layers/xrRender_R2/r2.cpp
+++ b/src/Layers/xrRender_R2/r2.cpp
@@ -42,20 +42,20 @@ public:
 
 float r_dtex_range = 50.f;
 //////////////////////////////////////////////////////////////////////////
-ShaderElement* CRender::rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq)
+ShaderElement* CRender::rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq, u32 phase)
 {
     int id = SE_R2_SHADOW;
-    if (CRender::PHASE_NORMAL == RImplementation.active_phase())
+    if (CRender::PHASE_NORMAL == phase)
     {
         id = ((_sqrt(cdist_sq) - pVisual->vis.sphere.R) < r_dtex_range) ? SE_R2_NORMAL_HQ : SE_R2_NORMAL_LQ;
     }
     return pVisual->shader->E[id]._get();
 }
 //////////////////////////////////////////////////////////////////////////
-ShaderElement* CRender::rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq)
+ShaderElement* CRender::rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq, u32 phase)
 {
     int id = SE_R2_SHADOW;
-    if (CRender::PHASE_NORMAL == RImplementation.active_phase())
+    if (CRender::PHASE_NORMAL == phase)
     {
         id = ((_sqrt(cdist_sq) - pVisual->vis.sphere.R) < r_dtex_range) ? SE_R2_NORMAL_HQ : SE_R2_NORMAL_LQ;
     }
@@ -621,7 +621,6 @@ void CRender::create()
 #if defined(USE_DX11) || defined(USE_OGL)
     rmNormal();
 #endif
-    dsgraph.marker = 0;
     q_sync_point.Create();
 
     //	TODO: OGL: Implement FluidManager.
@@ -848,8 +847,10 @@ IRender_Glow* CRender::glow_create() { return xr_new<CGlow>(); }
 bool CRender::occ_visible(vis_data& P) { return HOM.visible(P); }
 bool CRender::occ_visible(sPoly& P) { return HOM.visible(P); }
 bool CRender::occ_visible(Fbox& P) { return HOM.visible(P); }
-void CRender::add_Visual(IRenderable* root, IRenderVisual* V, Fmatrix& m)
+void CRender::add_Visual(u32 context_id, IRenderable* root, IRenderVisual* V, Fmatrix& m)
 {
+    // TODO: this whole function should be replaced by a list of renderables+xforms returned from `renderable_Render` call
+    auto& dsgraph = get_context(context_id);
     dsgraph.add_leafs_dynamic(root, (dxRender_Visual*)V, m);
 }
 void CRender::add_StaticWallmark(ref_shader& S, const Fvector& P, float s, CDB::TRI* T, Fvector* verts)

--- a/src/Layers/xrRender_R2/r2.cpp
+++ b/src/Layers/xrRender_R2/r2.cpp
@@ -918,6 +918,7 @@ void CRender::rmNormal()
 //////////////////////////////////////////////////////////////////////
 CRender::CRender()
     : Sectors_xrc("render")
+    , r_main("main_render")
     , r_sun("sun_render")
     , r_sun_old("sun_render_old")
 #if RENDER != R_R2

--- a/src/Layers/xrRender_R2/r2.cpp
+++ b/src/Layers/xrRender_R2/r2.cpp
@@ -918,7 +918,6 @@ void CRender::rmNormal()
 //////////////////////////////////////////////////////////////////////
 CRender::CRender() : Sectors_xrc("render")
 {
-    init_cacades();
 }
 
 CRender::~CRender() {}

--- a/src/Layers/xrRender_R2/r2.cpp
+++ b/src/Layers/xrRender_R2/r2.cpp
@@ -916,7 +916,13 @@ void CRender::rmNormal()
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
-CRender::CRender() : Sectors_xrc("render")
+CRender::CRender()
+    : Sectors_xrc("render")
+    , r_sun("sun_render")
+    , r_sun_old("sun_render_old")
+#if RENDER != R_R2
+    , r_rain("rain_render")
+#endif
 {
 }
 

--- a/src/Layers/xrRender_R2/r2.cpp
+++ b/src/Layers/xrRender_R2/r2.cpp
@@ -657,7 +657,8 @@ void CRender::reset_begin()
                 continue;
             try
             {
-                Lights_LastFrame[it]->svis.resetoccq();
+                for (int id = 0; id < 3; ++id)
+                    Lights_LastFrame[it]->svis[id].resetoccq();
             }
             catch (...)
             {

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -209,6 +209,10 @@ public:
 
         u32 forcegloss : 1;
         u32 forceskinw : 1;
+
+        u32 mt_calculate : 1;
+        u32 mt_render : 1;
+
         float forcegloss_v;
     } o;
 

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -43,6 +43,43 @@ struct render_rain : public i_render_phase
 
     light RainLight;
 };
+
+struct render_sun : public i_render_phase
+{
+    void init() override;
+    void calculate() override;
+    void render() override;
+
+    bool should_render() const { return is_enabled; };
+
+    void calculate_cascade(int cascade_id);
+
+    xr_vector<sun::cascade> m_sun_cascades;
+    light* sun{ nullptr };
+    bool is_enabled{ false };
+};
+
+struct render_sun_old : public i_render_phase
+{
+    void init() override { /* the same as render_sun */ };
+    void calculate() override { /* the same as render_sun */ }
+    void render() override
+    {
+        render_sun_near();
+        render_sun();
+        render_sun_filtered();
+    }
+
+    bool should_render() const { return is_enabled; };
+
+    void render_sun();
+    void render_sun_near();
+    void render_sun_filtered() const;
+
+    xr_vector<sun::cascade> m_sun_cascades;
+    light* sun{ nullptr };
+    bool is_enabled{ false };
+};
 //----
 
 // definition
@@ -217,8 +254,6 @@ public:
     bool m_bMakeAsyncSS;
     bool m_bFirstFrameAfterReset{}; // Determines weather the frame is the first after resetting device.
 
-    xr_vector<sun::cascade> m_sun_cascades;
-
 private:
     // Loading / Unloading
     void LoadBuffers(CStreamReader* fs, bool alternative);
@@ -234,18 +269,13 @@ public:
     void render_forward();
     void render_indirect(light* L) const;
     void render_lights(light_Package& LP);
-    void render_sun();
-    void render_sun_near();
-    void render_sun_filtered() const;
     void render_menu();
 #if RENDER != R_R2
     render_rain r_rain;
 #endif
 
-    void render_sun_cascade(u32 cascade_ind);
-    void init_cacades();
-    void render_sun_cascades();
-    bool bSUN{ false };
+    render_sun r_sun;
+    render_sun_old r_sun_old;
 
 public:
     auto get_largest_sector() const { return largest_sector_id; }

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -91,6 +91,7 @@ struct render_rain : public i_render_phase
     void render() override;
 
     light RainLight;
+    u32 context_id{ R_dsgraph_structure::INVALID_CONTEXT_ID };
 };
 
 struct render_sun : public i_render_phase
@@ -101,19 +102,19 @@ struct render_sun : public i_render_phase
     void calculate_task(Task&, void*) override;
     void render() override;
 
-    void calculate_cascade(int cascade_id);
-
     xr_vector<sun::cascade> m_sun_cascades;
     light* sun{ nullptr };
     bool need_to_render_sunshafts{ false };
     bool last_cascade_chain_mode{ false };
+
+    u32 contexts_ids[R__NUM_SUN_CASCADES];
 };
 
 struct render_sun_old : public i_render_phase
 {
     explicit render_sun_old(const xr_string& name_in) : i_render_phase(name) {}
 
-    void init() override { /* the same as render_sun */ };
+    void init() override;
     void calculate_task(Task&, void*) override { /* the same as render_sun */ }
     void render() override
     {
@@ -128,6 +129,7 @@ struct render_sun_old : public i_render_phase
 
     xr_vector<sun::cascade> m_sun_cascades;
     light* sun{ nullptr };
+    u32 context_id{ R_dsgraph_structure::INVALID_CONTEXT_ID };
 };
 //----
 

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -228,8 +228,8 @@ public:
     void render_sun_cascades();
 
 public:
-    ShaderElement* rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq);
-    ShaderElement* rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq);
+    ShaderElement* rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
+    ShaderElement* rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
     VertexElement* getVB_Format(int id, bool alternative = false);
     VertexStagingBuffer* getVB(int id, bool alternative = false);
     IndexStagingBuffer* getIB(int id, bool alternative = false);
@@ -335,7 +335,7 @@ public:
     IRender_Target* getTarget() override;
 
     // Main
-    void add_Visual(IRenderable* root, IRenderVisual* V, Fmatrix& m) override; // add visual leaf	(no culling performed at all)
+    void add_Visual(u32 context_id, IRenderable* root, IRenderVisual* V, Fmatrix& m) override; // add visual leaf	(no culling performed at all)
     // wallmarks
     void add_StaticWallmark(ref_shader& S, const Fvector& P, float s, CDB::TRI* T, Fvector* V);
     void add_StaticWallmark(IWallMarkArray* pArray, const Fvector& P, float s, CDB::TRI* T, Fvector* V) override;

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -245,6 +245,7 @@ public:
     void render_sun_cascade(u32 cascade_ind);
     void init_cacades();
     void render_sun_cascades();
+    bool bSUN{ false };
 
 public:
     auto get_largest_sector() const { return largest_sector_id; }

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -25,6 +25,26 @@
 class CRenderTarget;
 class dxRender_Visual;
 
+// TODO: move it into separate file.
+struct i_render_phase
+{
+    virtual void init() = 0;
+    virtual void calculate() = 0;
+    virtual void render() = 0;
+};
+
+struct render_rain : public i_render_phase
+{
+    void init() override;
+    void calculate() override;
+    void render() override;
+
+    bool should_render() const;
+
+    light RainLight;
+};
+//----
+
 // definition
 class CRender final : public D3DXRenderBase
 {
@@ -179,7 +199,6 @@ public:
     SMAP_Allocator LP_smap_pool;
     light_Package LP_normal;
     light_Package LP_pending;
-    light RainLight;
 
     xr_vector<Fbox3> main_coarse_structure;
 
@@ -220,7 +239,7 @@ public:
     void render_sun_filtered() const;
     void render_menu();
 #if RENDER != R_R2
-    void render_rain();
+    render_rain r_rain;
 #endif
 
     void render_sun_cascade(u32 cascade_ind);
@@ -228,6 +247,7 @@ public:
     void render_sun_cascades();
 
 public:
+    auto get_largest_sector() const { return largest_sector_id; }
     ShaderElement* rimp_select_sh_static(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
     ShaderElement* rimp_select_sh_dynamic(dxRender_Visual* pVisual, float cdist_sq, u32 phase);
     VertexElement* getVB_Format(int id, bool alternative = false);

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -73,6 +73,15 @@ struct i_render_phase
     xr_string name{ "" };
 };
 
+struct render_main : public i_render_phase
+{
+    explicit render_main(const xr_string& name_in) : i_render_phase(name) {}
+
+    void init() override;
+    void calculate_task(Task&, void*) override;
+    void render() override;
+};
+
 struct render_rain : public i_render_phase
 {
     explicit render_rain(const xr_string& name_in) : i_render_phase(name) {}
@@ -96,6 +105,8 @@ struct render_sun : public i_render_phase
 
     xr_vector<sun::cascade> m_sun_cascades;
     light* sun{ nullptr };
+    bool need_to_render_sunshafts{ false };
+    bool last_cascade_chain_mode{ false };
 };
 
 struct render_sun_old : public i_render_phase
@@ -312,6 +323,8 @@ public:
     void render_indirect(light* L) const;
     void render_lights(light_Package& LP);
     void render_menu();
+
+    render_main r_main;
 #if RENDER != R_R2
     render_rain r_rain;
 #endif

--- a/src/Layers/xrRender_R2/r2.h
+++ b/src/Layers/xrRender_R2/r2.h
@@ -487,6 +487,8 @@ public:
 
     void Calculate() override;
     void Render() override;
+    void RenderMenu() override;
+
     void Screenshot(ScreenshotMode mode = SM_NORMAL, LPCSTR name = nullptr) override;
     void Screenshot(ScreenshotMode mode, CMemoryWriter& memory_writer) override;
     void ScreenshotAsyncBegin() override;

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -84,7 +84,7 @@ void CRender::Calculate()
     {
         dsgraph_main.o.phase = PHASE_NORMAL;
         dsgraph_main.r_pmask(true, false, true); // enable priority "0",+ capture wmarks
-        if (r_sun.should_render() && o.oldshadowcascades)
+        if (r_sun.o.active && o.oldshadowcascades)
             dsgraph_main.set_Recorder(&main_coarse_structure); // this is a show stopper. Can't be paralleled with sun
         else
             dsgraph_main.set_Recorder(nullptr);

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -62,7 +62,13 @@ void CRender::Calculate()
         Lights.add_light(L);
     }
 
+#if RENDER != R_R2
     auto& dsgraph_rain = alloc_context(eRDSG_RAIN);
+    {
+        r_rain.calculate();
+    }
+#endif
+
     auto& dsgraph_shadow0 = alloc_context(eRDSG_SHADOW_0);
     auto& dsgraph_shadow1 = alloc_context(eRDSG_SHADOW_1);
     auto& dsgraph_shadow2 = alloc_context(eRDSG_SHADOW_2);

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -26,6 +26,8 @@ void CRender::Calculate()
     r_ssaHZBvsTEX = _sqr(ps_r__ssaHZBvsTEX / 3) / g_fSCREEN;
     r_dtex_range = ps_r2_df_parallax_range * g_fSCREEN / (1024.f * 768.f);
 
+    auto& dsgraph = RImplementation.alloc_context(eRDSG_MAIN);
+
     // Detect camera-sector
     if (!Device.vCameraDirectionSaved.similar(Device.vCameraPosition, EPS_L))
     {

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -13,6 +13,9 @@ extern float r_ssaLOD_B;
 extern float r_ssaHZBvsTEX;
 extern float r_ssaGLOD_start, r_ssaGLOD_end;
 
+extern int ps_r2_mt_calculate;
+extern int ps_r2_mt_render;
+
 void CRender::Calculate()
 {
     // Transfer to global space to avoid deep pointer access
@@ -27,6 +30,9 @@ void CRender::Calculate()
     r_ssaGLOD_end = _sqr(ps_r__GLOD_ssa_end / 3) / g_fSCREEN;
     r_ssaHZBvsTEX = _sqr(ps_r__ssaHZBvsTEX / 3) / g_fSCREEN;
     r_dtex_range = ps_r2_df_parallax_range * g_fSCREEN / (1024.f * 768.f);
+
+    o.mt_calculate  = ps_r2_mt_calculate > 0;
+    o.mt_render     = ps_r2_mt_render > 0;
 
     auto& dsgraph_main = RImplementation.alloc_context(eRDSG_MAIN);
 

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -127,25 +127,32 @@ void CRender::Calculate()
     r_rain.init();
 #endif
 
-    //******* Main calc - DEFERRER RENDERER
     // Main calc
     BasicStats.Culling.Begin();
-    r_main.calculate();
+    {
+        r_main.calculate();
+    }
     BasicStats.Culling.End();
 
     // Rain calc
 #if RENDER != R_R2
-    auto& dsgraph_rain = alloc_context(eRDSG_RAIN);
+    if (r_rain.o.active)
     {
-        r_rain.calculate();
+        auto& dsgraph_rain = alloc_context(eRDSG_RAIN);
+        {
+            r_rain.calculate();
+        }
     }
 #endif
 
     // Sun calc
-    auto& dsgraph_shadow0 = alloc_context(eRDSG_SHADOW_0);
-    auto& dsgraph_shadow1 = alloc_context(eRDSG_SHADOW_1);
-    auto& dsgraph_shadow2 = alloc_context(eRDSG_SHADOW_2);
+    if (r_sun.o.active)
     {
-        r_sun.calculate();
+        auto& dsgraph_shadow0 = alloc_context(eRDSG_SHADOW_0);
+        auto& dsgraph_shadow1 = alloc_context(eRDSG_SHADOW_1);
+        auto& dsgraph_shadow2 = alloc_context(eRDSG_SHADOW_2);
+        {
+            r_sun.calculate();
+        }
     }
 }

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -29,7 +29,7 @@ void render_main::calculate_task(Task&, void*)
     auto& dsgraph_main = RImplementation.get_context(CRender::eRDSG_MAIN);
 
     dsgraph_main.o.phase = CRender::PHASE_NORMAL;
-    dsgraph_main.r_pmask(true, false, true); // enable priority "0",+ capture wmarks
+    dsgraph_main.r_pmask(true, true, true); // enable priority "0,1",+ capture wmarks
     if (RImplementation.r_sun.o.active && RImplementation.o.oldshadowcascades)
         dsgraph_main.set_Recorder(&RImplementation.main_coarse_structure); // this is a show-stopper. Can't be paralleled with sun
     else
@@ -49,9 +49,6 @@ void render_main::calculate_task(Task&, void*)
     dsgraph_main.o.mt_calculate = o.mt_enabled;
 
     dsgraph_main.build_subspace();
-
-    dsgraph_main.set_Recorder(nullptr);
-    dsgraph_main.r_pmask(true, false); // disable priority "1"
 }
 
 void render_main::render()
@@ -76,6 +73,9 @@ void CRender::Calculate()
     r_ssaHZBvsTEX = _sqr(ps_r__ssaHZBvsTEX / 3) / g_fSCREEN;
     r_dtex_range = ps_r2_df_parallax_range * g_fSCREEN / (1024.f * 768.f);
 
+    
+    // Configure
+    o.distortion    = o.distortion_enabled;
     o.mt_calculate  = ps_r2_mt_calculate > 0;
     o.mt_render     = ps_r2_mt_render > 0;
 
@@ -120,9 +120,6 @@ void CRender::Calculate()
     ViewBase.CreateFromMatrix(Device.mFullTransform, FRUSTUM_P_LRTB + FRUSTUM_P_FAR);
 
     TaskScheduler->Wait(*ProcessHOMTask);
-
-    // Configure
-    o.distortion = FALSE; // disable distorion
 
     r_main.init();
     r_sun.init();

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -46,6 +46,7 @@ void render_main::calculate_task(Task&, void*)
     dsgraph_main.o.view_frustum = RImplementation.ViewBase;
     dsgraph_main.o.query_box_side = VIEWPORT_NEAR + EPS_L;
     dsgraph_main.o.precise_portals = true;
+    dsgraph_main.o.mt_calculate = o.mt_enabled;
 
     dsgraph_main.build_subspace();
 

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -25,8 +25,8 @@ void render_main::init()
 }
 
 void render_main::calculate_task(Task&, void*)
-{    
-    auto& dsgraph_main = RImplementation.get_context(CRender::eRDSG_MAIN);
+{
+    auto& dsgraph_main = RImplementation.get_imm_context();
 
     dsgraph_main.o.phase = CRender::PHASE_NORMAL;
     dsgraph_main.r_pmask(true, true, true); // enable priority "0,1",+ capture wmarks
@@ -79,7 +79,7 @@ void CRender::Calculate()
     o.mt_calculate  = ps_r2_mt_calculate > 0;
     o.mt_render     = ps_r2_mt_render > 0;
 
-    auto& dsgraph_main = alloc_context(eRDSG_MAIN);
+    auto& dsgraph_main = get_imm_context();
 
     // Detect camera-sector
     if (!Device.vCameraDirectionSaved.similar(Device.vCameraPosition, EPS_L))
@@ -122,7 +122,10 @@ void CRender::Calculate()
     TaskScheduler->Wait(*ProcessHOMTask);
 
     r_main.init();
-    r_sun.init();
+    if (o.oldshadowcascades)
+        r_sun_old.init();
+    else
+        r_sun.init();
 #if RENDER != R_R2
     r_rain.init();
 #endif
@@ -138,7 +141,6 @@ void CRender::Calculate()
 #if RENDER != R_R2
     if (r_rain.o.active)
     {
-        auto& dsgraph_rain = alloc_context(eRDSG_RAIN);
         {
             r_rain.calculate();
         }
@@ -148,9 +150,6 @@ void CRender::Calculate()
     // Sun calc
     if (r_sun.o.active)
     {
-        auto& dsgraph_shadow0 = alloc_context(eRDSG_SHADOW_0);
-        auto& dsgraph_shadow1 = alloc_context(eRDSG_SHADOW_1);
-        auto& dsgraph_shadow2 = alloc_context(eRDSG_SHADOW_2);
         {
             r_sun.calculate();
         }

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -26,12 +26,12 @@ void CRender::Calculate()
     r_ssaHZBvsTEX = _sqr(ps_r__ssaHZBvsTEX / 3) / g_fSCREEN;
     r_dtex_range = ps_r2_df_parallax_range * g_fSCREEN / (1024.f * 768.f);
 
-    auto& dsgraph = RImplementation.alloc_context(eRDSG_MAIN);
+    auto& dsgraph_main = RImplementation.alloc_context(eRDSG_MAIN);
 
     // Detect camera-sector
     if (!Device.vCameraDirectionSaved.similar(Device.vCameraPosition, EPS_L))
     {
-        const auto sector_id = dsgraph.detect_sector(Device.vCameraPosition);
+        const auto sector_id = dsgraph_main.detect_sector(Device.vCameraPosition);
         if (sector_id != IRender_Sector::INVALID_SECTOR_ID)
         {
             if (sector_id != last_sector_id)
@@ -50,7 +50,7 @@ void CRender::Calculate()
     for (auto spatial : spatial_lights)
     {
         const auto& entity_pos = spatial->spatial_sector_point();
-        spatial->spatial_updatesector(dsgraph.detect_sector(entity_pos));
+        spatial->spatial_updatesector(dsgraph_main.detect_sector(entity_pos));
         const auto sector_id = spatial->GetSpatialData().sector_id;
         if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
             continue; // disassociated from S/P structure
@@ -62,5 +62,8 @@ void CRender::Calculate()
         Lights.add_light(L);
     }
 
-    // TODO: dsgraph setup goes here
+    auto& dsgraph_rain = alloc_context(eRDSG_RAIN);
+    auto& dsgraph_shadow0 = alloc_context(eRDSG_SHADOW_0);
+    auto& dsgraph_shadow1 = alloc_context(eRDSG_SHADOW_1);
+    auto& dsgraph_shadow2 = alloc_context(eRDSG_SHADOW_2);
 }

--- a/src/Layers/xrRender_R2/r2_R_lights.cpp
+++ b/src/Layers/xrRender_R2/r2_R_lights.cpp
@@ -99,7 +99,7 @@ void CRender::render_lights(light_Package& LP)
             Lights_LastFrame.push_back(L);
 
             // calculate
-            auto& dsgraph = get_context(eRDSG_MAIN);
+            auto& dsgraph = get_context(eRDSG_SHADOW_0); // TODO: batch by 3 smaps
             dsgraph.reset(); // tmp
             {
                 L->svis.begin(dsgraph.context_id);

--- a/src/Layers/xrRender_R2/r2_R_lights.cpp
+++ b/src/Layers/xrRender_R2/r2_R_lights.cpp
@@ -100,7 +100,6 @@ void CRender::render_lights(light_Package& LP)
 
             // calculate
             auto& dsgraph = get_context(eRDSG_SHADOW_0); // TODO: batch by 3 smaps
-            dsgraph.reset(); // tmp
             {
                 L->svis.begin(dsgraph.context_id);
 

--- a/src/Layers/xrRender_R2/r2_R_lights.cpp
+++ b/src/Layers/xrRender_R2/r2_R_lights.cpp
@@ -99,9 +99,10 @@ void CRender::render_lights(light_Package& LP)
             Lights_LastFrame.push_back(L);
 
             // calculate
-            dsgraph.reset();
+            auto& dsgraph = get_context(eRDSG_MAIN);
+            dsgraph.reset(); // tmp
             {
-                L->svis.begin();
+                L->svis.begin(dsgraph.context_id);
 
                 dsgraph.o.phase = PHASE_SMAP;
                 dsgraph.r_pmask(true, o.Tshadows);
@@ -144,7 +145,7 @@ void CRender::render_lights(light_Package& LP)
             {
                 Stats.s_finalclip++;
             }
-            L->svis.end();
+            L->svis.end(dsgraph.context_id); // NOTE(DX11): occqs are fetched here, this should be done on the imm context only
             dsgraph.r_pmask(true, false);
         }
 

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -332,18 +332,14 @@ void CRender::Render()
 #endif // !USE_DX9
 
     // Directional light - fucking sun
-    if (bSUN)
+    if (r_sun.should_render())
     {
         PIX_EVENT(DEFER_SUN);
         Stats.l_visible++;
         if (!RImplementation.o.oldshadowcascades)
-            render_sun_cascades();
+            r_sun.render();
         else
-        {
-            render_sun_near();
-            render_sun();
-            render_sun_filtered();
-        }
+            r_sun_old.render();
         Target->accum_direct_blend();
     }
 

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -150,6 +150,8 @@ void CRender::Render()
     BasicStats.WaitS.End();
     q_sync_point.End();
 
+    r_main.wait();
+
     if (ps_r2_ls_flags.test(R2FLAG_ZFILL))
     {
         // flush

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -332,12 +332,14 @@ void CRender::Render()
 #endif // !USE_DX9
 
     // Directional light - fucking sun
-    if (r_sun.should_render())
+    if (r_sun.o.active)
     {
         PIX_EVENT(DEFER_SUN);
         Stats.l_visible++;
         if (!RImplementation.o.oldshadowcascades)
+        {
             r_sun.render();
+        }
         else
             r_sun_old.render();
         Target->accum_direct_blend();

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -373,11 +373,9 @@ void CRender::Render()
         Target->mark_msaa_edges();
     }
 
-    //	TODO: DX11: Implement DX11 rain.
     if (ps_r2_ls_flags.test(R3FLAG_DYN_WET_SURF))
     {
-        PIX_EVENT(DEFER_RAIN);
-        render_rain();
+        r_rain.render();
     }
 #endif // !USE_DX9
 

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -99,7 +99,7 @@ void CRender::Render()
     }
 
     //.	VERIFY					(g_pGameLevel && g_pGameLevel->pHUD);
-    auto& dsgraph = get_context(eRDSG_MAIN);
+    auto& dsgraph = get_imm_context();
 
     //******* Z-prefill calc - DEFERRER RENDERER
     if (ps_r2_ls_flags.test(R2FLAG_ZFILL))
@@ -289,7 +289,7 @@ void CRender::Render()
         PIX_EVENT(DEFER_WALLMARKS);
         Target->phase_wallmarks();
         g_r = 0;
-        Wallmarks->Render(eRDSG_MAIN); // wallmarks has priority as normal geometry
+        Wallmarks->Render(); // wallmarks has priority as normal geometry
     }
 
     // Update incremental shadowmap-visibility solver
@@ -393,7 +393,7 @@ void CRender::Render()
 
 void CRender::render_forward()
 {
-    auto& dsgraph = get_context(eRDSG_MAIN);
+    auto& dsgraph = get_imm_context();
 
     //******* Main render - second order geometry (the one, that doesn't support deffering)
     //.todo: should be done inside "combine" with estimation of of luminance, tone-mapping, etc.

--- a/src/Layers/xrRender_R2/r2_R_render.cpp
+++ b/src/Layers/xrRender_R2/r2_R_render.cpp
@@ -8,7 +8,7 @@
 
 #include "Layers/xrRender/FBasicVisual.h"
 
-void CRender::render_menu()
+void CRender::RenderMenu()
 {
     PIX_EVENT(render_menu);
     //	Globals

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -927,6 +927,7 @@ void render_sun_old::render_sun_near()
         dsgraph.o.xform = cull_xform;
         dsgraph.o.view_frustum = cull_frustum;
         dsgraph.o.view_pos = cull_COP;
+        dsgraph.o.mt_calculate = o.mt_enabled;
 
         // Fill the database
         dsgraph.build_subspace();

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -1022,6 +1022,8 @@ void render_sun::init()
     o.active = ps_r2_ls_flags.test(R2FLAG_SUN) && (u_diffuse2s(sun_color.r, sun_color.g, sun_color.b) > EPS);
     if (RImplementation.o.sunstatic)
         o.active = false;
+
+    o.mt_enabled = RImplementation.o.mt_calculate;
 }
 
 void render_sun::calculate_task(Task&, void*)

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -1019,14 +1019,14 @@ void render_sun::init()
     sun = (light*)RImplementation.Lights.sun._get();
 
     const Fcolor sun_color = sun->color;
-    is_enabled = ps_r2_ls_flags.test(R2FLAG_SUN) && (u_diffuse2s(sun_color.r, sun_color.g, sun_color.b) > EPS);
+    o.active = ps_r2_ls_flags.test(R2FLAG_SUN) && (u_diffuse2s(sun_color.r, sun_color.g, sun_color.b) > EPS);
     if (RImplementation.o.sunstatic)
-        is_enabled = false;
+        o.active = false;
 }
 
-void render_sun::calculate()
+void render_sun::calculate_task(Task&, void*)
 {
-    if (!should_render())
+    if (!o.active)
     {
         return;
     }
@@ -1281,6 +1281,8 @@ void render_sun::calculate_cascade(int cascade_ind)
 
 void render_sun::render()
 {
+    wait();
+
     // Render shadow-map
     //. !!! We should clip based on shrinked frustum (again)
     for (int cascade_ind = 0; cascade_ind < 3; ++cascade_ind) // TODO: proper max cascades

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -1333,6 +1333,7 @@ void render_sun::render()
                 dsgraph.render_sorted(); // strict-sorted geoms
             }
         }
+        RImplementation.release_context(dsgraph.context_id);
 
         // Accumulate
         RImplementation.Target->phase_accumulator();

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -1286,7 +1286,7 @@ void render_sun::calculate_task(Task&, void*)
     
     if (o.mt_enabled)
     {
-        &xr_parallel_for(TaskRange<u32>(0, m_sun_cascades.size()), process_cascade);
+        xr_parallel_for(TaskRange<u32>(0, m_sun_cascades.size()), process_cascade);
     }
     else
     {

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -836,7 +836,7 @@ void render_sun_old::render_sun_near()
         hull.compute_caster_model(cull_planes, sun->direction);
 #ifdef _DEBUG
         for (u32 it = 0; it < cull_planes.size(); it++)
-            Target->dbg_addplane(cull_planes[it], 0xffffffff);
+            RImplementation.Target->dbg_addplane(cull_planes[it], 0xffffffff);
 #endif
 
         // COP - 100 km away

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -392,8 +392,7 @@ void CRender::render_sun()
     xr_vector<Fbox3>& s_receivers = main_coarse_structure;
     s_casters.reserve(s_receivers.size());
 
-    auto& dsgraph = get_context(eRDSG_MAIN);
-    dsgraph.reset(); // tmp
+    auto& dsgraph = get_context(eRDSG_SHADOW_1);
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -920,8 +919,7 @@ void CRender::render_sun_near()
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_MAIN);
-    dsgraph.reset(); // tmp
+    auto& dsgraph = get_context(eRDSG_SHADOW_0);
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.use_hom = false;
@@ -1257,11 +1255,9 @@ void CRender::render_sun_cascade(u32 cascade_ind)
     }
 
     // Begin SMAP-render
-    auto& dsgraph = get_context(eRDSG_MAIN);
-    dsgraph.reset(); // tmp
+    auto& dsgraph = get_context(eRDSG_SHADOW_0 + cascade_ind);
     {
         //		fuckingsun->svis.begin					();
-
         dsgraph.o.phase = PHASE_SMAP;
         dsgraph.r_pmask(true, o.Tshadows);
         dsgraph.o.sector_id = largest_sector_id;

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -1101,9 +1101,9 @@ void render_sun::calculate_task(Task&, void*)
     // Also compute virtual light position and sector it is inside
     xr_vector<Fplane> cull_planes;
 
-    CFrustum cull_frustum[3];
-    Fvector3 cull_COP[3];
-    Fmatrix cull_xform[3];
+    CFrustum cull_frustum[R__NUM_SUN_CASCADES];
+    Fvector3 cull_COP[R__NUM_SUN_CASCADES];
+    Fmatrix cull_xform[R__NUM_SUN_CASCADES];
 
     for (int cascade_ind = 0; cascade_ind < m_sun_cascades.size(); ++cascade_ind)
     {

--- a/src/Layers/xrRender_R2/r2_R_sun.cpp
+++ b/src/Layers/xrRender_R2/r2_R_sun.cpp
@@ -392,7 +392,8 @@ void CRender::render_sun()
     xr_vector<Fbox3>& s_receivers = main_coarse_structure;
     s_casters.reserve(s_receivers.size());
 
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.phase = PHASE_SMAP;
@@ -919,7 +920,8 @@ void CRender::render_sun_near()
     }
 
     // Begin SMAP-render
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
         dsgraph.o.use_hom = false;
@@ -1255,7 +1257,8 @@ void CRender::render_sun_cascade(u32 cascade_ind)
     }
 
     // Begin SMAP-render
-    dsgraph.reset();
+    auto& dsgraph = get_context(eRDSG_MAIN);
+    dsgraph.reset(); // tmp
     {
         //		fuckingsun->svis.begin					();
 

--- a/src/Layers/xrRender_R2/r2_loader.cpp
+++ b/src/Layers/xrRender_R2/r2_loader.cpp
@@ -477,7 +477,6 @@ void CRender::Load3DFluid()
                 dx113DFluidVolume* pVolume = xr_new<dx113DFluidVolume>();
                 pVolume->Load("", F, 0);
 
-                // we don't have an aquired context yet so take any from the pool, it should be initialized already
                 auto& dsgraph = get_imm_context();
 
                 //	Attach to sector's static geometry

--- a/src/Layers/xrRender_R2/r2_loader.cpp
+++ b/src/Layers/xrRender_R2/r2_loader.cpp
@@ -130,12 +130,7 @@ void CRender::level_Unload()
     Device.vCameraPositionSaved.set(0, 0, 0);
 
     // 2.
-    for (auto& [dsgraph, is_used] : dsgraph_pool)
-    {
-        dsgraph.reset();
-        dsgraph.unload();
-        is_used = false;
-    }
+    cleanup_contexts();
 
     //*** Lights
     // Glows.Unload			();
@@ -416,8 +411,9 @@ void CRender::LoadSectors(IReader* fs)
         rmPortals = nullptr;
     }
 
-    for (auto& [dsgraph, is_used] : dsgraph_pool)
+    for (int id = 0; id < eRDSG_NUM_CONTEXTS; ++id)
     {
+        auto& [dsgraph, is_used] = dsgraph_pool[id];
         dsgraph.reset();
         dsgraph.load(sectors_data, portals_data);
         is_used = false;

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -47,6 +47,8 @@ void render_rain::init()
     o.active = (!Device.vCameraPositionSaved.similar(Device.vCameraPosition, EPS_L) ||
         !Device.vCameraDirectionSaved.similar(Device.vCameraDirection, EPS_L) ||
         RainLight.frame_render == 0);
+    
+    o.mt_enabled = RImplementation.o.mt_calculate;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -260,7 +260,8 @@ void CRender::render_rain()
         }
 
         // Begin SMAP-render
-        dsgraph.reset();
+        auto& dsgraph = get_context(eRDSG_MAIN);
+        dsgraph.reset(); // tmp
         {
             dsgraph.o.phase = PHASE_SMAP;
             dsgraph.r_pmask(true, false);
@@ -293,10 +294,7 @@ void CRender::render_rain()
                 //	Details->Render					()	;
             }
         }
-    }
-
-    // End SMAP-render
-    {
+        // End SMAP-render
         //		fuckingsun->svis.end					();
         dsgraph.r_pmask(true, false);
     }

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -49,6 +49,10 @@ void render_rain::init()
         RainLight.frame_render == 0);
     
     o.mt_enabled = RImplementation.o.mt_calculate;
+
+    // pre-allocate context
+    context_id = RImplementation.alloc_context();
+    VERIFY(context_id != R_dsgraph_structure::INVALID_CONTEXT_ID);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -268,7 +272,7 @@ void render_rain::calculate_task(Task&, void*)
     }
 
     // Begin SMAP-render
-    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_RAIN);
+    auto& dsgraph = RImplementation.get_context(context_id);
     {
         dsgraph.o.phase = CRender::PHASE_SMAP;
         dsgraph.r_pmask(true, false);
@@ -294,7 +298,7 @@ void render_rain::render()
     {
         PIX_EVENT(RAIN);
 
-        auto& dsgraph = RImplementation.get_context(CRender::eRDSG_RAIN);
+        auto& dsgraph = RImplementation.get_context(context_id);
 
         // Render shadow-map
         //. !!! We should clip based on shrinked frustum (again)
@@ -313,7 +317,7 @@ void render_rain::render()
                 //	Details->Render					()	;
             }
         }
-        RImplementation.release_context(CRender::eRDSG_RAIN);
+        RImplementation.release_context(context_id);
     }
 
     // Restore XForms

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -44,18 +44,13 @@ static int facetable[6][4] =
 
 void render_rain::init()
 {
-    // TODO: move Target stuff here
-}
-
-bool render_rain::should_render() const
-{
-    return (!Device.vCameraPositionSaved.similar(Device.vCameraPosition, EPS_L) ||
+    o.active = (!Device.vCameraPositionSaved.similar(Device.vCameraPosition, EPS_L) ||
         !Device.vCameraDirectionSaved.similar(Device.vCameraDirection, EPS_L) ||
         RainLight.frame_render == 0);
 }
 
 //////////////////////////////////////////////////////////////////////////
-void render_rain::calculate()
+void render_rain::calculate_task(Task&, void*)
 {
     float fRainFactor = g_pGamePersistent->Environment().CurrentEnv.rain_density;
     if (fRainFactor < EPS_L)
@@ -64,7 +59,7 @@ void render_rain::calculate()
         return;
     }
 
-    if (!should_render())
+    if (!o.active)
     {
         return;
     }
@@ -290,7 +285,9 @@ void render_rain::calculate()
 
 void render_rain::render()
 {
-    if (should_render())
+    wait();
+
+    if (o.active)
     {
         PIX_EVENT(RAIN);
 

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -42,8 +42,20 @@ static int facetable[6][4] =
 };
 }
 
+void render_rain::init()
+{
+    // TODO: move Target stuff here
+}
+
+bool render_rain::should_render() const
+{
+    return (!Device.vCameraPositionSaved.similar(Device.vCameraPosition, EPS_L) ||
+        !Device.vCameraDirectionSaved.similar(Device.vCameraDirection, EPS_L) ||
+        RainLight.frame_render == 0);
+}
+
 //////////////////////////////////////////////////////////////////////////
-void CRender::render_rain()
+void render_rain::calculate()
 {
     float fRainFactor = g_pGamePersistent->Environment().CurrentEnv.rain_density;
     if (fRainFactor < EPS_L)
@@ -52,229 +64,237 @@ void CRender::render_rain()
         return;
     }
 
-    PIX_EVENT(render_rain);
-
-    if (!Device.vCameraPositionSaved.similar(Device.vCameraPosition, EPS_L) ||
-        !Device.vCameraDirectionSaved.similar(Device.vCameraDirection, EPS_L) ||
-        RainLight.frame_render == 0)
+    if (!should_render())
     {
-        // static const float	source_offset		= 40.f;
+        return;
+    }
 
-        static const float source_offset = 10000.f;
-        RainLight.direction.set(0.0f, -1.0f, 0.0f);
-        RainLight.position.set(Device.vCameraPosition.x, Device.vCameraPosition.y + source_offset,
-                               Device.vCameraPosition.z);
+    // static const float	source_offset		= 40.f;
 
-        float fBoundingSphereRadius = 0;
+    static const float source_offset = 10000.f;
+    RainLight.direction.set(0.0f, -1.0f, 0.0f);
+    RainLight.position.set(Device.vCameraPosition.x, Device.vCameraPosition.y + source_offset,
+                            Device.vCameraPosition.z);
 
-        // calculate view-frustum bounds in world space
-        Fmatrix ex_project, ex_full, ex_full_inverse;
-        {
-            const float fRainFar = ps_r3_dyn_wet_surf_far;
-            ex_project.build_projection(deg2rad(Device.fFOV /* * Device.fASPECT*/), Device.fASPECT, VIEWPORT_NEAR, fRainFar);
-            ex_full.mul(ex_project, Device.mView);
+    float fBoundingSphereRadius = 0;
+
+    // calculate view-frustum bounds in world space
+    Fmatrix ex_project, ex_full, ex_full_inverse;
+    {
+        const float fRainFar = ps_r3_dyn_wet_surf_far;
+        ex_project.build_projection(deg2rad(Device.fFOV /* * Device.fASPECT*/), Device.fASPECT, VIEWPORT_NEAR, fRainFar);
+        ex_full.mul(ex_project, Device.mView);
 #if defined(USE_DX11)
-            XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&ex_full_inverse),
-                XMMatrixInverse(nullptr, XMLoadFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&ex_full))));
+        XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&ex_full_inverse),
+            XMMatrixInverse(nullptr, XMLoadFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&ex_full))));
 #elif defined(USE_OGL)
-            XRMatrixInverse(&ex_full_inverse, nullptr, ex_full);
+        XRMatrixInverse(&ex_full_inverse, nullptr, ex_full);
 #else
 #   error No graphics API selected or enabled!
 #endif
 
-            //	Calculate view frustum were we can see dynamic rain radius
+        //	Calculate view frustum were we can see dynamic rain radius
+        {
+            //	b^2 = 2RH, B - side enge of the pyramid, h = height
+            //	R = b^2/(2*H)
+            const float H = fRainFar;
+            const float a = tanf(deg2rad(Device.fFOV) / 2);
+            const float c = tanf(deg2rad(Device.fFOV * Device.fASPECT) / 2);
+            const float b_2 = H * H * (1.0f + a * a + c * c);
+            fBoundingSphereRadius = b_2 / (2.0f * H);
+        }
+    }
+
+    // Compute volume(s) - something like a frustum for infinite directional light
+    // Also compute virtual light position and sector it is inside
+    CFrustum cull_frustum;
+    xr_vector<Fplane> cull_planes;
+    Fvector3 cull_COP;
+    Fmatrix cull_xform;
+    {
+        FPU::m64r();
+        // Lets begin from base frustum
+        Fmatrix fullxform_inv = ex_full_inverse;
+#ifdef _DEBUG
+        typedef DumbConvexVolume<true> t_volume;
+#else
+        typedef DumbConvexVolume<false> t_volume;
+#endif
+        t_volume hull;
+        {
+            hull.points.reserve(9);
+            for (int p = 0; p < 8; p++)
             {
-                //	b^2 = 2RH, B - side enge of the pyramid, h = height
-                //	R = b^2/(2*H)
-                const float H = fRainFar;
-                const float a = tanf(deg2rad(Device.fFOV) / 2);
-                const float c = tanf(deg2rad(Device.fFOV * Device.fASPECT) / 2);
-                const float b_2 = H * H * (1.0f + a * a + c * c);
-                fBoundingSphereRadius = b_2 / (2.0f * H);
+                Fvector3 xf = wform(fullxform_inv, rain::corners[p]);
+                hull.points.push_back(xf);
+            }
+            for (int plane = 0; plane < 6; plane++)
+            {
+                hull.polys.push_back(t_volume::_poly());
+                for (int pt = 0; pt < 4; pt++)
+                    hull.polys.back().points.push_back(rain::facetable[plane][pt]);
             }
         }
+        // hull.compute_caster_model	(cull_planes,fuckingsun->direction);
+        hull.compute_caster_model(cull_planes, RainLight.direction);
+#ifdef _DEBUG
+        for (u32 it = 0; it < cull_planes.size(); it++)
+            Target->dbg_addplane(cull_planes[it], 0xffffffff);
+#endif
 
-        // Compute volume(s) - something like a frustum for infinite directional light
-        // Also compute virtual light position and sector it is inside
-        CFrustum cull_frustum;
-        xr_vector<Fplane> cull_planes;
-        Fvector3 cull_COP;
-        Fmatrix cull_xform;
+        // COP - 100 km away
+        cull_COP.mad(Device.vCameraPosition, RainLight.direction, -tweak_rain_COP_initial_offs);
+        cull_COP.x += fBoundingSphereRadius * Device.vCameraDirection.x;
+        cull_COP.z += fBoundingSphereRadius * Device.vCameraDirection.z;
+
+        // Create frustum for query
+        cull_frustum._clear();
+        for (u32 p = 0; p < cull_planes.size(); p++)
+            cull_frustum._add(cull_planes[p]);
+
+        // Create approximate ortho-xform
+        // view: auto find 'up' and 'right' vectors
+        Fmatrix mdir_View, mdir_Project;
+        Fvector L_dir, L_up, L_right, L_pos;
+        L_pos.set(RainLight.position);
+        L_dir.set(RainLight.direction).normalize();
+        L_right.set(1, 0, 0);
+        if (_abs(L_right.dotproduct(L_dir)) > .99f)
+            L_right.set(0, 0, 1);
+        L_up.crossproduct(L_dir, L_right).normalize();
+        L_right.crossproduct(L_up, L_dir).normalize();
+        mdir_View.build_camera_dir(L_pos, L_dir, L_up);
+
+        // projection: box
+        //	Simple
+        Fbox frustum_bb;
+        frustum_bb.invalidate();
+        for (int it = 0; it < 8; it++)
         {
-            FPU::m64r();
-            // Lets begin from base frustum
-            Fmatrix fullxform_inv = ex_full_inverse;
-#ifdef _DEBUG
-            typedef DumbConvexVolume<true> t_volume;
-#else
-            typedef DumbConvexVolume<false> t_volume;
-#endif
-            t_volume hull;
-            {
-                hull.points.reserve(9);
-                for (int p = 0; p < 8; p++)
-                {
-                    Fvector3 xf = wform(fullxform_inv, rain::corners[p]);
-                    hull.points.push_back(xf);
-                }
-                for (int plane = 0; plane < 6; plane++)
-                {
-                    hull.polys.push_back(t_volume::_poly());
-                    for (int pt = 0; pt < 4; pt++)
-                        hull.polys.back().points.push_back(rain::facetable[plane][pt]);
-                }
-            }
-            // hull.compute_caster_model	(cull_planes,fuckingsun->direction);
-            hull.compute_caster_model(cull_planes, RainLight.direction);
-#ifdef _DEBUG
-            for (u32 it = 0; it < cull_planes.size(); it++)
-                Target->dbg_addplane(cull_planes[it], 0xffffffff);
-#endif
+            // for (int it=0; it<9; it++)	{
+            Fvector xf = wform(mdir_View, hull.points[it]);
+            frustum_bb.modify(xf);
+        }
+        Fbox& bb = frustum_bb;
+        bb.grow(EPS);
 
-            // COP - 100 km away
-            cull_COP.mad(Device.vCameraPosition, RainLight.direction, -tweak_rain_COP_initial_offs);
-            cull_COP.x += fBoundingSphereRadius * Device.vCameraDirection.x;
-            cull_COP.z += fBoundingSphereRadius * Device.vCameraDirection.z;
+        //	HACK
+        //	TODO: DX11: Calculate bounding sphere for view frustum
+        //	TODO: DX11: Reduce resolution.
+        // bb.vMin.x = -50;
+        // bb.vMax.x = 50;
+        // bb.vMin.y = -50;
+        // bb.vMax.y = 50;
 
-            // Create frustum for query
-            cull_frustum._clear();
-            for (u32 p = 0; p < cull_planes.size(); p++)
-                cull_frustum._add(cull_planes[p]);
-
-            // Create approximate ortho-xform
-            // view: auto find 'up' and 'right' vectors
-            Fmatrix mdir_View, mdir_Project;
-            Fvector L_dir, L_up, L_right, L_pos;
-            L_pos.set(RainLight.position);
-            L_dir.set(RainLight.direction).normalize();
-            L_right.set(1, 0, 0);
-            if (_abs(L_right.dotproduct(L_dir)) > .99f)
-                L_right.set(0, 0, 1);
-            L_up.crossproduct(L_dir, L_right).normalize();
-            L_right.crossproduct(L_up, L_dir).normalize();
-            mdir_View.build_camera_dir(L_pos, L_dir, L_up);
-
-            // projection: box
-            //	Simple
-            Fbox frustum_bb;
-            frustum_bb.invalidate();
-            for (int it = 0; it < 8; it++)
-            {
-                // for (int it=0; it<9; it++)	{
-                Fvector xf = wform(mdir_View, hull.points[it]);
-                frustum_bb.modify(xf);
-            }
-            Fbox& bb = frustum_bb;
-            bb.grow(EPS);
-
-            //	HACK
-            //	TODO: DX11: Calculate bounding sphere for view frustum
-            //	TODO: DX11: Reduce resolution.
-            // bb.vMin.x = -50;
-            // bb.vMax.x = 50;
-            // bb.vMin.y = -50;
-            // bb.vMax.y = 50;
-
-            //	Offset RainLight position to center rain shadowmap
-            Fvector3 vRectOffset =
-            {
-                fBoundingSphereRadius * Device.vCameraDirection.x,
-                0,
-                fBoundingSphereRadius * Device.vCameraDirection.z
-            };
-            bb.vMin.x = -fBoundingSphereRadius + vRectOffset.x;
-            bb.vMax.x = fBoundingSphereRadius + vRectOffset.x;
-            bb.vMin.y = -fBoundingSphereRadius + vRectOffset.z;
-            bb.vMax.y = fBoundingSphereRadius + vRectOffset.z;
+        //	Offset RainLight position to center rain shadowmap
+        Fvector3 vRectOffset =
+        {
+            fBoundingSphereRadius * Device.vCameraDirection.x,
+            0,
+            fBoundingSphereRadius * Device.vCameraDirection.z
+        };
+        bb.vMin.x = -fBoundingSphereRadius + vRectOffset.x;
+        bb.vMax.x = fBoundingSphereRadius + vRectOffset.x;
+        bb.vMin.y = -fBoundingSphereRadius + vRectOffset.z;
+        bb.vMax.y = fBoundingSphereRadius + vRectOffset.z;
 
 #if defined(USE_DX11)
-            XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&mdir_Project),
-                XMMatrixOrthographicOffCenterLH(
-                    bb.vMin.x, bb.vMax.x, bb.vMin.y, bb.vMax.y,
-                    bb.vMin.z - tweak_rain_ortho_xform_initial_offs,
-                    bb.vMin.z + 2 * tweak_rain_ortho_xform_initial_offs
-                )
-            );
-#elif defined(USE_OGL)
-            XRMatrixOrthoOffCenterLH(&mdir_Project,
+        XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&mdir_Project),
+            XMMatrixOrthographicOffCenterLH(
                 bb.vMin.x, bb.vMax.x, bb.vMin.y, bb.vMax.y,
                 bb.vMin.z - tweak_rain_ortho_xform_initial_offs,
                 bb.vMin.z + 2 * tweak_rain_ortho_xform_initial_offs
-            );
-#else
-#   error No graphics API selected or enabled!
-#endif
-
-            cull_xform.mul(mdir_Project, mdir_View);
-
-            s32 const limit = o.rain_smapsize;
-
-            // build viewport xform
-            float view_dim = float(limit);
-            float fTexelOffs = .5f / o.rain_smapsize;
-#if defined(USE_DX11)
-            Fmatrix m_viewport =
-            {
-                view_dim / 2.f, 0.0f, 0.0f, 0.0f,
-                0.0f, -view_dim / 2.f, 0.0f, 0.0f,
-                0.0f, 0.0f, 1.0f, 0.0f,
-                view_dim / 2.f + fTexelOffs, view_dim / 2.f + fTexelOffs, 0.0f, 1.0f
-            };
-            Fmatrix m_viewport_inv;
-            XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&m_viewport_inv),
-                XMMatrixInverse(nullptr, XMLoadFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&m_viewport))));
+            )
+        );
 #elif defined(USE_OGL)
-            Fmatrix m_viewport =
-            {
-                view_dim / 2.f, 0.0f, 0.0f, 0.0f,
-                0.0f, view_dim / 2.f, 0.0f, 0.0f,
-                0.0f, 0.0f, 1.0f, 0.0f,
-                view_dim / 2.f + fTexelOffs, view_dim / 2.f + fTexelOffs, 0.0f, 1.0f
-            };
-            Fmatrix m_viewport_inv;
-            XRMatrixInverse(&m_viewport_inv, nullptr, m_viewport);
+        XRMatrixOrthoOffCenterLH(&mdir_Project,
+            bb.vMin.x, bb.vMax.x, bb.vMin.y, bb.vMax.y,
+            bb.vMin.z - tweak_rain_ortho_xform_initial_offs,
+            bb.vMin.z + 2 * tweak_rain_ortho_xform_initial_offs
+        );
 #else
 #   error No graphics API selected or enabled!
 #endif
 
-            // snap view-position to pixel
-            //	snap zero point to pixel
-            Fvector cam_proj = wform(cull_xform, Fvector().set(0, 0, 0));
-            Fvector cam_pixel = wform(m_viewport, cam_proj);
-            cam_pixel.x = floorf(cam_pixel.x);
-            cam_pixel.y = floorf(cam_pixel.y);
-            Fvector cam_snapped = wform(m_viewport_inv, cam_pixel);
-            Fvector diff;
-            diff.sub(cam_snapped, cam_proj);
-            Fmatrix adjust;
-            adjust.translate(diff);
-            cull_xform.mulA_44(adjust);
+        cull_xform.mul(mdir_Project, mdir_View);
 
-            RainLight.X.D.minX = 0;
-            RainLight.X.D.maxX = limit;
-            RainLight.X.D.minY = 0;
-            RainLight.X.D.maxY = limit;
+        s32 const limit = RImplementation.o.rain_smapsize;
 
-            // full-xform
-            FPU::m24r();
-        }
-
-        // Begin SMAP-render
-        auto& dsgraph = get_context(eRDSG_RAIN);
+        // build viewport xform
+        float view_dim = float(limit);
+        float fTexelOffs = .5f / RImplementation.o.rain_smapsize;
+#if defined(USE_DX11)
+        Fmatrix m_viewport =
         {
-            dsgraph.o.phase = PHASE_SMAP;
-            dsgraph.r_pmask(true, false);
-            dsgraph.o.sector_id = largest_sector_id;
-            dsgraph.o.xform = cull_xform;
-            dsgraph.o.view_frustum = cull_frustum;
-            dsgraph.o.view_pos = cull_COP;
+            view_dim / 2.f, 0.0f, 0.0f, 0.0f,
+            0.0f, -view_dim / 2.f, 0.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 0.0f,
+            view_dim / 2.f + fTexelOffs, view_dim / 2.f + fTexelOffs, 0.0f, 1.0f
+        };
+        Fmatrix m_viewport_inv;
+        XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&m_viewport_inv),
+            XMMatrixInverse(nullptr, XMLoadFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&m_viewport))));
+#elif defined(USE_OGL)
+        Fmatrix m_viewport =
+        {
+            view_dim / 2.f, 0.0f, 0.0f, 0.0f,
+            0.0f, view_dim / 2.f, 0.0f, 0.0f,
+            0.0f, 0.0f, 1.0f, 0.0f,
+            view_dim / 2.f + fTexelOffs, view_dim / 2.f + fTexelOffs, 0.0f, 1.0f
+        };
+        Fmatrix m_viewport_inv;
+        XRMatrixInverse(&m_viewport_inv, nullptr, m_viewport);
+#else
+#   error No graphics API selected or enabled!
+#endif
 
-            // Fill the database
-            dsgraph.build_subspace();
-        }
+        // snap view-position to pixel
+        //	snap zero point to pixel
+        Fvector cam_proj = wform(cull_xform, Fvector().set(0, 0, 0));
+        Fvector cam_pixel = wform(m_viewport, cam_proj);
+        cam_pixel.x = floorf(cam_pixel.x);
+        cam_pixel.y = floorf(cam_pixel.y);
+        Fvector cam_snapped = wform(m_viewport_inv, cam_pixel);
+        Fvector diff;
+        diff.sub(cam_snapped, cam_proj);
+        Fmatrix adjust;
+        adjust.translate(diff);
+        cull_xform.mulA_44(adjust);
 
-        // Finalize & Cleanup
-        RainLight.X.D.combine = cull_xform;
+        RainLight.X.D.minX = 0;
+        RainLight.X.D.maxX = limit;
+        RainLight.X.D.minY = 0;
+        RainLight.X.D.maxY = limit;
+
+        // full-xform
+        FPU::m24r();
+    }
+
+    // Begin SMAP-render
+    auto& dsgraph = RImplementation.get_context(CRender::eRDSG_RAIN);
+    {
+        dsgraph.o.phase = CRender::PHASE_SMAP;
+        dsgraph.r_pmask(true, false);
+        dsgraph.o.sector_id = RImplementation.get_largest_sector();
+        dsgraph.o.xform = cull_xform;
+        dsgraph.o.view_frustum = cull_frustum;
+        dsgraph.o.view_pos = cull_COP;
+
+        // Fill the database
+        dsgraph.build_subspace();
+    }
+
+    // Finalize & Cleanup
+    RainLight.X.D.combine = cull_xform;
+}
+
+void render_rain::render()
+{
+    if (should_render())
+    {
+        PIX_EVENT(RAIN);
+
+        auto& dsgraph = RImplementation.get_context(CRender::eRDSG_RAIN);
 
         // Render shadow-map
         //. !!! We should clip based on shrinked frustum (again)
@@ -284,7 +304,7 @@ void CRender::render_rain()
                 !dsgraph.mapSorted.empty();
             if (bNormal || bSpecial)
             {
-                Target->phase_smap_direct(&RainLight, SE_SUN_RAIN_SMAP);
+                RImplementation.Target->phase_smap_direct(&RainLight, SE_SUN_RAIN_SMAP);
                 RCache.set_xform_world(Fidentity);
                 RCache.set_xform_view(Fidentity);
                 RCache.set_xform_project(RainLight.X.D.combine);
@@ -293,9 +313,6 @@ void CRender::render_rain()
                 //	Details->Render					()	;
             }
         }
-        // End SMAP-render
-        //		fuckingsun->svis.end					();
-        dsgraph.r_pmask(true, false);
     }
 
     // Restore XForms
@@ -304,8 +321,8 @@ void CRender::render_rain()
     RCache.set_xform_project(Device.mProject);
 
     // Accumulate
-    Target->phase_rain();
-    Target->draw_rain(RainLight);
+    RImplementation.Target->phase_rain();
+    RImplementation.Target->draw_rain(RainLight);
 
     RainLight.frame_render = Device.dwFrame;
 }

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -276,6 +276,7 @@ void render_rain::calculate_task(Task&, void*)
         dsgraph.o.xform = cull_xform;
         dsgraph.o.view_frustum = cull_frustum;
         dsgraph.o.view_pos = cull_COP;
+        dsgraph.o.mt_calculate = o.mt_enabled;
 
         // Fill the database
         dsgraph.build_subspace();

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -140,7 +140,7 @@ void render_rain::calculate_task(Task&, void*)
         hull.compute_caster_model(cull_planes, RainLight.direction);
 #ifdef _DEBUG
         for (u32 it = 0; it < cull_planes.size(); it++)
-            Target->dbg_addplane(cull_planes[it], 0xffffffff);
+            RImplementation.Target->dbg_addplane(cull_planes[it], 0xffffffff);
 #endif
 
         // COP - 100 km away

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -261,10 +261,10 @@ void render_rain::calculate()
         adjust.translate(diff);
         cull_xform.mulA_44(adjust);
 
-        RainLight.X.D.minX = 0;
-        RainLight.X.D.maxX = limit;
-        RainLight.X.D.minY = 0;
-        RainLight.X.D.maxY = limit;
+        RainLight.X.D[0].minX = 0;
+        RainLight.X.D[0].maxX = limit;
+        RainLight.X.D[0].minY = 0;
+        RainLight.X.D[0].maxY = limit;
 
         // full-xform
         FPU::m24r();
@@ -285,7 +285,7 @@ void render_rain::calculate()
     }
 
     // Finalize & Cleanup
-    RainLight.X.D.combine = cull_xform;
+    RainLight.X.D[0].combine = cull_xform;
 }
 
 void render_rain::render()
@@ -307,7 +307,7 @@ void render_rain::render()
                 RImplementation.Target->phase_smap_direct(&RainLight, SE_SUN_RAIN_SMAP);
                 RCache.set_xform_world(Fidentity);
                 RCache.set_xform_view(Fidentity);
-                RCache.set_xform_project(RainLight.X.D.combine);
+                RCache.set_xform_project(RainLight.X.D[0].combine);
                 dsgraph.render_graph(0);
                 // if (ps_r2_ls_flags.test(R2FLAG_DETAIL_SHADOW))
                 //	Details->Render					()	;

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -313,6 +313,7 @@ void render_rain::render()
                 //	Details->Render					()	;
             }
         }
+        RImplementation.release_context(CRender::eRDSG_RAIN);
     }
 
     // Restore XForms
@@ -323,7 +324,6 @@ void render_rain::render()
     // Accumulate
     RImplementation.Target->phase_rain(); // TODO: move into this class as well
     RImplementation.Target->draw_rain(RainLight);
-    RImplementation.release_context(CRender::eRDSG_RAIN);
 
     RainLight.frame_render = Device.dwFrame;
 }

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -260,8 +260,7 @@ void CRender::render_rain()
         }
 
         // Begin SMAP-render
-        auto& dsgraph = get_context(eRDSG_MAIN);
-        dsgraph.reset(); // tmp
+        auto& dsgraph = get_context(eRDSG_RAIN);
         {
             dsgraph.o.phase = PHASE_SMAP;
             dsgraph.r_pmask(true, false);

--- a/src/Layers/xrRender_R2/r3_R_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_R_rain.cpp
@@ -321,8 +321,9 @@ void render_rain::render()
     RCache.set_xform_project(Device.mProject);
 
     // Accumulate
-    RImplementation.Target->phase_rain();
+    RImplementation.Target->phase_rain(); // TODO: move into this class as well
     RImplementation.Target->draw_rain(RainLight);
+    RImplementation.release_context(CRender::eRDSG_RAIN);
 
     RainLight.frame_render = Device.dwFrame;
 }

--- a/src/Layers/xrRender_R2/r3_rendertarget_draw_rain.cpp
+++ b/src/Layers/xrRender_R2/r3_rendertarget_draw_rain.cpp
@@ -51,10 +51,10 @@ void CRenderTarget::draw_rain(light& RainSetup)
         //		float			view_dimY			= float(RainSetup.X.D.maxX-RainSetup.X.D.minX-2)/smapsize;
         //		float			view_sx				= float(RainSetup.X.D.minX+1)/smapsize;
         //		float			view_sy				= float(RainSetup.X.D.minY+1)/smapsize;
-        float view_dimX = float(RainSetup.X.D.maxX - RainSetup.X.D.minX) / smapsize;
-        float view_dimY = float(RainSetup.X.D.maxX - RainSetup.X.D.minX) / smapsize;
-        float view_sx = float(RainSetup.X.D.minX) / smapsize;
-        float view_sy = float(RainSetup.X.D.minY) / smapsize;
+        float view_dimX = float(RainSetup.X.D[0].maxX - RainSetup.X.D[0].minX) / smapsize;
+        float view_dimY = float(RainSetup.X.D[0].maxX - RainSetup.X.D[0].minX) / smapsize;
+        float view_sx = float(RainSetup.X.D[0].minX) / smapsize;
+        float view_sy = float(RainSetup.X.D[0].minY) / smapsize;
 #if defined(USE_DX11)
         Fmatrix m_TexelAdjust =
         {
@@ -82,7 +82,7 @@ void CRenderTarget::draw_rain(light& RainSetup)
         Fmatrix m_shadow;
         {
             Fmatrix xf_project;
-            xf_project.mul(m_TexelAdjust, RainSetup.X.D.combine);
+            xf_project.mul(m_TexelAdjust, RainSetup.X.D[0].combine);
             m_shadow.mul(xf_project, Device.mInvView);
 
             FPU::m24r();

--- a/src/xrCore/Containers/FixedMap.h
+++ b/src/xrCore/Containers/FixedMap.h
@@ -63,7 +63,7 @@ public:
     using mapped_type = T;
     using value_type = xr_fixed_map_node<K, T>;
 
-    using callback = void __fastcall(const value_type&);
+    using callback = void __fastcall(u32, const value_type&);
     using callback_cmp = bool __fastcall(const value_type& N1, const value_type& N2);
 
     static_assert(TGrowMultiplier >= 1, "Grow multiplier can't be less than 1");
@@ -156,22 +156,22 @@ private:
         return N;
     }
 
-    void recurse_left_right(value_type* N, callback CB)
+    void recurse_left_right(u32 id, value_type* N, callback CB)
     {
         if (N->left)
-            recurse_left_right(N->left, CB);
-        CB(*N);
+            recurse_left_right(id, N->left, CB);
+        CB(id, *N);
         if (N->right)
-            recurse_left_right(N->right, CB);
+            recurse_left_right(id, N->right, CB);
     }
 
-    void recurse_right_left(value_type* N, callback CB)
+    void recurse_right_left(u32 id, value_type* N, callback CB)
     {
         if (N->right)
-            recurse_right_left(N->right, CB);
-        CB(*N);
+            recurse_right_left(id, N->right, CB);
+        CB(id, *N);
         if (N->left)
-            recurse_right_left(N->left, CB);
+            recurse_right_left(id, N->left, CB);
     }
 
     void get_left_right(value_type* N, xr_vector<T, xr_allocator<T>>& D)
@@ -361,16 +361,16 @@ public:
     mapped_type& at(const key_type& key) { return insert(key)->second; }
     mapped_type& operator[](const key_type& key) { return insert(key)->second; }
 
-    void traverse_left_right(callback CB)
+    void traverse_left_right(u32 id, callback CB)
     {
         if (pool)
-            recurse_left_right(nodes, CB);
+            recurse_left_right(id, nodes, CB);
     }
 
-    void traverse_right_left(callback CB)
+    void traverse_right_left(u32 id, callback CB)
     {
         if (pool)
-            recurse_right_left(nodes, CB);
+            recurse_right_left(id, nodes, CB);
     }
 
     void traverse_any(callback CB)

--- a/src/xrEngine/CustomHUD.h
+++ b/src/xrEngine/CustomHUD.h
@@ -27,8 +27,8 @@ public:
     CCustomHUD();
     virtual ~CCustomHUD();
 
-    virtual void Render_First() {}
-    virtual void Render_Last() {}
+    virtual void Render_First(u32 context_id) {}
+    virtual void Render_Last(u32 context_id) {}
 
     virtual void OnFrame() { ; }
     virtual void OnEvent(EVENT /*E*/, u64 /*P1*/, u64 /*P2*/) { ; }

--- a/src/xrEngine/Engine.h
+++ b/src/xrEngine/Engine.h
@@ -14,6 +14,12 @@
 #include "EventAPI.h"
 #include "xrSheduler.h"
 
+// TODO: this should be in render configuration
+#define R__NUM_SUN_CASCADES         (3u) // csm/s.ligts
+#define R__NUM_AUX_CONTEXTS         (1u) // rain/s.lights
+#define R__NUM_PARALLEL_CONTEXTS    (R__NUM_SUN_CASCADES + R__NUM_AUX_CONTEXTS)
+#define R__NUM_CONTEXTS             (R__NUM_PARALLEL_CONTEXTS + 1/* imm */)
+
 class ENGINE_API CEngine
 {
 public:

--- a/src/xrEngine/IRenderable.h
+++ b/src/xrEngine/IRenderable.h
@@ -22,7 +22,7 @@ class XR_NOVTABLE IRenderable
 public:
     virtual ~IRenderable() = 0;
     virtual RenderData& GetRenderData() = 0;
-    virtual void renderable_Render(IRenderable* root) = 0;
+    virtual void renderable_Render(u32 context_id, IRenderable* root) = 0;
     virtual IRender_ObjectSpecific* renderable_ROS() = 0;
     virtual bool renderable_ShadowGenerate() = 0;
     virtual bool renderable_ShadowReceive() = 0;

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -355,6 +355,7 @@ public:
     // Main
     virtual void Calculate() = 0;
     virtual void Render() = 0;
+    virtual void RenderMenu() = 0;
 
     virtual void BeforeWorldRender() = 0; //--#SM+#-- Перед рендерингом мира
     virtual void AfterWorldRender() = 0; //--#SM+#-- После рендеринга мира (до UI)

--- a/src/xrEngine/Render.h
+++ b/src/xrEngine/Render.h
@@ -307,7 +307,7 @@ public:
     virtual IRender_Target* getTarget() = 0;
 
     // Main
-    virtual void add_Visual(IRenderable* root, IRenderVisual* V, Fmatrix& m) = 0; // add visual leaf (no culling performed at all)
+    virtual void add_Visual(u32 context_id, IRenderable* root, IRenderVisual* V, Fmatrix& m) = 0; // add visual leaf (no culling performed at all)
     // virtual void add_StaticWallmark (ref_shader& S, const Fvector& P, float s, CDB::TRI* T, Fvector* V)=0;
     virtual void add_StaticWallmark(const wm_shader& S, const Fvector& P, float s, CDB::TRI* T, Fvector* V) = 0;
     // Prefer this function when possible
@@ -368,7 +368,6 @@ public:
     virtual void rmNear() = 0;
     virtual void rmFar() = 0;
     virtual void rmNormal() = 0;
-    virtual u32 active_phase() const = 0;
 
     // Constructor/destructor
     virtual ~IRender() {}

--- a/src/xrEngine/vis_common.h
+++ b/src/xrEngine/vis_common.h
@@ -13,7 +13,7 @@ private:
 public:
     Fsphere sphere; //
     Fbox box; //
-    u32 marker; // for different sub-renders
+    u32 marker[8]; // for different sub-renders
     u32 accept_frame; // when it was requisted accepted for main render
     u32 hom_frame; // when to perform test - shedule
     u32 hom_tested; // when it was last time tested
@@ -31,7 +31,7 @@ public:
         sphere.P.set(0, 0, 0);
         sphere.R = 0;
         box.invalidate();
-        marker = 0;
+        memset(marker, 0, sizeof(marker));
         accept_frame = 0;
         hom_frame = 0;
         hom_tested = 0;

--- a/src/xrEngine/vis_common.h
+++ b/src/xrEngine/vis_common.h
@@ -13,7 +13,7 @@ private:
 public:
     Fsphere sphere; //
     Fbox box; //
-    u32 marker[8]; // for different sub-renders
+    u32 marker[R__NUM_CONTEXTS]; // for different sub-renders
     u32 accept_frame; // when it was requisted accepted for main render
     u32 hom_frame; // when to perform test - shedule
     u32 hom_tested; // when it was last time tested

--- a/src/xrEngine/xr_object.h
+++ b/src/xrEngine/xr_object.h
@@ -225,7 +225,7 @@ public:
     virtual void ForceTransform(const Fmatrix& m) = 0;
     virtual void ForceTransformAndDirection(const Fmatrix& m) = 0;
     // HUD
-    virtual void OnHUDDraw(CCustomHUD* hud, IRenderable* root) = 0;
+    virtual void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) = 0;
     virtual void OnRenderHUD(IGameObject* pCurViewEntity) = 0; //--#SM+#--
     virtual void OnOwnedCameraMove(CCameraBase* pCam, float fOldYaw, float fOldPitch) = 0; //--#SM+#--
     // Active/non active

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1493,11 +1493,11 @@ void CActor::shedule_Update(u32 DT)
     Check_for_AutoPickUp();
 };
 #include "debug_renderer.h"
-void CActor::renderable_Render(IRenderable* root)
+void CActor::renderable_Render(u32 context_id, IRenderable* root)
 {
     VERIFY(_valid(XFORM()));
-    inherited::renderable_Render(root);
-    CInventoryOwner::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
+    CInventoryOwner::renderable_Render(context_id, root);
 }
 
 bool CActor::renderable_ShadowGenerate()
@@ -1537,11 +1537,11 @@ bool CActor::use_default_throw_force()
 float CActor::missile_throw_force() { return 0.f; }
 
 // HUD
-void CActor::OnHUDDraw(CCustomHUD* hud, IRenderable* root)
+void CActor::OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root)
 {
     R_ASSERT(IsFocused());
     if (!((mstate_real & mcLookout) && !IsGameTypeSingle()))
-        g_player_hud->render_hud(root);
+        g_player_hud->render_hud(context_id, root);
 }
 
 void CActor::RenderIndicator(Fvector dpos, float r1, float r2, const ui_shader& IndShader)

--- a/src/xrGame/Actor.h
+++ b/src/xrGame/Actor.h
@@ -100,7 +100,7 @@ public:
     virtual void OnEvent(NET_Packet& P, u16 type);
 
     // Render
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual bool renderable_ShadowGenerate();
     void feel_sound_new(IGameObject* who, int type, const CSound_UserDataPtr& user_data,
         const Fvector& position, float power) override;
@@ -306,7 +306,7 @@ public:
     void g_SetSprintAnimation(u32 mstate_rl, MotionID& head, MotionID& torso, MotionID& legs);
 
 public:
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override;
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override;
     BOOL HUDview() const;
 
     // visiblity

--- a/src/xrGame/Car.cpp
+++ b/src/xrGame/Car.cpp
@@ -476,9 +476,9 @@ void CCar::VisualUpdate(float fov)
     m_lights.Update();
 }
 
-void CCar::renderable_Render(IRenderable* root)
+void CCar::renderable_Render(u32 context_id, IRenderable* root)
 {
-    inherited::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
     if (m_car_weapon)
         m_car_weapon->Render_internal();
 }
@@ -499,7 +499,7 @@ void CCar::net_Import(NET_Packet& P)
     //	P.w_u32 (NumItems);
 }
 
-void CCar::OnHUDDraw(CCustomHUD* /*hud*/, IRenderable* /*root*/)
+void CCar::OnHUDDraw(u32 context_id, CCustomHUD* /*hud*/, IRenderable* /*root*/)
 {
 #ifdef DEBUG
     Fvector velocity;

--- a/src/xrGame/Car.h
+++ b/src/xrGame/Car.h
@@ -576,7 +576,7 @@ public:
     virtual void UpdateEx(float fov); // called by owner
 
     virtual void shedule_Update(u32 dt);
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual bool bfAssignMovement(CScriptEntityAction* tpEntityAction);
     virtual bool bfAssignObject(CScriptEntityAction* tpEntityAction);
 
@@ -627,7 +627,7 @@ public:
     virtual void g_fireParams(const CHudItem* /**pHudItem**/, Fvector& /**P**/, Fvector& /**D**/){};
     virtual u16 Initiator();
     // HUD
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override;
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override;
 
     CCameraBase* Camera() { return active_camera; }
     void SetExplodeTime(u32 et);

--- a/src/xrGame/CustomMonster.cpp
+++ b/src/xrGame/CustomMonster.cpp
@@ -784,7 +784,7 @@ bool CCustomMonster::net_Spawn(CSE_Abstract* DC)
 }
 
 #ifdef DEBUG
-void CCustomMonster::OnHUDDraw(CCustomHUD* /*hud*/, IRenderable* /*root*/) {}
+void CCustomMonster::OnHUDDraw(u32 context_id, CCustomHUD* /*hud*/, IRenderable* /*root*/) {}
 #endif
 
 void CCustomMonster::Exec_Action(float /**dt**/) {}

--- a/src/xrGame/CustomMonster.h
+++ b/src/xrGame/CustomMonster.h
@@ -158,7 +158,7 @@ public:
 // debug
 #ifdef DEBUG
     virtual void OnRender();
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override;
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override;
 #endif
 
     virtual bool bfExecMovement() { return (false); };

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -102,6 +102,8 @@ CGameObject::~CGameObject()
 
 void CGameObject::MakeMeCrow()
 {
+    ScopeLock lock{ &render_lock };
+
     if (Props.crow)
         return;
     if (!processing_enabled())

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -120,8 +120,8 @@ void CGameObject::MakeMeCrow()
         return;
 
     VERIFY(dwFrame_AsCrow == device_frame_id);
-    Props.crow = 1;
     g_pGameLevel->Objects.o_crow(this);
+    Props.crow = 1;
 }
 
 void CGameObject::cName_set(shared_str N) { NameObject = N; }

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -1068,12 +1068,12 @@ Fvector CGameObject::get_last_local_point_on_mesh(Fvector const& local_point, u1
     return result;
 }
 
-void CGameObject::renderable_Render(IRenderable* root)
+void CGameObject::renderable_Render(u32 context_id, IRenderable* root)
 {
     //
     MakeMeCrow();
     // ~
-    GEnv.Render->add_Visual(root, Visual(), XFORM());
+    GEnv.Render->add_Visual(context_id, root, Visual(), XFORM());
     Visual()->getVisData().hom_frame = Device.dwFrame;
 }
 

--- a/src/xrGame/GameObject.h
+++ b/src/xrGame/GameObject.h
@@ -247,11 +247,11 @@ public:
     virtual void ForceTransform(const Fmatrix& m) override {}
     void ForceTransformAndDirection(const Fmatrix& m) override { ForceTransform(m); }
 
-    void OnHUDDraw(CCustomHUD* /*hud*/, IRenderable* /*root*/) override {}
+    void OnHUDDraw(u32 context_id, CCustomHUD* /*hud*/, IRenderable* /*root*/) override {}
     void OnRenderHUD(IGameObject* pCurViewEntity) override {} //--#SM+#--
     void OnOwnedCameraMove(CCameraBase* pCam, float fOldYaw, float fOldPitch) override  {} //--#SM+#--
     virtual bool Ready() override { return getReady(); } // update only if active and fully initialized by/for network
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void OnEvent(NET_Packet& P, u16 type) override;
     virtual void Hit(SHit* pHDS) override {}
     virtual void SetHitInfo(IGameObject* who, IGameObject* weapon, s16 element, Fvector Pos, Fvector Dir) override {}

--- a/src/xrGame/GameObject.h
+++ b/src/xrGame/GameObject.h
@@ -92,6 +92,7 @@ private:
     ai_obstacle* m_ai_obstacle;
     Fmatrix m_previous_matrix;
     CALLBACK_VECTOR m_visual_callback;
+    Lock render_lock{};
 
 protected:
     CScriptBinder scriptBinder;

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -63,11 +63,12 @@ void CHUDManager::Render_First(u32 context_id)
 
     // On R1 render only shadow
     // On R2+ render everything
-    O->renderable_Invisible(GEnv.Render->GenerationIsR1());
-
-    O->renderable_Render(context_id, O->H_Root());
-
-    O->renderable_Invisible(false);
+    {
+        ScopeLock lock{ &render_lock };
+        O->renderable_Invisible(GEnv.Render->GenerationIsR1());
+        O->renderable_Render(context_id, O->H_Root());
+        O->renderable_Invisible(false);
+    }
 }
 
 bool need_render_hud()
@@ -101,9 +102,12 @@ void CHUDManager::Render_Last(u32 context_id)
 
     IGameObject* O = g_pGameLevel->CurrentViewEntity();
     // hud itself
-    O->renderable_HUD(true);
-    O->OnHUDDraw(context_id, this, O->H_Root());
-    O->renderable_HUD(false);
+    {
+        ScopeLock lock{ &render_lock };
+        O->renderable_HUD(true);
+        O->OnHUDDraw(context_id, this, O->H_Root());
+        O->renderable_HUD(false);
+    }
 }
 
 #include "player_hud.h"

--- a/src/xrGame/HUDManager.cpp
+++ b/src/xrGame/HUDManager.cpp
@@ -48,7 +48,7 @@ void CHUDManager::OnFrame()
 }
 //--------------------------------------------------------------------
 
-void CHUDManager::Render_First()
+void CHUDManager::Render_First(u32 context_id)
 {
     if (!psHUD_Flags.is(HUD_WEAPON | HUD_WEAPON_RT | HUD_WEAPON_RT2 | HUD_DRAW_RT2))
         return;
@@ -65,7 +65,7 @@ void CHUDManager::Render_First()
     // On R2+ render everything
     O->renderable_Invisible(GEnv.Render->GenerationIsR1());
 
-    O->renderable_Render(O->H_Root());
+    O->renderable_Render(context_id, O->H_Root());
 
     O->renderable_Invisible(false);
 }
@@ -89,7 +89,7 @@ bool need_render_hud()
     return true;
 }
 
-void CHUDManager::Render_Last()
+void CHUDManager::Render_Last(u32 context_id)
 {
     if (!psHUD_Flags.is(HUD_WEAPON | HUD_WEAPON_RT | HUD_WEAPON_RT2 | HUD_DRAW_RT2))
         return;
@@ -102,7 +102,7 @@ void CHUDManager::Render_Last()
     IGameObject* O = g_pGameLevel->CurrentViewEntity();
     // hud itself
     O->renderable_HUD(true);
-    O->OnHUDDraw(this, O->H_Root());
+    O->OnHUDDraw(context_id, this, O->H_Root());
     O->renderable_HUD(false);
 }
 

--- a/src/xrGame/HUDManager.h
+++ b/src/xrGame/HUDManager.h
@@ -23,8 +23,8 @@ public:
     virtual ~CHUDManager();
     virtual void OnEvent(EVENT E, u64 P1, u64 P2);
 
-    virtual void Render_First();
-    virtual void Render_Last();
+    virtual void Render_First(u32 context_id);
+    virtual void Render_Last(u32 context_id);
     virtual void OnFrame();
 
     virtual void RenderUI();

--- a/src/xrGame/HUDManager.h
+++ b/src/xrGame/HUDManager.h
@@ -12,6 +12,7 @@ class CHUDManager : public CCustomHUD
     friend class CUI;
 
 private:
+    Lock render_lock{}; // TODO: I believe this can be avoided, need to think more about it
     //.	CUI*					pUI;
     CUIGameCustom* pUIGame;
     CHitMarker HitMarker;

--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -62,7 +62,7 @@ void CHudItem::PlaySound(pcstr alias, const Fvector& position, u8 index)
 }
 //-Alundaio
 
-void CHudItem::renderable_Render(IRenderable* root)
+void CHudItem::renderable_Render(u32 context_id, IRenderable* root)
 {
     UpdateXForm();
     const bool _hud_render = root && root->renderable_HUD() && GetHUDmode();
@@ -74,7 +74,7 @@ void CHudItem::renderable_Render(IRenderable* root)
     {
         if (!object().H_Parent() || (!_hud_render && !IsHidden()))
         {
-            on_renderable_Render(root);
+            on_renderable_Render(context_id, root);
             debug_draw_firedeps();
         }
         else if (object().H_Parent())
@@ -83,7 +83,7 @@ void CHudItem::renderable_Render(IRenderable* root)
             VERIFY(owner);
             CInventoryItem* self = smart_cast<CInventoryItem*>(this);
             if (owner->attached(self))
-                on_renderable_Render(root);
+                on_renderable_Render(context_id, root);
         }
     }
 }

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -121,7 +121,7 @@ public:
     virtual void PlayAnimIdleSprint();
 
     virtual void UpdateCL();
-    virtual void renderable_Render(IRenderable* root);
+    virtual void renderable_Render(u32 context_id, IRenderable* root);
 
     virtual void UpdateHudAdditonal(Fmatrix&);
 
@@ -177,7 +177,7 @@ public:
         return (*m_item);
     }
     IC u32 animation_slot() { return m_animation_slot; }
-    virtual void on_renderable_Render(IRenderable* root) = 0;
+    virtual void on_renderable_Render(u32 context_id, IRenderable* root) = 0;
     virtual void debug_draw_firedeps(){};
 
     virtual CHudItem* cast_hud_item() { return this; }

--- a/src/xrGame/InventoryOwner.cpp
+++ b/src/xrGame/InventoryOwner.cpp
@@ -282,12 +282,12 @@ void CInventoryOwner::StopTrading()
 
 bool CInventoryOwner::IsTrading() { return m_bTrading; }
 //==============
-void CInventoryOwner::renderable_Render(IRenderable* root)
+void CInventoryOwner::renderable_Render(u32 context_id, IRenderable* root)
 {
     if (inventory().ActiveItem())
-        inventory().ActiveItem()->renderable_Render(root);
+        inventory().ActiveItem()->renderable_Render(context_id, root);
 
-    CAttachmentOwner::renderable_Render(root);
+    CAttachmentOwner::renderable_Render(context_id, root);
 }
 
 void CInventoryOwner::OnItemTake(CInventoryItem* inventory_item)

--- a/src/xrGame/InventoryOwner.h
+++ b/src/xrGame/InventoryOwner.h
@@ -189,7 +189,7 @@ protected:
     xr_string m_game_name;
 
 public:
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void OnItemTake(CInventoryItem* inventory_item);
 
     virtual void OnItemBelt(CInventoryItem* inventory_item, const SInvItemPlace& previous_place);

--- a/src/xrGame/MainMenu.cpp
+++ b/src/xrGame/MainMenu.cpp
@@ -490,10 +490,7 @@ void CMainMenu::OnRender()
     if (m_Flags.test(flGameSaveScreenshot))
         return;
 
-    if (g_pGameLevel)
-        GEnv.Render->Calculate();
-
-    GEnv.Render->Render();
+    GEnv.Render->RenderMenu();
     if (!OnRenderPPUI_query())
     {
         DoRenderDialogs();

--- a/src/xrGame/ParticlesObject.cpp
+++ b/src/xrGame/ParticlesObject.cpp
@@ -277,17 +277,13 @@ void CParticlesObject::renderable_Render(u32 context_id, IRenderable* root)
         return;
 
     VERIFY(renderable.visual);
+    const auto dt = Device.dwTimeGlobal - dwLastTime;
+    if (dt)
     {
-        ScopeLock lock{ &render_lock };
-
-        const auto dt = Device.dwTimeGlobal - dwLastTime;
-        if (dt)
-        {
-            IParticleCustom* V = smart_cast<IParticleCustom*>(renderable.visual);
-            VERIFY(V);
-            V->OnFrame(dt);
-            dwLastTime = Device.dwTimeGlobal;
-        }
+        IParticleCustom* V = smart_cast<IParticleCustom*>(renderable.visual);
+        VERIFY(V);
+        V->OnFrame(dt);
+        dwLastTime = Device.dwTimeGlobal;
     }
 
     GEnv.Render->add_Visual(context_id, root, renderable.visual, renderable.xform);

--- a/src/xrGame/ParticlesObject.cpp
+++ b/src/xrGame/ParticlesObject.cpp
@@ -277,13 +277,17 @@ void CParticlesObject::renderable_Render(u32 context_id, IRenderable* root)
         return;
 
     VERIFY(renderable.visual);
-    u32 dt = Device.dwTimeGlobal - dwLastTime;
-    if (dt)
     {
-        IParticleCustom* V = smart_cast<IParticleCustom*>(renderable.visual);
-        VERIFY(V);
-        V->OnFrame(dt);
-        dwLastTime = Device.dwTimeGlobal;
+        ScopeLock lock{ &render_lock };
+
+        const auto dt = Device.dwTimeGlobal - dwLastTime;
+        if (dt)
+        {
+            IParticleCustom* V = smart_cast<IParticleCustom*>(renderable.visual);
+            VERIFY(V);
+            V->OnFrame(dt);
+            dwLastTime = Device.dwTimeGlobal;
+        }
     }
 
     GEnv.Render->add_Visual(context_id, root, renderable.visual, renderable.xform);

--- a/src/xrGame/ParticlesObject.cpp
+++ b/src/xrGame/ParticlesObject.cpp
@@ -271,7 +271,7 @@ float CParticlesObject::shedule_Scale() const
     return Device.vCameraPosition.distance_to(Position()) / 200.f;
 }
 
-void CParticlesObject::renderable_Render(IRenderable* root)
+void CParticlesObject::renderable_Render(u32 context_id, IRenderable* root)
 {
     if (!psDeviceFlags.test(rsDrawParticles))
         return;
@@ -286,7 +286,7 @@ void CParticlesObject::renderable_Render(IRenderable* root)
         dwLastTime = Device.dwTimeGlobal;
     }
 
-    GEnv.Render->add_Visual(root, renderable.visual, renderable.xform);
+    GEnv.Render->add_Visual(context_id, root, renderable.visual, renderable.xform);
 }
 
 bool CParticlesObject::IsAutoRemove()

--- a/src/xrGame/ParticlesObject.h
+++ b/src/xrGame/ParticlesObject.h
@@ -8,6 +8,7 @@ class CParticlesObject : public CPS_Instance
 {
     using inherited = CPS_Instance;
 
+    Lock render_lock{};
     u32 dwLastTime;
     void Init(LPCSTR p_name, IRender_Sector::sector_id_t sector_id, BOOL bAutoRemove);
     void UpdateSpatial();

--- a/src/xrGame/ParticlesObject.h
+++ b/src/xrGame/ParticlesObject.h
@@ -28,7 +28,7 @@ public:
     virtual bool shedule_Needed() { return true; };
     virtual float shedule_Scale() const;
     virtual void shedule_Update(u32 dt);
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     void PerformAllTheWork(u32 dt);
     void PerformAllTheWork_mt();
 

--- a/src/xrGame/ShootingObject.cpp
+++ b/src/xrGame/ShootingObject.cpp
@@ -195,6 +195,7 @@ void CShootingObject::Light_Start()
 
 void CShootingObject::Light_Render(const Fvector& P)
 {
+    ScopeLock lock{ &render_lock };
     float light_scale = light_time / light_lifetime;
     R_ASSERT(light_render);
 

--- a/src/xrGame/ShootingObject.h
+++ b/src/xrGame/ShootingObject.h
@@ -20,6 +20,7 @@ extern const Fvector zero_vel;
 
 class CShootingObject : public IAnticheatDumpable
 {
+    Lock render_lock{};
 protected:
     CShootingObject();
     virtual ~CShootingObject();

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -911,7 +911,7 @@ void CWeapon::EnableActorNVisnAfterZoom()
 }
 
 bool CWeapon::need_renderable() { return !(IsZoomed() && ZoomTexture() && !IsRotatingToZoom()); }
-void CWeapon::renderable_Render(IRenderable* root)
+void CWeapon::renderable_Render(u32 context_id, IRenderable* root)
 {
     UpdateXForm();
 
@@ -925,7 +925,7 @@ void CWeapon::renderable_Render(IRenderable* root)
     else
         RenderHud(TRUE);
 
-    inherited::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
 }
 
 void CWeapon::signal_HideComplete()

--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -913,6 +913,8 @@ void CWeapon::EnableActorNVisnAfterZoom()
 bool CWeapon::need_renderable() { return !(IsZoomed() && ZoomTexture() && !IsRotatingToZoom()); }
 void CWeapon::renderable_Render(u32 context_id, IRenderable* root)
 {
+    ScopeLock lock{ &render_lock };
+
     UpdateXForm();
 
     //нарисовать подсветку

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -521,6 +521,8 @@ private:
 
     bool m_bRememberActorNVisnStatus;
 
+    Lock render_lock{};
+
 public:
     virtual void SetActivationSpeedOverride(Fvector const& speed);
     bool GetRememberActorNVisnStatus() { return m_bRememberActorNVisnStatus; };

--- a/src/xrGame/Weapon.h
+++ b/src/xrGame/Weapon.h
@@ -49,7 +49,7 @@ public:
     virtual void UpdateCL();
     virtual void shedule_Update(u32 dt);
 
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     void render_hud_mode() override;
     bool need_renderable() override;
 

--- a/src/xrGame/WeaponAmmo.cpp
+++ b/src/xrGame/WeaponAmmo.cpp
@@ -176,10 +176,10 @@ bool CWeaponAmmo::Get(CCartridge& cartridge)
     return true;
 }
 
-void CWeaponAmmo::renderable_Render(IRenderable* root)
+void CWeaponAmmo::renderable_Render(u32 context_id, IRenderable* root)
 {
     if (!m_ready_to_destroy)
-        inherited::renderable_Render(root);
+        inherited::renderable_Render(context_id, root);
 }
 
 void CWeaponAmmo::UpdateCL()

--- a/src/xrGame/WeaponAmmo.h
+++ b/src/xrGame/WeaponAmmo.h
@@ -68,7 +68,7 @@ public:
     virtual void OnH_B_Chield();
     virtual void OnH_B_Independent(bool just_before_destroy);
     virtual void UpdateCL();
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
 
     virtual bool Useful() const;
     virtual float Weight() const;

--- a/src/xrGame/WeaponStatMgun.cpp
+++ b/src/xrGame/WeaponStatMgun.cpp
@@ -247,9 +247,9 @@ void CWeaponStatMgun::cam_Update(float dt, float fov)
     Level().Cameras().UpdateFromCamera(Camera());
 }
 
-void CWeaponStatMgun::renderable_Render(IRenderable* root)
+void CWeaponStatMgun::renderable_Render(u32 context_id, IRenderable* root)
 {
-    inheritedPH::renderable_Render(root);
+    inheritedPH::renderable_Render(context_id, root);
 
     RenderLight();
 }

--- a/src/xrGame/WeaponStatMgun.h
+++ b/src/xrGame/WeaponStatMgun.h
@@ -97,7 +97,7 @@ public:
     virtual CInventory* GetInventory() { return NULL; };
     virtual void cam_Update(float dt, float fov = 90.0f);
 
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
 
     virtual bool attach_Actor(CGameObject* actor);
     virtual void detach_Actor();

--- a/src/xrGame/ai/crow/ai_crow.cpp
+++ b/src/xrGame/ai/crow/ai_crow.cpp
@@ -323,10 +323,10 @@ void CAI_Crow::UpdateCL()
         XFORM().set(m_pPhysicsShell->mXFORM);
     }
 }
-void CAI_Crow::renderable_Render(IRenderable* root)
+void CAI_Crow::renderable_Render(u32 context_id, IRenderable* root)
 {
     UpdateWorkload(Device.fTimeDelta * (Device.dwFrame - o_workload_frame));
-    inherited::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
     o_workload_rframe = Device.dwFrame;
 }
 void CAI_Crow::shedule_Update(u32 DT)

--- a/src/xrGame/ai/crow/ai_crow.cpp
+++ b/src/xrGame/ai/crow/ai_crow.cpp
@@ -325,12 +325,15 @@ void CAI_Crow::UpdateCL()
 }
 void CAI_Crow::renderable_Render(u32 context_id, IRenderable* root)
 {
+    ScopeLock lock{ &render_lock };
     UpdateWorkload(Device.fTimeDelta * (Device.dwFrame - o_workload_frame));
     inherited::renderable_Render(context_id, root);
     o_workload_rframe = Device.dwFrame;
 }
 void CAI_Crow::shedule_Update(u32 DT)
 {
+    ScopeLock lock{ &render_lock };
+
     float fDT = float(DT) / 1000.F;
     spatial.type &= ~STYPE_VISIBLEFORAI;
 

--- a/src/xrGame/ai/crow/ai_crow.h
+++ b/src/xrGame/ai/crow/ai_crow.h
@@ -121,7 +121,7 @@ public:
     virtual void net_Destroy();
     virtual bool renderable_ShadowGenerate() { return FALSE; }
     virtual bool renderable_ShadowReceive() { return FALSE; }
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void shedule_Update(u32 DT);
     virtual void UpdateCL();
 

--- a/src/xrGame/ai/crow/ai_crow.h
+++ b/src/xrGame/ai/crow/ai_crow.h
@@ -54,6 +54,8 @@ class CAI_Crow : public CEntity
         void Unload();
     };
 
+    Lock render_lock{}; // TODO: this can be avoided as well.
+
 public:
     void OnHitEndPlaying(CBlend* B);
 

--- a/src/xrGame/ai/monsters/basemonster/base_monster.h
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.h
@@ -76,7 +76,7 @@ public:
     virtual CInventoryOwner* cast_inventory_owner() override { return CallOfPripyatMode ? nullptr : this; }
 
 public:
-    virtual void renderable_Render(IRenderable* root) override { return inherited::renderable_Render(root); }
+    virtual void renderable_Render(u32 context_id, IRenderable* root) override { return inherited::renderable_Render(context_id, root); }
     virtual bool renderable_ShadowReceive() { return TRUE; }
     virtual void Die(IGameObject* who);
     virtual void HitSignal(float amount, Fvector& vLocalDir, IGameObject* who, s16 element);
@@ -121,7 +121,7 @@ public:
     virtual float evaluate(const CItemManager* manager, const CGameObject* object) const;
 
     virtual void OnEvent(NET_Packet& P, u16 type);
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override { return inherited::OnHUDDraw(hud, root); }
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override { return inherited::OnHUDDraw(context_id, hud, root); }
     virtual u16 PHGetSyncItemsNumber() { return inherited::PHGetSyncItemsNumber(); }
     virtual CPHSynchronize* PHGetSyncItem(u16 item) { return inherited::PHGetSyncItem(item); }
     virtual void PHUnFreeze() { return inherited::PHUnFreeze(); }

--- a/src/xrGame/ai/monsters/bloodsucker/bloodsucker.cpp
+++ b/src/xrGame/ai/monsters/bloodsucker/bloodsucker.cpp
@@ -803,11 +803,11 @@ void CAI_Bloodsucker::manual_deactivate()
     setVisible(TRUE);
 }
 
-void CAI_Bloodsucker::renderable_Render(IRenderable* root)
+void CAI_Bloodsucker::renderable_Render(u32 context_id, IRenderable* root)
 {
     if (m_visibility_state != no_visibility)
     {
-        inherited::renderable_Render(root);
+        inherited::renderable_Render(context_id, root);
     }
 }
 

--- a/src/xrGame/ai/monsters/bloodsucker/bloodsucker.h
+++ b/src/xrGame/ai/monsters/bloodsucker/bloodsucker.h
@@ -165,7 +165,7 @@ public:
 
     float get_vampire_distance() const { return m_vampire_distance; }
     pcstr get_monster_class_name() override { return "bloodsucker"; }
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
 
 #ifdef DEBUG
     virtual CBaseMonster::SDebugInfo show_debug_info();

--- a/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist.cpp
@@ -306,10 +306,10 @@ void CPoltergeist::Show()
     ability()->on_show();
 }
 
-void CPoltergeist::renderable_Render(IRenderable* root)
+void CPoltergeist::renderable_Render(u32 context_id, IRenderable* root)
 {
     Visual()->getVisData().hom_frame = Device.dwFrame;
-    inherited::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
 }
 
 void CPoltergeist::UpdateCL()

--- a/src/xrGame/ai/monsters/poltergeist/poltergeist.h
+++ b/src/xrGame/ai/monsters/poltergeist/poltergeist.h
@@ -75,7 +75,7 @@ public:
     bool detected_enemy();
     float get_fly_around_distance() const { return m_fly_around_distance; }
     float get_fly_around_change_direction_time() const { return m_fly_around_change_direction_time; }
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
 
     IC CPolterSpecialAbility* ability() { return (m_flame ? m_flame : m_tele); }
     IC bool is_hidden() { return state_invisible; }

--- a/src/xrGame/ai/monsters/rats/ai_rat.h
+++ b/src/xrGame/ai/monsters/rats/ai_rat.h
@@ -391,7 +391,7 @@ public:
 
     /////////////////////////////////////
     // rat as eatable item
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override { inherited::OnHUDDraw(hud, root); }
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override { inherited::OnHUDDraw(context_id, hud, root); }
     virtual void OnH_B_Chield();
     virtual void OnH_B_Independent();
     virtual void OnH_A_Independent();

--- a/src/xrGame/ai/stalker/ai_stalker.h
+++ b/src/xrGame/ai/stalker/ai_stalker.h
@@ -193,14 +193,14 @@ public:
     virtual void feel_touch_new(IGameObject* O);
     virtual void feel_touch_delete(IGameObject* O);
     void on_ownership_reject(IGameObject* O, bool just_before_destroy);
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void Exec_Look(float dt);
     virtual void Hit(SHit* pHDS);
     virtual void PHHit(SHit& H);
     virtual bool feel_vision_isRelevant(IGameObject* who);
     virtual float Radius() const;
 #ifdef DEBUG
-    void OnHUDDraw(CCustomHUD* hud, IRenderable* root) override;
+    void OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root) override;
     virtual void OnRender();
     void debug_text();
     bool m_dbg_hud_draw;

--- a/src/xrGame/ai/stalker/ai_stalker_debug.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_debug.cpp
@@ -951,9 +951,9 @@ void CAI_Stalker::debug_text()
     }
 }
 
-void CAI_Stalker::OnHUDDraw(CCustomHUD* hud, IRenderable* root)
+void CAI_Stalker::OnHUDDraw(u32 context_id, CCustomHUD* hud, IRenderable* root)
 {
-    inherited::OnHUDDraw(hud, root);
+    inherited::OnHUDDraw(context_id, hud, root);
     m_dbg_hud_draw = true;
 }
 

--- a/src/xrGame/ai/stalker/ai_stalker_feel.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_feel.cpp
@@ -32,12 +32,12 @@ bool CAI_Stalker::feel_vision_isRelevant(IGameObject* O)
     return (true);
 }
 
-void CAI_Stalker::renderable_Render(IRenderable* root)
+void CAI_Stalker::renderable_Render(u32 context_id, IRenderable* root)
 {
-    inherited::renderable_Render(root);
+    inherited::renderable_Render(context_id, root);
 
     if (!already_dead())
-        CInventoryOwner::renderable_Render(root);
+        CInventoryOwner::renderable_Render(context_id, root);
 
 #ifdef DEBUG
     if (g_Alive())

--- a/src/xrGame/attachable_item.cpp
+++ b/src/xrGame/attachable_item.cpp
@@ -59,9 +59,9 @@ void CAttachableItem::OnH_A_Chield()
         object().setVisible(true);
 }
 
-void CAttachableItem::renderable_Render(IRenderable* root)
+void CAttachableItem::renderable_Render(u32 context_id, IRenderable* root)
 {
-    GEnv.Render->add_Visual(root, object().Visual(), object().XFORM());
+    GEnv.Render->add_Visual(context_id, root, object().Visual(), object().XFORM());
 }
 
 void CAttachableItem::OnH_A_Independent() { enable(false); }

--- a/src/xrGame/attachable_item.h
+++ b/src/xrGame/attachable_item.h
@@ -39,7 +39,7 @@ public:
     virtual void reload(LPCSTR section);
     virtual void OnH_A_Chield();
     virtual void OnH_A_Independent();
-    virtual void renderable_Render(IRenderable* root);
+    virtual void renderable_Render(u32 context_id, IRenderable* root);
     virtual bool can_be_attached() const;
     bool load_attach_position(LPCSTR section);
     virtual void afterAttach();

--- a/src/xrGame/attachment_owner.cpp
+++ b/src/xrGame/attachment_owner.cpp
@@ -46,12 +46,12 @@ void CAttachmentOwner::net_Destroy()
     R_ASSERT(attached_objects().empty());
 }
 
-void CAttachmentOwner::renderable_Render(IRenderable* root)
+void CAttachmentOwner::renderable_Render(u32 context_id, IRenderable* root)
 {
     xr_vector<CAttachableItem*>::iterator I = m_attached_objects.begin();
     xr_vector<CAttachableItem*>::iterator E = m_attached_objects.end();
     for (; I != E; ++I)
-        (*I)->renderable_Render(root);
+        (*I)->renderable_Render(context_id, root);
 }
 
 void AttachmentCallback(IKinematics* tpKinematics)

--- a/src/xrGame/attachment_owner.h
+++ b/src/xrGame/attachment_owner.h
@@ -27,7 +27,7 @@ public:
     virtual void reinit();
     virtual void reload(LPCSTR section);
     virtual void net_Destroy();
-    virtual void renderable_Render(IRenderable* root);
+    virtual void renderable_Render(u32 context_id, IRenderable* root);
     virtual void attach(CInventoryItem* inventory_item);
     virtual void detach(CInventoryItem* inventory_item);
     virtual bool can_attach(const CInventoryItem* inventory_item) const;

--- a/src/xrGame/eatable_item_object.cpp
+++ b/src/xrGame/eatable_item_object.cpp
@@ -125,10 +125,10 @@ void CEatableItemObject::load(IReader& packet)
     CEatableItem::load(packet);
 }
 
-void CEatableItemObject::renderable_Render(IRenderable* root)
+void CEatableItemObject::renderable_Render(u32 context_id, IRenderable* root)
 {
-    CPhysicItem::renderable_Render(root);
-    CEatableItem::renderable_Render(root);
+    CPhysicItem::renderable_Render(context_id, root);
+    CEatableItem::renderable_Render(context_id, root);
 }
 
 void CEatableItemObject::reload(LPCSTR section)

--- a/src/xrGame/eatable_item_object.h
+++ b/src/xrGame/eatable_item_object.h
@@ -45,7 +45,7 @@ public:
     virtual void save(NET_Packet& output_packet);
     virtual void load(IReader& input_packet);
     virtual bool net_SaveRelevant() { return TRUE; }
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void reload(LPCSTR section);
     virtual void reinit();
     virtual void activate_physic_shell();

--- a/src/xrGame/hud_item_object.cpp
+++ b/src/xrGame/hud_item_object.cpp
@@ -80,5 +80,5 @@ void CHudItemObject::UpdateCL()
     CHudItem::UpdateCL();
 }
 
-void CHudItemObject::renderable_Render(IRenderable* root) { CHudItem::renderable_Render(root); }
-void CHudItemObject::on_renderable_Render(IRenderable* root) { CInventoryItemObject::renderable_Render(root); }
+void CHudItemObject::renderable_Render(u32 context_id, IRenderable* root) { CHudItem::renderable_Render(context_id, root); }
+void CHudItemObject::on_renderable_Render(u32 context_id, IRenderable* root) { CInventoryItemObject::renderable_Render(context_id, root); }

--- a/src/xrGame/hud_item_object.h
+++ b/src/xrGame/hud_item_object.h
@@ -29,8 +29,8 @@ public:
     virtual bool ActivateItem();
     virtual void DeactivateItem();
     virtual void UpdateCL();
-    void renderable_Render(IRenderable* root) override;
-    void on_renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
+    void on_renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void OnMoveToRuck(const SInvItemPlace& prev);
 
     virtual bool use_parent_ai_locations() const

--- a/src/xrGame/inventory_item_object.cpp
+++ b/src/xrGame/inventory_item_object.cpp
@@ -110,10 +110,10 @@ void CInventoryItemObject::load(IReader& packet)
     CInventoryItem::load(packet);
 }
 
-void CInventoryItemObject::renderable_Render(IRenderable* root)
+void CInventoryItemObject::renderable_Render(u32 context_id, IRenderable* root)
 {
-    CPhysicItem::renderable_Render(root);
-    CInventoryItem::renderable_Render(root);
+    CPhysicItem::renderable_Render(context_id, root);
+    CInventoryItem::renderable_Render(context_id, root);
 }
 
 void CInventoryItemObject::reload(LPCSTR section)

--- a/src/xrGame/inventory_item_object.h
+++ b/src/xrGame/inventory_item_object.h
@@ -47,7 +47,7 @@ public:
     virtual void save(NET_Packet& output_packet);
     virtual void load(IReader& input_packet);
     virtual bool net_SaveRelevant() { return true; }
-    void renderable_Render(IRenderable* root) override;
+    void renderable_Render(u32 context_id, IRenderable* root) override;
     virtual void reload(LPCSTR section);
     virtual void reinit();
     virtual void activate_physic_shell();

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -192,9 +192,9 @@ void attachable_hud_item::setup_firedeps(firedeps& fd)
 
 bool attachable_hud_item::need_renderable() const { return m_parent_hud_item->need_renderable(); }
 
-void attachable_hud_item::render(IRenderable* root)
+void attachable_hud_item::render(u32 context_id, IRenderable* root)
 {
-    GEnv.Render->add_Visual(root, m_model->dcast_RenderVisual(), m_item_transform);
+    GEnv.Render->add_Visual(context_id, root, m_model->dcast_RenderVisual(), m_item_transform);
     debug_draw_firedeps();
     m_parent_hud_item->render_hud_mode();
 }
@@ -588,7 +588,7 @@ void player_hud::render_item_ui() const
         m_attached_items[1]->render_item_ui();
 }
 
-void player_hud::render_hud(IRenderable* root)
+void player_hud::render_hud(u32 context_id, IRenderable* root)
 {
     attachable_hud_item* item0 = m_attached_items[0];
     attachable_hud_item* item1 = m_attached_items[1];
@@ -603,13 +603,13 @@ void player_hud::render_hud(IRenderable* root)
         return;
 
     if (m_model)
-        GEnv.Render->add_Visual(root, m_model->dcast_RenderVisual(), m_transform);
+        GEnv.Render->add_Visual(context_id, root, m_model->dcast_RenderVisual(), m_transform);
 
     if (item0)
-        item0->render(root);
+        item0->render(context_id, root);
 
     if (item1)
-        item1->render(root);
+        item1->render(context_id, root);
 }
 
 #include "xrCore/Animation/Motion.hpp"

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -102,7 +102,7 @@ struct attachable_hud_item
 
     void setup_firedeps(firedeps& fd);
 
-    void render(IRenderable* root);
+    void render(u32 context_id, IRenderable* root);
     void render_item_ui() const;
     bool render_item_ui_query() const;
     bool need_renderable() const;
@@ -131,7 +131,7 @@ public:
     void load(const shared_str& model_name);
     void load_default() { load("actor_hud_05"); };
     void update(const Fmatrix& trans);
-    void render_hud(IRenderable* root);
+    void render_hud(u32 context_id, IRenderable* root);
     void render_item_ui() const;
     bool render_item_ui_query() const;
     u32 anim_play(u16 part, const MotionID& M, BOOL bMixIn, const CMotionDef*& md, float speed, IKinematicsAnimated* itemModel);

--- a/src/xrParticles/particle_actions.h
+++ b/src/xrParticles/particle_actions.h
@@ -32,6 +32,8 @@ class ParticleActions
     bool m_bLocked;
 
 public:
+    Lock pa_lock;
+
     ParticleActions()
     {
         actions.reserve(4);
@@ -42,6 +44,7 @@ public:
 
     void clear()
     {
+        ScopeLock lock{ &pa_lock };
         R_ASSERT(!m_bLocked);
         for (auto& it : actions)
             xr_delete(it);
@@ -50,6 +53,7 @@ public:
 
     void append(ParticleAction* pa)
     {
+        ScopeLock lock{ &pa_lock };
         R_ASSERT(!m_bLocked);
         actions.push_back(pa);
     }
@@ -61,20 +65,21 @@ public:
 
     void resize(int cnt)
     {
+        ScopeLock lock{ &pa_lock };
         R_ASSERT(!m_bLocked);
         actions.resize(cnt);
     }
 
-    void copy(ParticleActions* src);
-
     void lock()
     {
+        pa_lock.Enter();
         R_ASSERT(!m_bLocked);
         m_bLocked = true;
     }
 
     void unlock()
     {
+        pa_lock.Leave();
         R_ASSERT(m_bLocked);
         m_bLocked = false;
     }

--- a/src/xrParticles/particle_actions.h
+++ b/src/xrParticles/particle_actions.h
@@ -79,9 +79,9 @@ public:
 
     void unlock()
     {
-        pa_lock.Leave();
         R_ASSERT(m_bLocked);
         m_bLocked = false;
+        pa_lock.Leave();
     }
 };
 } // namespace PAPI

--- a/src/xrParticles/particle_manager.cpp
+++ b/src/xrParticles/particle_manager.cpp
@@ -15,12 +15,14 @@ CParticleManager::~CParticleManager() {}
 
 ParticleEffect* CParticleManager::GetEffectPtr(int effect_id)
 {
+    ScopeLock lock{ &pm_lock };
     R_ASSERT(effect_id >= 0 && effect_id < (int)effect_vec.size());
     return effect_vec[effect_id];
 }
 
 ParticleActions* CParticleManager::GetActionListPtr(int a_list_num)
 {
+    ScopeLock lock{ &pm_lock };
     R_ASSERT(a_list_num >= 0 && a_list_num < (int)m_alist_vec.size());
     return m_alist_vec[a_list_num];
 }
@@ -28,6 +30,7 @@ ParticleActions* CParticleManager::GetActionListPtr(int a_list_num)
 // create
 int CParticleManager::CreateEffect(u32 max_particles)
 {
+    ScopeLock lock{ &pm_lock };
     int eff_id = -1;
     for (int i = 0; i < (int)effect_vec.size(); i++)
         if (!effect_vec[i])
@@ -50,12 +53,14 @@ int CParticleManager::CreateEffect(u32 max_particles)
 
 void CParticleManager::DestroyEffect(int effect_id)
 {
+    ScopeLock lock{ &pm_lock };
     R_ASSERT(effect_id >= 0 && effect_id < (int)effect_vec.size());
     xr_delete(effect_vec[effect_id]);
 }
 
 int CParticleManager::CreateActionList()
 {
+    ScopeLock lock{ &pm_lock };
     int list_id = -1;
     for (u32 i = 0; i < m_alist_vec.size(); ++i)
         if (!m_alist_vec[i])
@@ -78,6 +83,7 @@ int CParticleManager::CreateActionList()
 
 void CParticleManager::DestroyActionList(int alist_id)
 {
+    ScopeLock lock{ &pm_lock };
     R_ASSERT(alist_id >= 0 && alist_id < (int)m_alist_vec.size());
     xr_delete(m_alist_vec[alist_id]);
 }

--- a/src/xrParticles/particle_manager.h
+++ b/src/xrParticles/particle_manager.h
@@ -12,6 +12,7 @@ class CParticleManager : public IParticleManager
     using ParticleActionsVec = xr_vector<ParticleActions*>;
     ParticleEffectVec effect_vec;
     ParticleActionsVec m_alist_vec;
+    Lock pm_lock;
 
 public:
     CParticleManager();


### PR DESCRIPTION
This splits renderer into subsystems and adds parallel scene traversal for each of them:
![IMG_3199](https://user-images.githubusercontent.com/6388589/235096818-fc766398-b47d-4ba0-886f-5919890cf272.jpeg)

Note: shadow casting lights are batched by 3 and re-use contexts from cascades calculation. In case if more contexts needed, one can increase `R__NUM_AUX_CONTEXTS`.
Some of locks can be avoided if gameplay code will be untangled.

Next steps are:
- parallel command lists recording (green events on the picture)
- faster scene/lights occlusion + some opts.