### PR TITLE
xrCore: Fix null pointer dereference in `std::hash<shared_str>`

### DIFF
--- a/src/xrCore/xrstring.h
+++ b/src/xrCore/xrstring.h
@@ -198,7 +198,8 @@ struct std::hash<shared_str>
 {
     [[nodiscard]] size_t operator()(const shared_str& str) const noexcept
     {
-        return std::hash<pcstr>{}(str._get()->value);
+        const auto str_val = str._get();
+        return std::hash<pcstr>{}(str_val ? str_val->value : nullptr);
     }
 };
 


### PR DESCRIPTION
Caught with the undefined behavior sanitizer