### PR TITLE
Fix unpredictable console cursor behaviour (closes #1356)

### DIFF
--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -632,7 +632,11 @@ void line_edit_control::delete_word_forward()
 
 void line_edit_control::move_pos_home() { m_cur_pos = 0; }
 void line_edit_control::move_pos_end() { m_cur_pos = xr_strlen(m_edit_str); }
-void line_edit_control::move_pos_left() { if(m_cur_pos > 0) --m_cur_pos; }
+void line_edit_control::move_pos_left()
+{
+    if (m_cur_pos > 0)
+        --m_cur_pos;
+}
 void line_edit_control::move_pos_right() { ++m_cur_pos; }
 void line_edit_control::move_pos_left_word()
 {
@@ -646,7 +650,8 @@ void line_edit_control::move_pos_left_word()
         while (i > 0 && !terminate_char(m_edit_str[i], true))
             --i;
 
-        if (i > 0) ++i;
+        if (i > 0)
+            ++i;
     }
 
     m_cur_pos = i;

--- a/src/xrEngine/line_edit_control.cpp
+++ b/src/xrEngine/line_edit_control.cpp
@@ -632,21 +632,21 @@ void line_edit_control::delete_word_forward()
 
 void line_edit_control::move_pos_home() { m_cur_pos = 0; }
 void line_edit_control::move_pos_end() { m_cur_pos = xr_strlen(m_edit_str); }
-void line_edit_control::move_pos_left() { --m_cur_pos; }
+void line_edit_control::move_pos_left() { if(m_cur_pos > 0) --m_cur_pos; }
 void line_edit_control::move_pos_right() { ++m_cur_pos; }
 void line_edit_control::move_pos_left_word()
 {
-    size_t i = m_cur_pos - 1;
+    size_t i = m_cur_pos > 0 ? m_cur_pos - 1 : 0;
 
-    while (i >= 0 && m_edit_str[i] == ' ')
+    while (i > 0 && m_edit_str[i] == ' ')
         --i;
 
-    if (!terminate_char(m_edit_str[i]))
+    if (i > 0 && !terminate_char(m_edit_str[i]))
     {
-        while (i >= 0 && !terminate_char(m_edit_str[i], true))
+        while (i > 0 && !terminate_char(m_edit_str[i], true))
             --i;
 
-        ++i;
+        if (i > 0) ++i;
     }
 
     m_cur_pos = i;


### PR DESCRIPTION
cursor jump was caused by variable overflow
issue [#1356](https://github.com/OpenXRay/xray-16/issues/1356)