### PR TITLE
xrCore: Fix undefined behavior passing `nullptr` to `dlclose` in `ModuleLookup::Close()`

### DIFF
--- a/src/xrCore/ModuleLookup.cpp
+++ b/src/xrCore/ModuleLookup.cpp
@@ -64,7 +64,7 @@ void* ModuleHandle::Open(pcstr moduleName)
 
 void ModuleHandle::Close()
 {
-    if (dontUnload)
+    if (dontUnload || !handle)
         return;
 
 #if defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_BSD)


### PR DESCRIPTION
It's undefined behavior to call `dlclose` with with null. But in the case of our handle being null we gladly don't have to do anything so we can just return.

UBSAN message:
```
/mnt/data/dev/xray-16/src/xrCore/ModuleLookup.cpp:71:12: runtime error: null pointer passed as argument 1, which is declared to never be null
```