### PR TITLE
xrGame: Early return in `obstacles_query::set_intersection` if obstacles is empty

### DIFF
--- a/src/xrGame/obstacles_query.cpp
+++ b/src/xrGame/obstacles_query.cpp
@@ -15,6 +15,9 @@
 
 void obstacles_query::set_intersection(const obstacles_query& query)
 {
+    if (m_obstacles.empty())
+        return;
+
     // XXX: probably replace xr_alloca
     const u32 n = m_obstacles.size();
     const u32 buffer_size = n * sizeof(OBSTACLES::value_type);


### PR DESCRIPTION
Also fixes undefined behavior since in that case we would reference a nullptr.