### PR TITLE
[Vanilla Bugfix]: Fix reversed input assignment, and dependent logic

### DIFF
--- a/src/xrGame/ActorInput.cpp
+++ b/src/xrGame/ActorInput.cpp
@@ -219,7 +219,7 @@ void CActor::IR_OnMouseWheel(int x, int y)
         return;
     }
 
-    if (inventory().Action((y > 0) ? (u16)kWPN_ZOOM_DEC : (u16)kWPN_ZOOM_INC, CMD_START))
+    if (inventory().Action((y > 0) ? (u16)kWPN_ZOOM_INC : (u16)kWPN_ZOOM_DEC, CMD_START))
         return;
 
     if (y > 0)

--- a/src/xrGame/WeaponBinoculars.cpp
+++ b/src/xrGame/WeaponBinoculars.cpp
@@ -114,7 +114,7 @@ void CWeaponBinoculars::ZoomInc()
     float delta, min_zoom_factor;
     GetZoomData(m_zoom_params.m_fScopeZoomFactor, delta, min_zoom_factor);
 
-    float f = GetZoomFactor() - delta;
+    float f = GetZoomFactor() + delta;
     clamp(f, m_zoom_params.m_fScopeZoomFactor, min_zoom_factor);
     SetZoomFactor(f);
 }
@@ -124,7 +124,7 @@ void CWeaponBinoculars::ZoomDec()
     float delta, min_zoom_factor;
     GetZoomData(m_zoom_params.m_fScopeZoomFactor, delta, min_zoom_factor);
 
-    float f = GetZoomFactor() + delta;
+    float f = GetZoomFactor() - delta;
     clamp(f, m_zoom_params.m_fScopeZoomFactor, min_zoom_factor);
     SetZoomFactor(f);
 }


### PR DESCRIPTION
Bug: Mousewheel up is assigned to `kWPN_ZOOM_DEC`, mousewheel down is assigned to `kWPN_ZOOM_INC`.

Binocular also has reversed logic in `ZoomInc`/`ZoomDec` functions due to this.

Fix: Assign `kWPN_ZOOM_INC` to mousewheel up, and `kWPN_ZOOM_DEC` to mousewheel down, fix logic in binoculars.cpp.
