### PR TITLE
[Feature]: #1992 Add top, right, bottom, left alignment for CUIStatic

### DIFF
--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -1058,30 +1058,39 @@ void CUIXmlInitBase::ApplyAlign(float& x, float& y, u32 align)
 
 //////////////////////////////////////////////////////////////////////////
 
+// source: https://stackoverflow.com/questions/650162/why-cant-the-switch-statement-be-applied-to-strings
+constexpr uint32_t hash(const std::string_view data) noexcept 
+{ 
+    uint32_t hash = 5385;    
+    for (const auto& e : data)     
+        hash = ((hash << 5) + hash) + e;    
+    return hash; 
+}
+
 bool CUIXmlInitBase::InitAlignment(CUIXml& xml_doc, const char* path, int index, float& x, float& y, CUIWindow* pWnd)
 {
     // Alignment: top: "t", right: "r", bottom: "b", left: "l", center: "c"
     xr_string wnd_alignment = xml_doc.ReadAttrib(path, index, "alignment", "");
 
-    if (strchr(wnd_alignment.c_str(), 'r'))
+    switch (hash(wnd_alignment.c_str()))
     {
+    case hash("r"):
         pWnd->SetAlignment(waRight);
-    }
-    if (strchr(wnd_alignment.c_str(), 'l'))
-    {
+        break;
+    case hash("l"):
         pWnd->SetAlignment(waLeft);
-    }
-    if (strchr(wnd_alignment.c_str(), 't'))
-    {
+        break;
+    case hash("t"):
         pWnd->SetAlignment(waTop);
-    }
-    if (strchr(wnd_alignment.c_str(), 'b'))
-    {
+        break;
+    case hash("b"):
         pWnd->SetAlignment(waBottom);
-    }
-    if (strchr(wnd_alignment.c_str(), 'c'))
-    {
+        break;
+    case hash("c"):
         pWnd->SetAlignment(waCenter);
+        break;
+    default:
+        break;
     }
 
     // Alignment: right: "r", bottom: "b". Top, left - useless
@@ -1089,20 +1098,22 @@ bool CUIXmlInitBase::InitAlignment(CUIXml& xml_doc, const char* path, int index,
 
     bool result = false;
 
-    if (strchr(*alignStr, 'r'))
+    switch (hash(alignStr.c_str()))
     {
+    case hash("r"):
         x = ApplyAlignX(x, alRight);
         result = true;
-    }
-    if (strchr(*alignStr, 'b'))
-    {
+        break;
+    case hash("b"):
         y = ApplyAlignY(y, alBottom);
         result = true;
-    }
-    if (strchr(*alignStr, 'c'))
-    {
+        break;
+    case hash("c"):
         ApplyAlign(x, y, alCenter);
         result = true;
+        break;
+    default:
+        break;
     }
 
     return result;

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -1060,10 +1060,29 @@ void CUIXmlInitBase::ApplyAlign(float& x, float& y, u32 align)
 
 bool CUIXmlInitBase::InitAlignment(CUIXml& xml_doc, const char* path, int index, float& x, float& y, CUIWindow* pWnd)
 {
+    // Alignment: top: "t", right: "r", bottom: "b", left: "l", center: "c"
     xr_string wnd_alignment = xml_doc.ReadAttrib(path, index, "alignment", "");
 
+    if (strchr(wnd_alignment.c_str(), 'r'))
+    {
+        pWnd->SetAlignment(waRight);
+    }
+    if (strchr(wnd_alignment.c_str(), 'l'))
+    {
+        pWnd->SetAlignment(waLeft);
+    }
+    if (strchr(wnd_alignment.c_str(), 't'))
+    {
+        pWnd->SetAlignment(waTop);
+    }
+    if (strchr(wnd_alignment.c_str(), 'b'))
+    {
+        pWnd->SetAlignment(waBottom);
+    }
     if (strchr(wnd_alignment.c_str(), 'c'))
+    {
         pWnd->SetAlignment(waCenter);
+    }
 
     // Alignment: right: "r", bottom: "b". Top, left - useless
     shared_str alignStr = xml_doc.ReadAttrib(path, index, "align", "");

--- a/src/xrUICore/uiabstract.h
+++ b/src/xrUICore/uiabstract.h
@@ -86,16 +86,37 @@ public:
     }
     IC void GetWndRect(Frect& res) const
     {
+        const float width = (float)Device.dwWidth * (UI_BASE_WIDTH / (float)Device.dwWidth);
+        const float height = (float)Device.dwHeight * (UI_BASE_HEIGHT / (float)Device.dwHeight);
+
         switch (m_alignment)
         {
-        case waNone: res.set(m_wndPos.x, m_wndPos.y, m_wndPos.x + m_wndSize.x, m_wndPos.y + m_wndSize.y); break;
+        case waNone:
+        case waLeft:
+        {
+            res.set(m_wndPos.x, m_wndPos.y, m_wndPos.x + m_wndSize.x, m_wndPos.y + m_wndSize.y);
+            break;
+        }
         case waCenter:
         {
             float half_w = m_wndSize.x / 2.0f;
             float half_h = m_wndSize.y / 2.0f;
             res.set(m_wndPos.x - half_w, m_wndPos.y - half_h, m_wndPos.x + half_w, m_wndPos.y + half_h);
+            break;
         }
-        break;
+        case waRight:
+        {
+            res.set(width - m_wndSize.x, m_wndPos.y, width, m_wndPos.y + m_wndSize.y);
+            break;
+        }
+        case waTop:
+        {
+            res.set(m_wndPos.x, 0.f, m_wndPos.x + m_wndSize.x, m_wndSize.y);
+            break;
+        }
+        case waBottom:
+            res.set(m_wndPos.x, height - m_wndSize.y, m_wndPos.x + m_wndSize.x, height);
+            break;
         default: NODEFAULT;
         };
     }


### PR DESCRIPTION
Resolves https://github.com/OpenXRay/xray-16/issues/1192

Example:

![xrEngine_2023_05_17_12_16_05_514](https://github.com/OpenXRay/xray-16/assets/11345783/24608071-e8fb-4a6f-931e-a7ca2686f375)

Example code in ui_custom_msgs.xml:
```xml
  <test x="0" y="0" width="50" height="50" alignment="l">
          <text font="graffiti32"  r="240" g="217" b="182" a="255">Left</text>
  </test>
  <test2 x="0" y="0" width="50" height="50" alignment="r">
          <text font="graffiti32"  r="240" g="217" b="182" a="255">Right</text>
  </test2>
  <test3 x="500" y="0" width="50" height="50" alignment="t">
          <text font="graffiti32"  r="240" g="217" b="182" a="255">Top</text>
  </test3>
  <test4 x="500" y="0" width="50" height="50" alignment="b">
          <text font="graffiti32"  r="240" g="217" b="182" a="255">Bottom</text>
  </test4>
```