### PR TITLE
[Vanilla Bugfix]: Grenade hide animation doesn't play when switching grenade type (closes #1124)

### DIFF
--- a/src/xrGame/Grenade.cpp
+++ b/src/xrGame/Grenade.cpp
@@ -288,22 +288,7 @@ bool CGrenade::Action(u16 cmd, u32 flags)
         if (flags & CMD_START)
         {
             if (m_pInventory)
-            {
-                TIItemContainer::iterator it = m_pInventory->m_ruck.begin();
-                TIItemContainer::iterator it_e = m_pInventory->m_ruck.end();
-                for (; it != it_e; ++it)
-                {
-                    CGrenade* pGrenade = smart_cast<CGrenade*>(*it);
-                    if (pGrenade && xr_strcmp(pGrenade->cNameSect(), cNameSect()))
-                    {
-                        m_pInventory->Ruck(this);
-                        m_pInventory->SetActiveSlot(NO_ACTIVE_SLOT);
-                        m_pInventory->Slot(pGrenade->BaseSlot(), pGrenade);
-                        return true;
-                    }
-                }
-                return true;
-            }
+                m_pInventory->ActivateDeffered();
         }
         return true;
     };

--- a/src/xrGame/Grenade.cpp
+++ b/src/xrGame/Grenade.cpp
@@ -288,7 +288,7 @@ bool CGrenade::Action(u16 cmd, u32 flags)
         if (flags & CMD_START)
         {
             if (m_pInventory)
-                m_pInventory->ActivateDeffered();
+                m_pInventory->ActivateNextGrenadeDeffered();
         }
         return true;
     };

--- a/src/xrGame/Inventory.cpp
+++ b/src/xrGame/Inventory.cpp
@@ -100,6 +100,7 @@ CInventory::CInventory()
     // ^ resize will default initialize everything with 0
 
     InitPriorityGroupsForQSwitch();
+    m_change_after_deactivate = false;
 }
 
 CInventory::~CInventory() {}
@@ -792,6 +793,9 @@ void CInventory::Update()
                     return;
                 }
             }
+
+            if (m_change_after_deactivate)
+                ActivateNextGrenade();
 
             if (GetNextActiveSlot() != NO_ACTIVE_SLOT)
             {

--- a/src/xrGame/Inventory.cpp
+++ b/src/xrGame/Inventory.cpp
@@ -526,12 +526,10 @@ bool CInventory::Ruck(PIItem pIItem, bool strict_placement)
     CGrenade* pGrenade = smart_cast<CGrenade*>(pIItem);
     if (pGrenade)
     {
-        xr_vector<shared_str>::const_iterator I = m_available_grenade_types.begin();
-        xr_vector<shared_str>::const_iterator E = m_available_grenade_types.end();
         bool new_type = true;
-        for (; I != E; ++I)
+        for (auto grenade_type : m_available_grenade_types)
         {
-            if (!xr_strcmp(pGrenade->cNameSect(), *I))
+            if (!xr_strcmp(pGrenade->cNameSect(), grenade_type))
                 new_type = false;
         }
         if (new_type)

--- a/src/xrGame/Inventory.h
+++ b/src/xrGame/Inventory.h
@@ -62,6 +62,11 @@ public:
 
     void Activate(u16 slot, /*EActivationReason reason=eGeneral, */ bool bForce = false);
 
+    bool m_change_after_deactivate;
+    void ActivateDeffered();
+    PIItem GetNextActiveGrenade();
+    bool ActivateNextGrenade();
+
     static u32 const qs_priorities_count = 5;
     PIItem GetNextItemInActiveSlot(u8 const priority_value, bool ignore_ammo);
     bool ActivateNextItemInActiveSlot();

--- a/src/xrGame/Inventory.h
+++ b/src/xrGame/Inventory.h
@@ -62,10 +62,12 @@ public:
 
     void Activate(u16 slot, /*EActivationReason reason=eGeneral, */ bool bForce = false);
 
-    bool m_change_after_deactivate;
-    void ActivateDeffered();
-    PIItem GetNextActiveGrenade();
+    xr_vector<shared_str> m_available_grenade_types;
+    bool m_isActivatingNextGrenade;
+    bool HasNextGrenade() { return m_available_grenade_types.size() > 1; };
+    PIItem GetNextGrenade();
     bool ActivateNextGrenade();
+    void ActivateNextGrenadeDeffered();
 
     static u32 const qs_priorities_count = 5;
     PIItem GetNextItemInActiveSlot(u8 const priority_value, bool ignore_ammo);

--- a/src/xrGame/inventory_quickswitch.cpp
+++ b/src/xrGame/inventory_quickswitch.cpp
@@ -255,11 +255,9 @@ PIItem CInventory::GetNextGrenade()
     if (count_types > 1)
     {
         int curr_num = 0;
-        auto I = m_available_grenade_types.begin();
-        auto E = m_available_grenade_types.end();
-        for (; I != E; ++I)
+        for (auto grenade_type : m_available_grenade_types)
         {
-            if (!xr_strcmp(ActiveItem()->cast_game_object()->cNameSect(), *I))
+            if (!xr_strcmp(ActiveItem()->cast_game_object()->cNameSect(), grenade_type))
                 break;
             curr_num++;
         }
@@ -268,15 +266,12 @@ PIItem CInventory::GetNextGrenade()
             next_num = 0;
 
         shared_str sect_next_grn = m_available_grenade_types[next_num];
-       
-        auto it = m_ruck.begin();
-        auto it_e = m_ruck.end();
 
-        for (; it != it_e; ++it)
+        for (auto itm : m_ruck)
         {
-            CGrenade* pGrenade = smart_cast<CGrenade*>(*it);
+            CGrenade* pGrenade = smart_cast<CGrenade*>(itm);
             if (pGrenade && !xr_strcmp(pGrenade->cNameSect(), sect_next_grn))
-                return *it;
+                return itm;
         }
     }
 

--- a/src/xrGame/inventory_quickswitch.cpp
+++ b/src/xrGame/inventory_quickswitch.cpp
@@ -1,6 +1,7 @@
 #include "StdAfx.h"
 #include "Inventory.h"
 #include "Weapon.h"
+#include "Grenade.h"
 #include "Actor.h"
 #include "xrCore/xr_ini.h"
 
@@ -238,4 +239,92 @@ void priority_group::init_group(shared_str const& game_section, shared_str const
 bool priority_group::is_item_in_group(shared_str const& section_name) const
 {
     return m_sections.find(section_name) != m_sections.end();
+}
+
+void CInventory::ActivateDeffered()
+{
+    m_change_after_deactivate = true;
+    Activate(NO_ACTIVE_SLOT);
+}
+
+PIItem CInventory::GetNextActiveGrenade()
+{
+    xr_vector<shared_str> types_sect_grn;
+    types_sect_grn.push_back(ActiveItem()->cast_game_object()->cNameSect());
+    int count_types = 1;
+    TIItemContainer::iterator it = m_ruck.begin();
+    TIItemContainer::iterator it_e = m_ruck.end();
+    for (; it != it_e; ++it)
+    {
+        CGrenade* pGrenade = smart_cast<CGrenade*>(*it);
+        if (pGrenade)
+        {
+            xr_vector<shared_str>::const_iterator I = types_sect_grn.begin();
+            xr_vector<shared_str>::const_iterator E = types_sect_grn.end();
+            bool new_type = true;
+            for (; I != E; ++I)
+            {
+                if (!xr_strcmp(pGrenade->cNameSect(), *I))
+                    new_type = false;
+            }
+            if (new_type)
+            {
+                types_sect_grn.push_back(pGrenade->cNameSect());
+                count_types++;
+            }
+        }
+    }
+
+    if (count_types > 1)
+    {
+        int curr_num = 0;
+        std::sort(types_sect_grn.begin(), types_sect_grn.end());
+        xr_vector<shared_str>::const_iterator I = types_sect_grn.begin();
+        xr_vector<shared_str>::const_iterator E = types_sect_grn.end();
+        for (; I != E; ++I)
+        {
+            if (!xr_strcmp(ActiveItem()->cast_game_object()->cNameSect(), *I))
+                break;
+            curr_num++;
+        }
+        int next_num = curr_num + 1;
+        if (next_num >= count_types)
+            next_num = 0;
+
+        shared_str sect_next_grn = types_sect_grn[next_num];
+       
+        it = m_ruck.begin();
+        it_e = m_ruck.end();
+        for (; it != it_e; ++it)
+        {
+            CGrenade* pGrenade = smart_cast<CGrenade*>(*it);
+            if (pGrenade && !xr_strcmp(pGrenade->cNameSect(), sect_next_grn))
+                return *it;
+        }
+    }
+
+    return nullptr;
+}
+
+bool CInventory::ActivateNextGrenade()
+{
+    if (m_iActiveSlot == NO_ACTIVE_SLOT)
+        return false;
+
+    CGameObject* pActor_owner = smart_cast<CGameObject*>(m_pOwner);
+    if (Level().CurrentViewEntity() != pActor_owner)
+        return false;
+
+    PIItem new_item = GetNextActiveGrenade();
+    if (!new_item)
+        return false;
+
+    PIItem current_item = ActiveItem();
+    if (current_item)
+    {
+        m_change_after_deactivate = false;
+        Ruck(current_item);
+        Slot(new_item->BaseSlot(), new_item);
+    }
+    return true;
 }


### PR DESCRIPTION
credits: [Monolith engine](https://bitbucket.org/anomalymod/xray-monolith/src/master/)

This causes some lag on grenade switch in mixed build, release/release master gold should be unaffected.