### PR TITLE
Refactor `script_game_object` money functions to use u32

### DIFF
--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -369,8 +369,8 @@ public:
     void DropItemAndTeleport(CScriptGameObject* pItem, Fvector position);
     void ForEachInventoryItems(const luabind::functor<void>& functor);
     void TransferItem(CScriptGameObject* pItem, CScriptGameObject* pForWho);
-    void TransferMoney(int money, CScriptGameObject* pForWho);
-    void GiveMoney(int money);
+    void TransferMoney(u32 money, CScriptGameObject* pForWho);
+    void GiveMoney(u32 money);
     u32 Money();
     void MakeItemActive(CScriptGameObject* pItem);
 

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -486,7 +486,7 @@ void CScriptGameObject::TransferMoney(u32 money, CScriptGameObject* pForWho)
     CInventoryOwner* pOtherOwner = smart_cast<CInventoryOwner*>(&pForWho->object());
     VERIFY(pOtherOwner);
 
-    if (pOurOwner->get_money() - money < 0)
+    if (pOurOwner->get_money() < money)
     {
         GEnv.ScriptEngine->script_log(LuaMessageType::Error, "Character does not have enought money");
         return;

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -474,7 +474,7 @@ u32 CScriptGameObject::Money()
     return pOurOwner->get_money();
 }
 
-void CScriptGameObject::TransferMoney(int money, CScriptGameObject* pForWho)
+void CScriptGameObject::TransferMoney(u32 money, CScriptGameObject* pForWho)
 {
     if (!pForWho)
     {
@@ -496,7 +496,7 @@ void CScriptGameObject::TransferMoney(int money, CScriptGameObject* pForWho)
     pOtherOwner->set_money(pOtherOwner->get_money() + money, true);
 }
 
-void CScriptGameObject::GiveMoney(int money)
+void CScriptGameObject::GiveMoney(u32 money)
 {
     CInventoryOwner* pOurOwner = smart_cast<CInventoryOwner*>(&object());
     VERIFY(pOurOwner);

--- a/src/xrGame/script_game_object_inventory_owner.cpp
+++ b/src/xrGame/script_game_object_inventory_owner.cpp
@@ -488,7 +488,7 @@ void CScriptGameObject::TransferMoney(u32 money, CScriptGameObject* pForWho)
 
     if (pOurOwner->get_money() < money)
     {
-        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "Character does not have enought money");
+        GEnv.ScriptEngine->script_log(LuaMessageType::Error, "Character does not have enough money");
         return;
     }
 


### PR DESCRIPTION
Since `CInventoryOwner` already stored `money` as a `u32` it only makes since for us to also treat it like one.

Also fixed a logic bug which would have allowed the object to transfer money which it didn't have.

Since both values are unsigned subtracting them from another will never
produce a negative value.

This bug was also present before changing the function signature since the `money`
variable was implicitly converted to an `u32` resulting in the same problem.