### PR TITLE
Add option to enable link-time-optimizations (LTO)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,10 +204,27 @@ string(REPLACE ";" " " SANITIZE_FLAGS "${SANITIZE_FLAGS}")
 
 message(STATUS "USE_ADDRESS_SANITIZER: ${USE_ADDRESS_SANITIZER}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS}")
+option(USE_LTO "Use Link Time Optimization" ${MASTER_GOLD})
+if (USE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT LTO_SUPPORTED)
+
+    if (LTO_SUPPORTED)
+        # With clang cmake only enables '-flto=thin' but we want full LTO
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            set(LTO_FLAGS "-flto=full")
+        else()
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+        endif()
+    endif()
+endif()
+
+message(STATUS "USE_LTO: ${USE_LTO}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZE_FLAGS} ${LTO_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZE_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZE_FLAGS}")
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${SANITIZE_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${SANITIZE_FLAGS} ${LTO_FLAGS}")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${SANITIZE_FLAGS} ${LTO_FLAGS}")
 
 set(LUA_LIBRARIES xrLuajit)
 


### PR DESCRIPTION
The option to enable LTO can be controlled with the `USE_LTO` option and defaults to true for master gold builds.

Here are some quick comparisons of build sizes.

gcc-13 without LTO
```
  240216 cximage.a
  922028 libGameSpy-oxr.a
  108906 libxrMiscMath.a
  209776 libxrQSlim.a
  744312 xrAICore.so
    7696 xrAPI.so
  326016 xrCDB.so
  715752 xrCore.so
 2421024 xrEngine.so
62433720 xrGame.so
  119114 xrGameSpy.a
 1788920 xrImGui.a
   13360 xrLCUtil.so
   91816 xrLuaFix.a
  200288 xrLuabind.so
  603632 xrLuajit.so
  112648 xrNetServer.so
  462824 xrODE.a
  282024 xrOPCODE.a
  213520 xrParticles.so
 1598100 xrPhysics.a
 3868192 xrRender_GL.so
  574800 xrScriptEngine.so
  203936 xrSound.so
 3023560 xrUICore.so
   13920 xr_3da
```

gcc-13 with LTO
```
  664330 cximage.a
 3044020 libGameSpy-oxr.a
  243626 libxrMiscMath.a
  864204 libxrQSlim.a
  559176 xrAICore.so
    7664 xrAPI.so
  287112 xrCDB.so
  684960 xrCore.so
 2296960 xrEngine.so
44586664 xrGame.so
  479566 xrGameSpy.a
 4171622 xrImGui.a
   13392 xrLCUtil.so
  248422 xrLuaFix.a
  173480 xrLuabind.so
  620768 xrLuajit.so
  103936 xrNetServer.so
 1251242 xrODE.a
  881210 xrOPCODE.a
  204568 xrParticles.so
 5107958 xrPhysics.a
 3621848 xrRender_GL.so
  511456 xrScriptEngine.so
  198304 xrSound.so
 2412224 xrUICore.so
   13736 xr_3da
```

clang-17 without LTO
```
  245132 cximage.a
  916508 libGameSpy-oxr.a
  118058 libxrMiscMath.a
  243736 libxrQSlim.a
  692336 xrAICore.so
    4272 xrAPI.so
  286448 xrCDB.so
  743000 xrCore.so
 2508680 xrEngine.so
59053256 xrGame.so
  126908 xrGameSpy.a
 2084626 xrImGui.a
   13848 xrLCUtil.so
  107080 xrLuaFix.a
  190088 xrLuabind.so
  644616 xrLuajit.so
  106544 xrNetServer.so
  435040 xrODE.a
  245354 xrOPCODE.a
  186592 xrParticles.so
 1524302 xrPhysics.a
 3829064 xrRender_GL.so
  496528 xrScriptEngine.so
  188968 xrSound.so
 2912528 xrUICore.so
   11272 xr_3da
```

clang-17 with LTO
```
  283528 cximage.a
  916508 libGameSpy-oxr.a
  104046 libxrMiscMath.a
  329336 libxrQSlim.a
  485120 xrAICore.so
    4232 xrAPI.so
  271744 xrCDB.so
  721184 xrCore.so
 2805920 xrEngine.so
50283368 xrGame.so
  160480 xrGameSpy.a
 2232442 xrImGui.a
   13608 xrLCUtil.so
  118168 xrLuaFix.a
  154352 xrLuabind.so
  644616 xrLuajit.so
  102568 xrNetServer.so
  617948 xrODE.a
  353926 xrOPCODE.a
  189216 xrParticles.so
 2246994 xrPhysics.a
 3805784 xrRender_GL.so
  419216 xrScriptEngine.so
  181960 xrSound.so
 2185240 xrUICore.so
   11120 xr_3da
```