### PR TITLE
[FIX] Custom drag drop script export fix.

### DIFF
--- a/src/xrGame/ui/UIActorMenu_action.cpp
+++ b/src/xrGame/ui/UIActorMenu_action.cpp
@@ -92,8 +92,12 @@ bool CUIActorMenu::DropItemOnAnotherItem(EDDListType t_old, EDDListType t_new, C
 
         const PIItem _iitem = _citem ? static_cast<PIItem>(_citem->m_pData) : nullptr;
 
+        // Callback handles dropping item on item, in other cases (moving, dropping from inventory) we do not fire it.
+        if (_iitem == nullptr)
+            return true;
+
         CGameObject* GO1 = smart_cast<CGameObject*>(CurrentIItem());
-        CGameObject* GO2 = _iitem ? smart_cast<CGameObject*>(_iitem) : nullptr;
+        CGameObject* GO2 = smart_cast<CGameObject*>(_iitem);
 
         return funct1(GO1 ? GO1->lua_game_object() : nullptr, GO2 ? GO2->lua_game_object() : nullptr, (int)t_old, (int)t_new);
     }

--- a/src/xrGame/ui/UIActorMenu_action.cpp
+++ b/src/xrGame/ui/UIActorMenu_action.cpp
@@ -92,11 +92,8 @@ bool CUIActorMenu::DropItemOnAnotherItem(EDDListType t_old, EDDListType t_new, C
 
         const PIItem _iitem = _citem ? static_cast<PIItem>(_citem->m_pData) : nullptr;
 
-        if (_iitem == nullptr)
-            return false;
-
         CGameObject* GO1 = smart_cast<CGameObject*>(CurrentIItem());
-        CGameObject* GO2 = smart_cast<CGameObject*>(_iitem);
+        CGameObject* GO2 = _iitem ? smart_cast<CGameObject*>(_iitem) : nullptr;
 
         return funct1(GO1 ? GO1->lua_game_object() : nullptr, GO2 ? GO2->lua_game_object() : nullptr, (int)t_old, (int)t_new);
     }


### PR DESCRIPTION
## Changes:
- Fixing drag drop callback logic according to (https://github.com/Roman-n/xray-monolith__/blob/d404b95d92947e83b283d912111fe0957fb5fbb6/src/xrGame/ui/UIActorMenu_action.cpp#L99)

Without this fix bugs happened (game drag drops are just not usable when users have actor_menu_inventory.CUIActorMenu_OnItemDropped callback defined):
 - Items drop crashed game
 - You could attach bread etc to weapon
 - You could place weapon as artefact / armor etc
 - And many others

I think it happened because when code was moved from anomaly, it was not obvious that XRay implementation and Monolith engines have reversed conditions.

Checked in game drop events -> callback only firing when dropping item on item and not firing when moving/equiping/dropping items. 

---

Also I have noticed that we do not have check for `actor_menu_inventory` file existence before calling `CUIActorMenu_OnItemDropped` callback it it. As result, every drag-drop prints stack trace that file does not exist in game
