### PR TITLE
xrServerEntities: Initialize `freezed` member to `false`

### DIFF
--- a/src/xrServerEntities/xrServer_Objects_ALife.cpp
+++ b/src/xrServerEntities/xrServer_Objects_ALife.cpp
@@ -838,7 +838,7 @@ void CSE_ALifeLevelChanger::FillProps(LPCSTR pref, PropItemVec& items)
 // CSE_ALifeObjectPhysic
 ////////////////////////////////////////////////////////////////////////////
 CSE_ALifeObjectPhysic::CSE_ALifeObjectPhysic(LPCSTR caSection)
-    : CSE_ALifeDynamicObjectVisual(caSection), CSE_PHSkeleton(caSection)
+    : CSE_ALifeDynamicObjectVisual(caSection), CSE_PHSkeleton(caSection), freezed{false}
 {
     type = epotSkeleton;
     mass = 10.f;


### PR DESCRIPTION
The uninitialized value would be loaded on line [1029](https://github.com/OpenXRay/xray-16/blob/dev/src/xrServerEntities/xrServer_Objects_ALife.cpp#L1029) inside `UPDATE_Read` resulting in undefined behavior and a non deterministic value assigned to `prev_freezed`.