### PR TITLE
[Bugfix]: fix race condition preventing OnAnimationEnd call for shoot animation (closes #1371)

### DIFF
--- a/src/xrGame/WeaponFire.cpp
+++ b/src/xrGame/WeaponFire.cpp
@@ -132,8 +132,6 @@ void CWeapon::StopShooting()
     if (m_pFlameParticles && m_pFlameParticles->IsLooped())
         StopFlameParticles();
 
-    SwitchState(eIdle);
-
     bWorking = false;
 }
 

--- a/src/xrGame/WeaponMagazined.cpp
+++ b/src/xrGame/WeaponMagazined.cpp
@@ -588,7 +588,8 @@ void CWeaponMagazined::state_Fire(float dt)
         if (iAmmoElapsed == 0)
             OnMagazineEmpty();
 
-        StopShooting();
+        if (m_dwMotionCurrTm >= m_dwMotionEndTm)
+            StopShooting();
     }
     else
     {
@@ -639,6 +640,9 @@ void CWeaponMagazined::OnAnimationEnd(u32 state)
 {
     switch (state)
     {
+    case eFire:
+        SwitchState(eIdle);
+        break;
     case eReload:
         ReloadMagazine();
         SwitchState(eIdle);


### PR DESCRIPTION
Added a check to see if the shoot animation is complete before we call `StopShooting`

The bug was caused because `StopShooting` causes immediate state switch to `eIdle`. In this case, it is called just before `m_dwMotionCurrTm > m_dwMotionEndTm` can evaluate to true for shooting anim in `CHudItem::UpdateCL`, preventing `OnAnimationEnd` from getting called. 