### PR TITLE
xrGame: Fix undelegated constructor for `FractionState`

### DIFF
--- a/src/xrGame/ui/FractionState.cpp
+++ b/src/xrGame/ui/FractionState.cpp
@@ -34,8 +34,8 @@ FractionState::FractionState():
 }
 
 FractionState::FractionState( shared_str const& id )
+	: FractionState()
 {
-	FractionState();
 	set_fraction_id2( id );
 }
 


### PR DESCRIPTION
Previously we would only create a temporary object which would immediately be destroyed instead of calling the default constructor.