### PR TITLE
Restore original ffp ppe implementation 

### DIFF
--- a/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
+++ b/src/Layers/xrRenderPC_R1/FStaticRender_RenderTarget.h
@@ -12,6 +12,18 @@ private:
     u32 curWidth;
     u32 curHeight;
 
+    // FFP
+    ref_shader			pShaderSet;
+    ref_shader			pShaderGray;
+    ref_shader			pShaderBlend;
+    ref_shader			pShaderDuality;
+    ref_shader			pShaderNoise;
+    ref_geom			pGeom;
+    ref_geom			pGeom2;
+    void				e_render_noise();
+    void				e_render_duality();
+    u32					param_noise_color;
+
 public:
     // Base targets
     xr_vector<ref_rt> rt_Base;
@@ -74,6 +86,7 @@ private:
 
 public:
     CRenderTarget();
+    ~CRenderTarget();
 
     void Begin();
     void End();


### PR DESCRIPTION
Referencing commit from SoC historical repo:
https://github.com/OpenXRay/xray-soc-history/commit/2dc9530fa6b11b270780d35d1f5d4e87836df686
https://github.com/OpenXRay/xray-soc-history/commit/998b717185d278f48fb4feb2f2ba3c02aecd4e46
https://github.com/OpenXRay/xray-soc-history/commit/9480c4414b8221d2f1773fb04064b4b9f5c9dcd5

Discord discussion: https://discord.com/channels/410170555619082240/489453264157409281/1104616744913489980

Pic is from ffp build, I also looked at this spot with rtx remix enabled and didn't get any weird rasterization issue like we typically would when ppe is applied.
![image](https://github.com/OpenXRay/xray-16/assets/2989212/e4c1c1dd-8eb6-42e1-8f31-da8a0dd64f0d)

It doesn't apply hue though when compared to vanilla. The noise effect is also a little different.
![image](https://github.com/OpenXRay/xray-16/assets/2989212/eafbea40-4b51-4a43-8cc3-e54b2068fe30)
