### PR TITLE
Fixed disappearing of "load_last_save" button

### DIFF
--- a/src/xrGame/alife_storage_manager.cpp
+++ b/src/xrGame/alife_storage_manager.cpp
@@ -27,7 +27,7 @@ using namespace ALife;
 
 extern string_path g_last_saved_game;
 
-CALifeStorageManager::~CALifeStorageManager() { *g_last_saved_game = 0; }
+CALifeStorageManager::~CALifeStorageManager() {}
 void CALifeStorageManager::save(LPCSTR save_name_no_check, bool update_name)
 {
     pcstr gameSaveExtension = SAVE_EXTENSION;


### PR DESCRIPTION
Since CS, GSC made a mistake and it brokes that button after quitting on loaded level