### PR TITLE
GitHub Actions: Add workflow to check file encoding

### DIFF
--- a/.github/workflows/stylecheck.yml
+++ b/.github/workflows/stylecheck.yml
@@ -38,3 +38,31 @@ jobs:
             git diff --color=always --minimal
             exit 1
           fi
+
+  encoding:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install
+        run: sudo apt-get install dos2unix recode
+
+      - name: Fix encoding
+        run: |
+          # Ensure that files are UTF-8 encoded
+          find . \( -path ./Externals -o -path ./src/_CppDependOut -o -path ./sdk -o -path ./src/utils/mp_gpprof_server/libraries -o -path ./res \) -prune -o -iregex '.*\.\(h\|hpp\|inl\|c\|cpp\|yaml\|yml\|md\|txt\|cmake\|sh\)' -type f -exec bash -c 'recode UTF-8 "$0" 2> /dev/null' {} \;
+
+          # Ensure that files have LF line endings and do not contain a BOM
+          find . \( -path ./Externals -o -path ./src/_CppDependOut -o -path ./sdk -o -path ./src/utils/mp_gpprof_server/libraries -o -path ./res \) -prune -o -iregex '.*\.\(h\|hpp\|inl\|c\|cpp\|yaml\|yml\|md\|txt\|cmake\|sh\)' -type f -exec bash -c 'dos2unix "$0" 2> /dev/null' {} \;
+
+      - name: Report result
+        run: |
+          if [ -z "$(git status -s)" ]; then
+            echo Everything seems to be in order
+          else
+            echo Encoding problems found!
+            git diff --color=always --minimal
+            exit 1
+          fi


### PR DESCRIPTION
Part of #1474 

Glad to report that all source files in the repository are currently correctly encoded as utf-8 and don't contain windows encoding.

We workflow will ensure that no future files change this.