### PR TITLE
xrPhysics: Initialize `was_control` to `false` in `CPHSimpleCharacter`

### DIFF
--- a/src/xrPhysics/PHSimpleCharacter.cpp
+++ b/src/xrPhysics/PHSimpleCharacter.cpp
@@ -156,6 +156,7 @@ CPHSimpleCharacter::CPHSimpleCharacter()
     is_contact = false;
     was_contact = false;
     is_control = false;
+    was_control = false;
     b_depart = false;
     b_meet = false;
     b_lose_control = true;


### PR DESCRIPTION
This would previously lead to an the uninitialized value begin used to set `b_stop_control` on line [642](https://github.com/OpenXRay/xray-16/blob/dev/src/xrPhysics/PHSimpleCharacter.cpp#L642) in `CPHSimpleCharacter::PhTune`