### PR TITLE
[SHOC/Hang]: Reaching end of file while loading content from archive causes hang at startup.

### DIFF
--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -342,11 +342,15 @@ IReader* open_chunk(int fd, u32 ID, pcstr archiveName, size_t archiveSize, bool 
         read_byte = ::read(fd, &dwType, 4);
         if (read_byte == -1)
             return nullptr;
+        else if (read_byte == 0)
+            return nullptr;
 
         u32 tempSize = 0;
         read_byte = ::read(fd, &tempSize, 4);
         dwSize = tempSize;
         if (read_byte == -1)
+            return nullptr;
+        else if (read_byte == 0)
             return nullptr;
 
         if ((dwType & ~CFS_CompressMark) == ID)


### PR DESCRIPTION
LocatorAPI could reach end of file while loading content and got stuck in infinite loop.