### PR TITLE
[Vanilla Bugfix]: corrected create_hud_item logic for duplicate hud section (closes #1359)

### DIFF
--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -40,7 +40,9 @@ CHudItem::~CHudItem() {}
 void CHudItem::Load(cpcstr section)
 {
     //загрузить hud, если он нужен
+    IncrementInstanceId();
     hud_sect = pSettings->read_if_exists<pcstr>(section, "hud", nullptr);
+    m_unique_hud_sect = shared_str().printf("%s_%d", hud_sect.c_str(), m_inst_id);
 
     if (m_animation_slot != u32(-1)) // if it has default hardcoded slot, then don't crash
         pSettings->read_if_exists(m_animation_slot, section, "animation_slot");
@@ -309,7 +311,7 @@ u32 CHudItem::PlayHUDMotion_noCB(const shared_str& motion_name, BOOL bMixIn)
     else
     {
         m_started_rnd_anim_idx = 0;
-        return g_player_hud->motion_length(motion_name, HudSection(), m_current_motion_def);
+        return g_player_hud->motion_length(motion_name, this, m_current_motion_def);
     }
 }
 
@@ -388,7 +390,7 @@ bool CHudItem::isHUDAnimationExist(pcstr anim_name) const
     else if (HudSection().c_str()) // Third person
     {
         const CMotionDef* temp_motion_def;
-        if (g_player_hud->motion_length(anim_name, HudSection(), temp_motion_def) > 100)
+        if (g_player_hud->motion_length(anim_name, this, temp_motion_def) > 100)
             return true;
     }
     else

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -163,9 +163,13 @@ protected:
 private:
     CPhysicItem* m_object;
     CInventoryItem* m_item;
+    inline static int m_inst_id = 0;
+    shared_str m_unique_hud_sect;
 
 public:
+    void IncrementInstanceId() { m_inst_id += 1; }
     const shared_str& HudSection() const { return hud_sect; }
+    const shared_str& UniqueHudSection() const { return m_unique_hud_sect; }
     IC CPhysicItem& object() const
     {
         VERIFY(m_object);

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -167,7 +167,13 @@ private:
     shared_str m_unique_hud_sect;
 
 public:
-    void IncrementInstanceId() { m_inst_id += 1; }
+    void IncrementInstanceId()
+    {
+        if (m_inst_id < std::numeric_limits<int>::max())
+            m_inst_id += 1;
+        else
+            m_inst_id = 0;
+    }
     const shared_str& HudSection() const { return hud_sect; }
     const shared_str& UniqueHudSection() const { return m_unique_hud_sect; }
     IC CPhysicItem& object() const

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -618,10 +618,12 @@ void player_hud::render_hud(u32 context_id, IRenderable* root)
 
 #include "xrCore/Animation/Motion.hpp"
 
-u32 player_hud::motion_length(const shared_str& anim_name, const shared_str& hud_name, const CMotionDef*& md)
+u32 player_hud::motion_length(const shared_str& anim_name, const CHudItem* hudItem, const CMotionDef*& md)
 {
     const float speed = CalcMotionSpeed(anim_name);
-    attachable_hud_item* pi = create_hud_item(hud_name);
+    attachable_hud_item* pi = create_hud_item(hudItem);
+    shared_str hud_name = hudItem->HudSection();
+
     const player_hud_motion* pm = pi->m_hand_motions.find_motion(anim_name);
 
     if (!pm)
@@ -828,13 +830,12 @@ void player_hud::update_inertion(Fmatrix& trans) const
     }
 }
 
-attachable_hud_item* player_hud::create_hud_item(const shared_str& sect)
+attachable_hud_item* player_hud::create_hud_item(const CHudItem* hudItem)
 {
-    current_player_hud_sect = sect;
-    auto& item = m_pool[sect];
+    auto& item = m_pool[hudItem->UniqueHudSection()];
 
     if (!item)
-        item = xr_new<attachable_hud_item>(this, sect, m_model);
+        item = xr_new<attachable_hud_item>(this, hudItem->HudSection(), m_model);
 
     return item;
 }
@@ -849,7 +850,7 @@ bool player_hud::allow_activation(CHudItem* item) const
 
 void player_hud::attach_item(CHudItem* item)
 {
-    attachable_hud_item* pi = create_hud_item(item->HudSection());
+    attachable_hud_item* pi = create_hud_item(item);
     const int item_idx = pi->m_attach_place_idx;
 
     if (m_attached_items[item_idx] != pi)

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -137,7 +137,7 @@ public:
     bool render_item_ui_query() const;
     u32 anim_play(u16 part, const MotionID& M, BOOL bMixIn, const CMotionDef*& md, float speed, IKinematicsAnimated* itemModel);
     const shared_str& section_name() const { return m_sect_name; }
-    attachable_hud_item* create_hud_item(const shared_str& sect);
+    attachable_hud_item* create_hud_item(const CHudItem* hudItem);
 
     void attach_item(CHudItem* item);
     bool allow_activation(CHudItem* item) const;
@@ -153,7 +153,7 @@ public:
     void calc_transform(u16 attach_slot_idx, const Fmatrix& offset, Fmatrix& result) const;
     void tune(Ivector values);
     u32 motion_length(const MotionID& M, const CMotionDef*& md, float speed, IKinematicsAnimated* itemModel) const;
-    u32 motion_length(const shared_str& anim_name, const shared_str& hud_name, const CMotionDef*& md);
+    u32 motion_length(const shared_str& anim_name, const CHudItem* hudItem, const CMotionDef*& md);
     void OnMovementChanged(ACTOR_DEFS::EMoveCommand cmd) const;
 
 private:


### PR DESCRIPTION
Fixes [issue 1359](https://github.com/OpenXRay/xray-16/issues/1359)

The root issue is this function:
```cpp
attachable_hud_item* player_hud::create_hud_item(const shared_str& sect)
{
    auto& item = m_pool[sect]; // each key in m_pool is set to hud_sect. These are not unique.

    if (!item)  // If equipped item 1 hud_sect == equipped item 2 hud_sect, the line below is not called, causing the bug.
        item = xr_new<attachable_hud_item>(this, sect, m_model);

    return item;
}
```

The fix:

1. Add instance id `m_inst_id` to CHudItem, which gets incremented any time a new item gets loaded.
2. Add `m_unique_hud_sect` to CHudItem, which = `hud_sect + m_inst_id`
3. Refactor `create_hud_item` to take CHudItem as parameter & key `m_pool` by `m_unique_hud_sect` to avoid duplicate item bug.