### PR TITLE
[Feature] Extending `upgrade` api for scripting, correct some upgrading logics

### DIFF
--- a/src/xrGame/ExplosiveRocket.cpp
+++ b/src/xrGame/ExplosiveRocket.cpp
@@ -27,8 +27,10 @@ void CExplosiveRocket::Load(LPCSTR section)
 
 bool CExplosiveRocket::net_Spawn(CSE_Abstract* DC)
 {
+    CInventoryItem::net_Spawn_install_upgrades(DC);
     BOOL result = inherited::net_Spawn(DC);
     result = result && CInventoryItem::net_Spawn(DC);
+
     Fvector box;
     BoundingBox().getsize(box);
     float max_size = _max(_max(box.x, box.y), box.z);

--- a/src/xrGame/ExplosiveRocket.cpp
+++ b/src/xrGame/ExplosiveRocket.cpp
@@ -30,7 +30,6 @@ bool CExplosiveRocket::net_Spawn(CSE_Abstract* DC)
     CInventoryItem::net_Spawn_install_upgrades(DC);
     BOOL result = inherited::net_Spawn(DC);
     result = result && CInventoryItem::net_Spawn(DC);
-
     Fvector box;
     BoundingBox().getsize(box);
     float max_size = _max(_max(box.x, box.y), box.z);

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -63,10 +63,6 @@ bool CWeaponMagazinedWGrenade::net_Spawn(CSE_Abstract* DC)
 {
     CSE_ALifeItemWeapon* const weapon = smart_cast<CSE_ALifeItemWeapon*>(DC);
     R_ASSERT(weapon);
-    if (IsGameTypeSingle())
-    {
-        inherited::net_Spawn_install_upgrades(weapon->m_upgrades);
-    }
 
     BOOL l_res = inherited::net_Spawn(DC);
 
@@ -919,12 +915,6 @@ bool CWeaponMagazinedWGrenade::install_upgrade_impl(LPCSTR section, bool test)
     result |= result2;
 
     return result;
-}
-
-void CWeaponMagazinedWGrenade::net_Spawn_install_upgrades(Upgrades_type saved_upgrades)
-{
-    // do not delete this
-    // this is intended behaviour
 }
 
 bool CWeaponMagazinedWGrenade::GetBriefInfo(II_BriefInfo& info)

--- a/src/xrGame/WeaponMagazinedWGrenade.h
+++ b/src/xrGame/WeaponMagazinedWGrenade.h
@@ -68,7 +68,6 @@ public:
     virtual void PlayAnimBore();
 
 private:
-    virtual void net_Spawn_install_upgrades(Upgrades_type saved_upgrades);
     virtual bool install_upgrade_impl(LPCSTR section, bool test);
     virtual bool install_upgrade_ammo_class(LPCSTR section, bool test);
 

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -337,11 +337,6 @@ bool CInventoryItem::net_Spawn(CSE_Abstract* DC)
     //!!!
     m_fCondition = pSE_InventoryItem->m_fCondition;
 
-    if (IsGameTypeSingle())
-    {
-        net_Spawn_install_upgrades(pSE_InventoryItem->m_upgrades);
-    }
-
     if (GameID() != eGameIDSingle)
         object().processing_activate();
 

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -285,6 +285,7 @@ public:
     IC bool has_any_upgrades() { return (m_upgrades.size() != 0); }
     bool has_upgrade(const shared_str& upgrade_id);
     bool has_upgrade_group(const shared_str& upgrade_group_id);
+    bool has_upgrade_group_by_upgrade_id(const shared_str& upgrade_id);
     void add_upgrade(const shared_str& upgrade_id, bool loading);
     bool get_upgrades_str(string2048& res) const;
 #ifdef GAME_OBJECT_EXTENDED_EXPORTS
@@ -306,7 +307,7 @@ public:
     float interpolate_states(net_update_IItem const& first, net_update_IItem const& last, SPHNetState& current);
 
 protected:
-    virtual void net_Spawn_install_upgrades(Upgrades_type saved_upgrades);
+    virtual void net_Spawn_install_upgrades(CSE_Abstract* DC);
     virtual bool install_upgrade_impl(LPCSTR section, bool test);
 
     template <typename T>

--- a/src/xrGame/inventory_item_object.cpp
+++ b/src/xrGame/inventory_item_object.cpp
@@ -85,6 +85,7 @@ void CInventoryItemObject::OnEvent(NET_Packet& P, u16 type)
 
 bool CInventoryItemObject::net_Spawn(CSE_Abstract* DC)
 {
+    CInventoryItem::net_Spawn_install_upgrades(DC);
     BOOL res = CPhysicItem::net_Spawn(DC);
     CInventoryItem::net_Spawn(DC);
     return (res);

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -37,6 +37,18 @@ bool CInventoryItem::has_upgrade_group(const shared_str& upgrade_group_id)
     return false;
 }
 
+bool CInventoryItem::has_upgrade_group_by_upgrade_id(const shared_str& upgrade_id)
+{
+    inventory::upgrade::Upgrade* upgrade = ai().alife().inventory_upgrade_manager().get_upgrade(upgrade_id);
+
+    if (!upgrade)
+    {
+        return false;
+    }
+
+    return has_upgrade_group(upgrade->parent_group_id());
+}
+
 bool CInventoryItem::has_upgrade(const shared_str& upgrade_id)
 {
     if (m_section_id == upgrade_id)
@@ -137,22 +149,28 @@ void CInventoryItem::log_upgrades()
 }
 #endif // DEBUG
 
-void CInventoryItem::net_Spawn_install_upgrades(Upgrades_type saved_upgrades) // net_Spawn
+void CInventoryItem::net_Spawn_install_upgrades(CSE_Abstract* DC) // net_Spawn
 {
-    m_upgrades.clear();
-
-    if (!ai().get_alife())
+    if (!IsGameTypeSingle() || !ai().get_alife())
     {
         return;
     }
 
+    CSE_ALifeInventoryItem* pSE_InventoryItem = smart_cast<CSE_ALifeInventoryItem*>(DC);
+    if (!pSE_InventoryItem)
+    {
+        return;
+    }
+
+    Upgrades_type saved_upgrades = pSE_InventoryItem->m_upgrades;
+
+    m_upgrades.clear();
+
     ai().alife().inventory_upgrade_manager().init_install(*this); // from pSettings
 
-    auto ib = saved_upgrades.begin();
-    auto ie = saved_upgrades.end();
-    for (; ib != ie; ++ib)
+    for (auto it:saved_upgrades)
     {
-        ai().alife().inventory_upgrade_manager().upgrade_install(*this, (*ib), true);
+        ai().alife().inventory_upgrade_manager().upgrade_install(*this, (*it), true);
     }
 }
 

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -168,7 +168,7 @@ void CInventoryItem::net_Spawn_install_upgrades(CSE_Abstract* DC) // net_Spawn
 
     ai().alife().inventory_upgrade_manager().init_install(*this); // from pSettings
 
-    for (auto it:saved_upgrades)
+    for (auto it : saved_upgrades)
     {
         ai().alife().inventory_upgrade_manager().upgrade_install(*this, (*it), true);
     }

--- a/src/xrGame/inventory_item_upgrade.cpp
+++ b/src/xrGame/inventory_item_upgrade.cpp
@@ -168,9 +168,9 @@ void CInventoryItem::net_Spawn_install_upgrades(CSE_Abstract* DC) // net_Spawn
 
     ai().alife().inventory_upgrade_manager().init_install(*this); // from pSettings
 
-    for (auto it : saved_upgrades)
+    for (const auto& upgrade : saved_upgrades)
     {
-        ai().alife().inventory_upgrade_manager().upgrade_install(*this, (*it), true);
+        ai().alife().inventory_upgrade_manager().upgrade_install(*this, *upgrade, true);
     }
 }
 

--- a/src/xrGame/inventory_upgrade.cpp
+++ b/src/xrGame/inventory_upgrade.cpp
@@ -145,6 +145,12 @@ enum UpgradeStateResultScript
 
 UpgradeStateResult Upgrade::can_install(CInventoryItem& item, bool loading)
 {
+    // If loading data, it was already saved in such state and checked in process of installation.
+    if (loading)
+    {
+        return result_ok;
+    }
+
     UpgradeStateResult res = inherited::can_install(item, loading);
     if (res != result_ok)
     {
@@ -152,10 +158,6 @@ UpgradeStateResult Upgrade::can_install(CInventoryItem& item, bool loading)
     }
 
     res = m_parent_group->can_install(item, *this, loading);
-    if (loading)
-    {
-        return res; // later script check
-    }
 
     int script_res = m_preconditions();
 
@@ -180,6 +182,11 @@ UpgradeStateResult Upgrade::can_install(CInventoryItem& item, bool loading)
     }
 
     return result_ok;
+}
+
+UpgradeStateResult Upgrade::can_add(CInventoryItem& item)
+{
+   return inherited::can_install(item, false);
 }
 
 bool Upgrade::check_scheme_index(Ivector2 const& scheme_index)

--- a/src/xrGame/inventory_upgrade.h
+++ b/src/xrGame/inventory_upgrade.h
@@ -106,6 +106,7 @@ public:
     virtual void fill_root_container(Root* root);
 
     virtual UpgradeStateResult can_install(CInventoryItem& item, bool loading);
+    virtual UpgradeStateResult can_add(CInventoryItem& item);
     bool check_scheme_index(const Ivector2& scheme_index);
     void set_highlight(bool value);
     void run_effects(bool loading);

--- a/src/xrGame/inventory_upgrade_manager.cpp
+++ b/src/xrGame/inventory_upgrade_manager.cpp
@@ -361,6 +361,40 @@ bool Manager::is_disabled_upgrade( CInventoryItem& item, shared_str const& upgra
 }
 */
 
+bool Manager::can_install_upgrade(CInventoryItem& item, shared_str const& upgrade_id)
+{
+    return upgrade_verify(item.m_section_id, upgrade_id)->can_install(item, false) == result_ok;
+}
+
+bool Manager::can_add_upgrade(CInventoryItem& item, shared_str const& upgrade_id)
+{
+    return upgrade_verify(item.m_section_id, upgrade_id)->can_add(item) == result_ok;
+}
+
+bool Manager::upgrade_add(CInventoryItem& item, shared_str const& upgrade_id)
+{
+    Upgrade* upgrade = upgrade_verify(item.m_section_id, upgrade_id);
+    UpgradeStateResult res = upgrade->can_add(item);
+
+    if (res == result_ok)
+    {
+        if (item.install_upgrade(upgrade->section()))
+        {
+            item.add_upgrade(upgrade_id, false);
+
+            return true;
+        }
+        else
+        {
+            FATAL(make_string("! Upgrade <%s> of item [%s] (id = %d) is EMPTY or FAILED !", upgrade_id.c_str(),
+                item.m_section_id.c_str(), item.object_id())
+                      .c_str());
+        }
+    }
+
+    return false;
+}
+
 bool Manager::upgrade_install(CInventoryItem& item, shared_str const& upgrade_id, bool loading)
 {
     Upgrade* upgrade = upgrade_verify(item.m_section_id, upgrade_id);

--- a/src/xrGame/inventory_upgrade_manager.h
+++ b/src/xrGame/inventory_upgrade_manager.h
@@ -60,7 +60,10 @@ public:
     bool is_known_upgrade(shared_str const& upgrade_id);
     //*			bool		is_disabled_upgrade( CInventoryItem& item, shared_str const& upgrade_id );
 
+    bool can_install_upgrade(CInventoryItem& item, shared_str const& upgrade_id);
+    bool can_add_upgrade(CInventoryItem& item, shared_str const& upgrade_id);
     bool upgrade_install(CInventoryItem& item, shared_str const& upgrade_id, bool loading);
+    bool upgrade_add(CInventoryItem& item, shared_str const& upgrade_id);
     void init_install(CInventoryItem& item);
 
     bool compute_range(LPCSTR parameter, float& low, float& high);

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -833,8 +833,13 @@ public:
     u8 GetAmmoType();
 
     //Weapon & Outfit
+    bool AddUpgrade(pcstr upgrade);
     bool InstallUpgrade(pcstr upgrade);
     bool HasUpgrade(pcstr upgrade) const;
+    bool HasUpgradeGroup(pcstr upgrade_group) const;
+    bool HasUpgradeGroupByUpgradeId(pcstr upgrade) const;
+    bool CanAddUpgrade(pcstr upgrade) const;
+    bool CanInstallUpgrade(pcstr upgrade) const;
     void IterateInstalledUpgrades(luabind::functor<void> functor);
 
     //Car

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -1794,8 +1794,7 @@ bool CScriptGameObject::AddUpgrade(pcstr upgrade)
     CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
     if (!item)
     {
-        GEnv.ScriptEngine->script_log(
-            LuaMessageType::Error, "CInventoryItem : cannot access class member AddUpgrade!");
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member AddUpgrade!");
         return false;
     }
 
@@ -1810,8 +1809,7 @@ bool CScriptGameObject::InstallUpgrade(pcstr upgrade)
     CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
     if (!item)
     {
-        GEnv.ScriptEngine->script_log(
-            LuaMessageType::Error, "CInventoryItem : cannot access class member InstallUpgrade!");
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member InstallUpgrade!");
         return false;
     }
 

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -1789,12 +1789,29 @@ void CScriptGameObject::Weapon_AddonDetach(pcstr item_section)
         weapon->Detach(item_section, true);
 }
 
+bool CScriptGameObject::AddUpgrade(pcstr upgrade)
+{
+    CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
+    if (!item)
+    {
+        GEnv.ScriptEngine->script_log(
+            LuaMessageType::Error, "CInventoryItem : cannot access class member AddUpgrade!");
+        return false;
+    }
+
+    if (!pSettings->section_exist(upgrade))
+        return false;
+
+    return ai().alife().inventory_upgrade_manager().upgrade_add(*item, upgrade);
+}
+
 bool CScriptGameObject::InstallUpgrade(pcstr upgrade)
 {
     CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
     if (!item)
     {
-        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member InstallUpgrade!");
+        GEnv.ScriptEngine->script_log(
+            LuaMessageType::Error, "CInventoryItem : cannot access class member InstallUpgrade!");
         return false;
     }
 
@@ -1802,6 +1819,36 @@ bool CScriptGameObject::InstallUpgrade(pcstr upgrade)
         return false;
 
     return ai().alife().inventory_upgrade_manager().upgrade_install(*item, upgrade, false);
+}
+
+bool CScriptGameObject::CanAddUpgrade(pcstr upgrade) const
+{
+    CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
+    if (!item)
+    {
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member CanAddUpgrade!");
+        return false;
+    }
+
+    if (!pSettings->section_exist(upgrade))
+        return false;
+
+    return ai().alife().inventory_upgrade_manager().can_add_upgrade(*item, upgrade);
+}
+
+bool CScriptGameObject::CanInstallUpgrade(pcstr upgrade) const
+{
+    CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
+    if (!item)
+    {
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member CanInstallUpgrade!");
+        return false;
+    }
+
+    if (!pSettings->section_exist(upgrade))
+        return false;
+
+    return ai().alife().inventory_upgrade_manager().can_install_upgrade(*item, upgrade);
 }
 
 bool CScriptGameObject::HasUpgrade(pcstr upgrade) const
@@ -1817,6 +1864,36 @@ bool CScriptGameObject::HasUpgrade(pcstr upgrade) const
         return false;
 
     return item->has_upgrade(upgrade);
+}
+
+bool CScriptGameObject::HasUpgradeGroup(pcstr upgrade_group) const
+{
+    CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
+    if (!item)
+    {
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member HasUpgradeGroup!");
+        return false;
+    }
+
+    if (!pSettings->section_exist(upgrade_group))
+        return false;
+
+    return item->has_upgrade_group(upgrade_group);
+}
+
+bool CScriptGameObject::HasUpgradeGroupByUpgradeId(pcstr upgrade) const
+{
+    CInventoryItem* item = smart_cast<CInventoryItem*>(&object());
+    if (!item)
+    {
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "CInventoryItem : cannot access class member HasUpgradeGroupByUpgradeId!");
+        return false;
+    }
+
+    if (!pSettings->section_exist(upgrade))
+        return false;
+
+    return item->has_upgrade_group_by_upgrade_id(upgrade);
 }
 
 void CScriptGameObject::IterateInstalledUpgrades(luabind::functor<void> functor)

--- a/src/xrGame/script_game_object_script3.cpp
+++ b/src/xrGame/script_game_object_script3.cpp
@@ -440,8 +440,13 @@ luabind::class_<CScriptGameObject>& script_register_game_object2(luabind::class_
         .def("weapon_addon_detach", &CScriptGameObject::Weapon_AddonDetach)
 
         //For Weapon & Outfit
+        .def("add_upgrade", &CScriptGameObject::AddUpgrade)
         .def("install_upgrade", &CScriptGameObject::InstallUpgrade)
         .def("has_upgrade", &CScriptGameObject::HasUpgrade)
+        .def("has_upgrade_group", &CScriptGameObject::HasUpgradeGroup)
+        .def("has_upgrade_group_by_upgrade_id", &CScriptGameObject::HasUpgradeGroupByUpgradeId)
+        .def("can_install_upgrade", &CScriptGameObject::CanInstallUpgrade)
+        .def("can_add_upgrade", &CScriptGameObject::CanAddUpgrade)
         .def("iterate_installed_upgrades", &CScriptGameObject::IterateInstalledUpgrades)
 
         // For CHudItem


### PR DESCRIPTION
## Changes

- Unified `net_Spawn_install_upgrades` logics to work with same signature as original `net_Spawn` event and expect abstract entity
- Moved `net_Spawn_install_upgrades` logics call before base method related to net spawning and binder lifecycle calls [A]
- Less strict check in `can_install` when loading data -> does not make sense to check data when loading from file, it should be validated on moment of addition [B]
- Added/exported method to check if upgrade group is installed by upgrade id (has_upgrade_group_by_upgrade_id)
- Added/exported method to check if upgrade group is installed
- Added/exported method to check if upgrade can be added [C]
- Added/exported method to check if upgrade can be installed [C]


### A

Previous implementation of `net_Spawn_install_upgrades` called cleanup of client side object `m_upgrades` and tried to sync it with server entity. Also it was called `after` binder lifecycle methods from script so it made all the logics used in scripts on spawn event irrelevant (LUA added extension -> it is added to client object -> it is added to server object -> inventory item lifecycle deletes all the data from client object and fetches it from temporary spawn entity where it is empty).

Also I believe some code parts mocked this method and called original one before base lifecycle specifically for same reasons.

### B

On load event we should not re-validate everything what was done before by game engine. Also keeping old logics blocks us from installing all upgrades with scripts. Once you are loading save where 2 upgrades from same group are installed, game crashes without these changes. So basically the change solves two problems.

### C

Added new methods and separated concept of `install` and `add` for compatibility and code quality. Problem is that `install` runs script checks and script effects which are part of interaction with mechanic. If you want to purely add upgrades based only on script logics you have to use something else.

`add` just adds and saves upgrade ignoring script effects/preconditions and it does not unload/detach addons from weapons and armor.

## Usage 

As result, I was able to create logics in my mod where all the weapon/armor get random upgrades on spawn with random chance.
It makes looting more fun + there are situations with unique items where both upgrades from same group are activated.