### PR TITLE
[FEATURE] Updating debug methods for GOAP planner

### DIFF
--- a/src/xrGame/action_planner_inline.h
+++ b/src/xrGame/action_planner_inline.h
@@ -256,7 +256,18 @@ IC void CPlanner::show(LPCSTR offset)
     Msg("\n%sEVALUATORS : %d\n", offset, this->evaluators().size());
 
     for (const auto& it : this->evaluators())
-        Msg("%sevaluator   [%d][%s]", offset, it.first, property2string(it.first));
+    {
+        auto J = std::lower_bound(this->current_state().conditions().cbegin(),
+            this->current_state().conditions().cend(), CWorldProperty(it.first, false));
+        char current = '?';
+
+         if ((J != this->current_state().conditions().end()) && ((*J).condition() == it.first))
+        {
+            current = (*J).value() ? '+' : '-';
+        }
+
+        Msg("%sevaluator   [%d][%s][%c]", offset, it.first, property2string(it.first), current);
+    }
 
     Msg("\n%sOPERATORS : %d\n", offset, this->operators().size());
     for (const auto& it : this->operators())

--- a/src/xrGame/action_planner_script.cpp
+++ b/src/xrGame/action_planner_script.cpp
@@ -51,6 +51,8 @@ IC static void CScriptActionPlanner_Export(lua_State* luaState)
             .def("clear", &CScriptActionPlanner::clear)
 #ifdef LOG_ACTION
             .def("show", &CScriptActionPlanner::show)
+            .def("show_current_world_state", &CScriptActionPlanner::show_current_world_state)
+            .def("show_target_world_state", &CScriptActionPlanner::show_target_world_state)
 #endif // LOG_ACTION
 
             ,


### PR DESCRIPTION
Updated GOAP debugging methods to be more informative when doing AI changed. Used already existing code snippet to get evaluators current state

## Changes
- Exporting show methods for target world state / current world state. `show` method does not print this information
- In `show` method display actual value of evaluators when printing list, `?` for nulls, `+`/`-` for true-false correspondingly

