### PR TITLE
Common/PlatformApple.inl: Fix compilation with GCC

### DIFF
--- a/src/Common/PlatformApple.inl
+++ b/src/Common/PlatformApple.inl
@@ -25,6 +25,8 @@
 #include <utime.h>
 #include <ctime>
 
+#include <xlocale.h> // for locale_t
+
 #define _LINUX // for GameSpy
 
 #define _MAX_PATH 4096 + 1
@@ -40,6 +42,7 @@
 
 #define __cdecl
 #define __stdcall
+#define __fastcall
 
 //#define __declspec
 #define __forceinline FORCE_INLINE


### PR DESCRIPTION
Get `locale_t` via `xlocale.h`:
![image](https://github.com/OpenXRay/xray-16/assets/23431373/c595e73d-f3db-4ef5-953e-c158efae83d6)

Define `__fastcall`:
![image](https://github.com/OpenXRay/xray-16/assets/23431373/dcb065ae-d76e-4182-bbff-35e478233eee)
