### PR TITLE
[Bugfix]: #1374 - fix incorrect initialization CHUDState by setting eHidden as first value of EHudStates

### DIFF
--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -18,10 +18,10 @@ class CHUDState
 public:
     enum EHudStates
     {
-        eIdle = 0,
+        eHidden = 0,
+        eIdle,
         eShowing,
         eHiding,
-        eHidden,
         eBore,
         eLastBaseState = eBore,
     };


### PR DESCRIPTION
avoids editing packets - yay!