### PR TITLE
Fix `Wunused-variable` warnings (#713)

### DIFF
--- a/src/utils/xrQSlim/MxQSlim.cpp
+++ b/src/utils/xrQSlim/MxQSlim.cpp
@@ -298,7 +298,6 @@ void MxEdgeQSlim::apply_mesh_penalties(MxQSlimEdge* info)
     if (nfailed)
         bias += nfailed * meshing_penalty;
 
-    static u32 a = 0;
     //	if (a)
     {
         double Nmin1 = check_local_inversion(info->v1, info->v2, info->vnew);
@@ -481,7 +480,7 @@ void MxEdgeQSlim::update_pre_contract(const MxPairContraction& conx)
         if (u == v1 || varray_find(star, u))
         {
             // This is a useless link --- kill it
-            bool found = varray_find(edge_links(u), e, &j);
+            [[maybe_unused]] bool found = varray_find(edge_links(u), e, &j);
             VERIFY(found);
             edge_links(u).remove(j);
             heap.remove(e);

--- a/src/utils/xrQSlim/MxStdModel.cpp
+++ b/src/utils/xrQSlim/MxStdModel.cpp
@@ -48,8 +48,7 @@ MxVertexID MxStdModel::alloc_vertex(float x, float y, float z)
     vertex_mark_valid(id);
 
     face_links.add(xr_new<MxFaceList>());
-    unsigned int l = face_links.last_id();
-    VERIFY(l == id);
+    VERIFY(face_links.last_id() == id);
     VERIFY(neighbors(id).length() == 0);
 
     return id;
@@ -560,7 +559,7 @@ void MxStdModel::apply_expansion(const MxPairExpansion& conx)
         MxFaceID fid = conx.delta_faces(i);
         face(fid).remap_vertex(v1, v2);
         neighbors(v2).add(fid);
-        bool found = varray_find(neighbors(v1), fid, &j);
+        [[maybe_unused]] bool found = varray_find(neighbors(v1), fid, &j);
         VERIFY(found);
         neighbors(v1).remove(j);
     }

--- a/src/xrAICore/Navigation/PatrolPath/patrol_path_storage.cpp
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_path_storage.cpp
@@ -31,8 +31,7 @@ void CPatrolPathStorage::load_raw(
 
         shared_str patrol_name;
         sub_chunk->r_stringZ(patrol_name);
-        const_iterator I = m_registry.find(patrol_name);
-        VERIFY3(I == m_registry.end(), "Duplicated patrol path found", *patrol_name);
+        VERIFY3(m_registry.find(patrol_name) == m_registry.end(), "Duplicated patrol path found", *patrol_name);
         m_registry.emplace(
             patrol_name, &(xr_new<CPatrolPath>(patrol_name))->load_raw(level_graph, cross, game_graph, *sub_chunk)
 		);

--- a/src/xrAICore/Navigation/graph_vertex_inline.h
+++ b/src/xrAICore/Navigation/graph_vertex_inline.h
@@ -65,8 +65,7 @@ IC typename _graph_type::CEdge* CSGraphVertex::edge(const _vertex_id_type& verte
 TEMPLATE_SPECIALIZATION
 IC void CSGraphVertex::add_edge(CGraphVertex* vertex, const typename _graph_type::CEdge::edge_weight_type& edge_weight)
 {
-    typename EDGES::iterator I = std::find(m_edges.begin(), m_edges.end(), vertex->vertex_id());
-    VERIFY(m_edges.end() == I);
+    VERIFY(m_edges.end() == std::find(m_edges.begin(), m_edges.end(), vertex->vertex_id()));
     vertex->on_edge_addition(this);
     m_edges.push_back(typename _graph_type::CEdge(edge_weight, vertex));
     ++*m_edge_count;
@@ -86,8 +85,7 @@ IC void CSGraphVertex::remove_edge(const _vertex_id_type& vertex_id)
 TEMPLATE_SPECIALIZATION
 IC void CSGraphVertex::on_edge_addition(CGraphVertex* vertex)
 {
-    typename VERTICES::const_iterator I = std::find(m_vertices.begin(), m_vertices.end(), vertex);
-    VERIFY(I == m_vertices.end());
+    VERIFY(std::find(m_vertices.begin(), m_vertices.end(), vertex) == m_vertices.end());
     m_vertices.push_back(vertex);
 }
 

--- a/src/xrEngine/Rain.cpp
+++ b/src/xrEngine/Rain.cpp
@@ -14,13 +14,13 @@
 #endif
 
 // Warning: duplicated in dxRainRender
-static const int max_desired_items = 2500;
-static const float source_radius = 12.5f;
+//static const int max_desired_items = 2500;
+//static const float source_radius = 12.5f;
 static const float source_offset = 40.f;
 static const float max_distance = source_offset * 1.25f;
-static const float sink_offset = -(max_distance - source_offset);
-static const float drop_length = 5.f;
-static const float drop_width = 0.30f;
+//static const float sink_offset = -(max_distance - source_offset);
+//static const float drop_length = 5.f;
+//static const float drop_width = 0.30f;
 static const float drop_angle = 3.0f;
 static const float drop_max_angle = deg2rad(10.f);
 static const float drop_max_wind_vel = 20.0f;
@@ -28,7 +28,7 @@ static const float drop_speed_min = 40.f;
 static const float drop_speed_max = 80.f;
 
 const int max_particles = 1000;
-const int particles_cache = 400;
+//const int particles_cache = 400;
 const float particles_time = .3f;
 
 //////////////////////////////////////////////////////////////////////

--- a/src/xrEngine/XR_IOConsole.cpp
+++ b/src/xrEngine/XR_IOConsole.cpp
@@ -14,9 +14,8 @@
 #include "GameFont.h"
 
 #include "Include/xrRender/UIRender.h"
+#include "xrUICore/ui_defs.h"
 
-static float const UI_BASE_WIDTH = 1024.0f;
-static float const UI_BASE_HEIGHT = 768.0f;
 static float const LDIST = 0.05f;
 static u32 const cmd_history_max = 64;
 

--- a/src/xrEngine/xrSheduler.cpp
+++ b/src/xrEngine/xrSheduler.cpp
@@ -319,7 +319,10 @@ void CSheduler::ProcessStep()
 {
     // Normal priority
     const u32 dwTime = Device.dwTimeGlobal;
+
+#ifdef DEBUG
     CTimer eTimer;
+#endif
 
     for (int i = 0; !Items.empty() && Top().dwTimeForExecute < dwTime; ++i)
     {

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -75,9 +75,9 @@
 #include "ui/UIDragDropReferenceList.h"
 #include "xrCore/xr_token.h"
 
-const u32 patch_frames = 50;
-const float respawn_delay = 1.f;
-const float respawn_auto = 7.f;
+//const u32 patch_frames = 50;
+//const float respawn_delay = 1.f;
+//const float respawn_auto = 7.f;
 
 constexpr float default_feedback_duration = 0.2f;
 

--- a/src/xrGame/ActorAnimation.cpp
+++ b/src/xrGame/ActorAnimation.cpp
@@ -316,10 +316,11 @@ CMotion* FindMotionKeys(MotionID motion_ID, IRenderVisual* V)
 
 #ifdef DEBUG
 BOOL g_ShowAnimationInfo = FALSE;
-#endif // DEBUG
 constexpr pcstr mov_state[] = {
     "idle", "walk", "run", "sprint",
 };
+#endif // DEBUG
+
 void CActor::g_SetAnimation(u32 mstate_rl)
 {
     if (!g_Alive())

--- a/src/xrGame/ContextMenu.cpp
+++ b/src/xrGame/ContextMenu.cpp
@@ -2,7 +2,7 @@
 #include "ContextMenu.h"
 #include "../xrEngine/GameFont.h"
 
-const float fade_speed = 8.0f;
+//const float fade_speed = 8.0f;
 
 CContextMenu::~CContextMenu()
 {

--- a/src/xrGame/LevelGraphDebugRender.cpp
+++ b/src/xrGame/LevelGraphDebugRender.cpp
@@ -368,11 +368,12 @@ void LevelGraphDebugRender::DrawGameGraph()
     IGameObject* entity = Level().CurrentEntity();
     if (!entity)
         return;
+
+// draw back plane
+#if 0 // XXX: disabled in original, reenable?
     const Fmatrix& xform = entity->XFORM();
     Fvector center = {0.f, 5.f, 0.f};
     Fvector bounds = {3.f, 0.f, 3.f};
-// draw back plane
-#if 0 // XXX: disabled in original, reenable?
     Fvector vertices[4];
     xform.transform_tiny(vertices[0], {center.x-bounds.x, center.y+bounds.y, center.z+bounds.z});
     xform.transform_tiny(vertices[1], {center.x+bounds.x, center.y+bounds.y, center.z+bounds.z});

--- a/src/xrGame/Level_input.cpp
+++ b/src/xrGame/Level_input.cpp
@@ -385,7 +385,7 @@ void CLevel::IR_OnKeyboardPress(int key)
     // Lain: added
     case SDL_SCANCODE_F5:
     {
-        if (CBaseMonster* pBM = smart_cast<CBaseMonster*>(CurrentEntity()))
+        if (smart_cast<CBaseMonster*>(CurrentEntity()))
         {
             DBG().log_debug_info();
         }
@@ -483,7 +483,7 @@ void CLevel::IR_OnKeyboardHold(int key)
         static u32 time = Device.dwTimeGlobal;
         if (Device.dwTimeGlobal - time > 20)
         {
-            if (CBaseMonster* pBM = smart_cast<CBaseMonster*>(CurrentEntity()))
+            if (smart_cast<CBaseMonster*>(CurrentEntity()))
             {
                 DBG().debug_info_up();
                 time = Device.dwTimeGlobal;
@@ -495,7 +495,7 @@ void CLevel::IR_OnKeyboardHold(int key)
         static u32 time = Device.dwTimeGlobal;
         if (Device.dwTimeGlobal - time > 20)
         {
-            if (CBaseMonster* pBM = smart_cast<CBaseMonster*>(CurrentEntity()))
+            if (smart_cast<CBaseMonster*>(CurrentEntity()))
             {
                 DBG().debug_info_down();
                 time = Device.dwTimeGlobal;

--- a/src/xrGame/Level_network.cpp
+++ b/src/xrGame/Level_network.cpp
@@ -344,7 +344,7 @@ const int ConnectionTimeOut = 60000; // 1 min
 
 bool CLevel::Connect2Server(const char* options)
 {
-    NET_Packet P;
+    //NET_Packet P;
     m_bConnectResultReceived = false;
     m_bConnectResult = true;
 

--- a/src/xrGame/MainMenu.cpp
+++ b/src/xrGame/MainMenu.cpp
@@ -44,6 +44,7 @@ extern ENGINE_API bool bShowPauseString;
 
 //#define DEMO_BUILD
 
+#ifdef XR_PLATFORM_WINDOWS
 constexpr cpcstr ErrMsgBoxTemplate[] =
 {
     "message_box_invalid_pass",
@@ -65,6 +66,7 @@ constexpr cpcstr ErrMsgBoxTemplate[] =
     "msg_box_error_loading",
     "message_box_download_level"
 };
+#endif
 
 extern bool b_shniaganeed_pp;
 

--- a/src/xrGame/PHMovementControl.cpp
+++ b/src/xrGame/PHMovementControl.cpp
@@ -36,7 +36,7 @@
 #define def_Y_SIZE_2 0.8f
 #define def_Z_SIZE_2 0.35f
 
-const u64 after_creation_collision_hit_block_steps_number = 100;
+//const u64 after_creation_collision_hit_block_steps_number = 100;
 
 CPHMovementControl::CPHMovementControl(IGameObject* parent)
 {

--- a/src/xrGame/Tracer.cpp
+++ b/src/xrGame/Tracer.cpp
@@ -6,8 +6,8 @@
 #include "Include/xrRender/UIRender.h"
 #include "xrCore/_fbox2.h"
 
-const u32 MAX_TRACERS = (1024 * 5);
-const float TRACER_SIZE = 0.13f;
+//const u32 MAX_TRACERS = (1024 * 5);
+//const float TRACER_SIZE = 0.13f;
 
 CTracer::CTracer()
 {

--- a/src/xrGame/UIDialogHolder.cpp
+++ b/src/xrGame/UIDialogHolder.cpp
@@ -529,7 +529,8 @@ bool CDialogHolder::IR_UIOnControllerHold(int dik, float x, float y)
 
 bool CDialogHolder::FillDebugTree(const CUIDebugState& debugState)
 {
-    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_OpenOnArrow;
+    // XXX: Was this meant to be used somewhere here? Because currently its unused and could also be constexpr
+    //ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnDoubleClick | ImGuiTreeNodeFlags_OpenOnArrow;
 
     if (m_input_receivers.empty())
         ImGui::BulletText("Input receivers: 0");

--- a/src/xrGame/ai/monsters/anim_triple.cpp
+++ b/src/xrGame/ai/monsters/anim_triple.cpp
@@ -2,7 +2,7 @@
 #include "anim_triple.h"
 #include "control_manager.h"
 
-constexpr pcstr dbg_states[] = { "eStatePrepare", "eStateExecute", "eStateFinalize", "eStateNone" };
+//constexpr pcstr dbg_states[] = { "eStatePrepare", "eStateExecute", "eStateFinalize", "eStateNone" };
 
 void CAnimationTriple::reset_data() { m_data.capture_type = 0; }
 void CAnimationTriple::on_capture()

--- a/src/xrGame/ai/monsters/bloodsucker/bloodsucker.cpp
+++ b/src/xrGame/ai/monsters/bloodsucker/bloodsucker.cpp
@@ -26,10 +26,10 @@ namespace detail::bloodsucker
 {
 // default hit settings
 float const default_critical_hit_chance = 0.25f;
-float const default_hit_camera_effector_angle = 0;
-float const default_critical_hit_camera_effector_angle = 3.1415f / 6;
+//float const default_hit_camera_effector_angle = 0;
+//float const default_critical_hit_camera_effector_angle = 3.1415f / 6;
 
-float const default_camera_effector_move_angular_speed = 1.5f;
+//float const default_camera_effector_move_angular_speed = 1.5f;
 u32 const default_visibility_state_change_min_delay = 1000;
 
 float const default_full_visibility_radius = 5;

--- a/src/xrGame/ai/monsters/control_animation_base_update.cpp
+++ b/src/xrGame/ai/monsters/control_animation_base_update.cpp
@@ -10,6 +10,7 @@
 #include "ai/monsters/control_path_builder_base.h"
 
 // DEBUG purpose only
+#if 0
 constexpr pcstr dbg_anim_name_table[] = {"eAnimStandIdle", "eAnimStandTurnLeft", "eAnimStandTurnRight",
 
     "eAnimSitIdle", "eAnimLieIdle",
@@ -52,6 +53,7 @@ constexpr pcstr dbg_anim_name_table[] = {"eAnimStandIdle", "eAnimStandTurnLeft",
     "eAnimTeleRaise", "eAnimTeleFire", "eAnimGraviPrepare", "eAnimGraviFire",
 
     "eAnimCount", "eAnimUndefined"};
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // m_tAction processing

--- a/src/xrGame/ai/stalker/ai_stalker_debug.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_debug.cpp
@@ -1129,8 +1129,6 @@ void CAI_Stalker::dbg_draw_visibility_rays()
 
 xr_vector<Fmatrix> g_stalker_skeleton;
 
-static Fvector s_spine_bone;
-
 static Fmatrix aim_on_actor(Fvector const& bone_position, Fvector const& weapon_position,
     Fvector const& weapon_direction, Fvector const& target, bool const& debug_draw)
 {

--- a/src/xrGame/ai/stalker/ai_stalker_fire.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker_fire.cpp
@@ -62,7 +62,7 @@ static float const FLOOR_DISTANCE = 2.f;
 static float const NEAR_DISTANCE = 2.5f;
 static u32 const FIRE_MAKE_SENSE_INTERVAL = 10000;
 
-static float const min_throw_distance = 10.f;
+//static float const min_throw_distance = 10.f;
 
 float CAI_Stalker::GetWeaponAccuracy() const
 {

--- a/src/xrGame/ik/IKLimb.cpp
+++ b/src/xrGame/ik/IKLimb.cpp
@@ -19,22 +19,22 @@ int ik_blend_free_foot = 1;
 int ik_local_blending = 0;
 int ik_collide_blend = 0;
 
-const Matrix Midentity = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}; //. in XGlobal
+//const Matrix Midentity = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}; //. in XGlobal
 
-const Matrix IKLocalJoint = {0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1}; //. in XGlobal
-const Fmatrix XLocalJoint = {0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+//const Matrix IKLocalJoint = {0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1}; //. in XGlobal
+//const Fmatrix XLocalJoint = {0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
 const Fmatrix xm2im = {0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
 
-const Fvector xgproj_axis = {0, 1, 0};
-const Fvector xgpos_axis = {0, 0, 1};
+//const Fvector xgproj_axis = {0, 1, 0};
+//const Fvector xgpos_axis = {0, 0, 1};
 
-const Fvector xlproj_axis = {1, 0, 0};
-const Fvector xlpos_axis = {0, 0, 1};
+//const Fvector xlproj_axis = {1, 0, 0};
+//const Fvector xlpos_axis = {0, 0, 1};
 typedef float IVektor[3];
 
-const IVektor lproj_vector = {0, 0, 1};
-const IVektor lpos_vector = {-1, 0, 0};
+//const IVektor lproj_vector = {0, 0, 1};
+//const IVektor lpos_vector = {-1, 0, 0};
 
 const IVektor gproj_vector = {0, 0, 1}; //. in XGlobal
 const IVektor gpos_vector = {1, 0, 0};
@@ -845,7 +845,7 @@ void CIKLimb::ToeTimeDiff(Fvector& v, const SCalculateData& cd) const
 
 void CIKLimb::ToeTimeDiffPredict(Fvector& v) const { v.set(0, -1, 0); }
 static const float pick_dir_mix_in_factor = 0.01f;
-static const float pick_dir_mix_in_doun_factor = 0.01f;
+//static const float pick_dir_mix_in_doun_factor = 0.01f;
 void pick_dir_update(Fvector& v, const Fvector& previous_dir, const Fvector& new_dir)
 {
     Fvector dir = new_dir;

--- a/src/xrGame/movement_manager.cpp
+++ b/src/xrGame/movement_manager.cpp
@@ -30,7 +30,9 @@
 
 using namespace MovementManager;
 
+#ifdef USE_FREE_IN_RESTRICTIONS
 const float verify_distance = 15.f;
+#endif
 
 CMovementManager::CMovementManager(CCustomMonster* object)
 {

--- a/src/xrGame/profile_store.cpp
+++ b/src/xrGame/profile_store.cpp
@@ -256,11 +256,13 @@ void profile_store::onlylog_completion(bool const result, char const* err_descr)
     Msg("* Profile loading successfully complete");
 }
 
+#ifdef XR_PLATFORM_WINDOWS
 #ifdef DEBUG
 static u32 const actuality_update_time = 120;
 #else
 static u32 const actuality_update_time = 3600;
 #endif //#ifdef DEBUG
+#endif //#ifdef XR_PLATFORM_WINDOWS
 
 void profile_store::check_sake_actuality()
 {

--- a/src/xrGame/space_restriction.cpp
+++ b/src/xrGame/space_restriction.cpp
@@ -16,7 +16,7 @@
 #include "xrCore/xrDebug_macros.h"
 #include "xrCore/buffer_vector.h"
 
-const float dependent_distance = 100.f;
+//const float dependent_distance = 100.f;
 
 template <bool a>
 struct CMergeInOutPredicate

--- a/src/xrGame/stalker_animation_legs.cpp
+++ b/src/xrGame/stalker_animation_legs.cpp
@@ -21,7 +21,6 @@
 const float right_forward_angle = PI_DIV_4;
 const float left_forward_angle = PI_DIV_4;
 // const float standing_turn_angle			= PI_DIV_6;
-const float epsilon = EPS_L;
 
 const u32 direction_switch_interval = 500;
 

--- a/src/xrGame/ui/UIMap.cpp
+++ b/src/xrGame/ui/UIMap.cpp
@@ -8,9 +8,9 @@
 #include "xrEngine/xr_input.h" //remove me !!!
 #include "xrCore/_fbox2.h"
 
-const u32 activeLocalMapColor = 0xffffffff; // 0xffc80000;
-const u32 inactiveLocalMapColor = 0xffffffff; // 0xff438cd1;
-const u32 ourLevelMapColor = 0xffffffff;
+//const u32 activeLocalMapColor = 0xffffffff; // 0xffc80000;
+//const u32 inactiveLocalMapColor = 0xffffffff; // 0xff438cd1;
+//const u32 ourLevelMapColor = 0xffffffff;
 
 CUICustomMap::CUICustomMap() : CUIStatic("Custom Map")
 {

--- a/src/xrNetServer/empty/NET_Client.cpp
+++ b/src/xrNetServer/empty/NET_Client.cpp
@@ -35,7 +35,7 @@ INetQueue::~INetQueue()
     xr_delete(pcs);
 }
 
-static u32 LastTimeCreate = 0;
+//static u32 LastTimeCreate = 0;
 
 NET_Packet* INetQueue::Create()
 {
@@ -103,7 +103,7 @@ void INetQueue::Release()
     VERIFY(!ready.empty());
     //---------------------------------------------
     // u32 tmp_time = SDL_GetTicks() - 60000;
-    u32 size = unused.size();
+    //u32 size = unused.size();
     ready.front()->B.count = 0;
     /*
    * if ((LastTimeCreate < tmp_time) && (size > 32))
@@ -128,7 +128,7 @@ void INetQueue::UnlockQ()
 }
 
 const u32 syncQueueSize = 512;
-const int syncSamples = 256;
+//const int syncSamples = 256;
 
 class XRNETSERVER_API syncQueue {
     u32 table[syncQueueSize];
@@ -330,8 +330,6 @@ bool IPureClient::Connect(pcstr options)
         net_Disconnected = false;
 
         //---------------------------
-        string1024 tmp = "";
-//---------------------------
 
         bool bSimulator = false;
         if (strstr(Core.Params, "-netsim"))
@@ -382,7 +380,6 @@ bool IPureClient::Connect(pcstr options)
             string64 EnumData;
             EnumData[0] = 0;
             xr_strcat(EnumData, "ToConnect");
-            u32 EnumSize = xr_strlen(EnumData) + 1;
             // We now have the host address so lets enum
             u32 c_port = psCL_Port;
             HRESULT res = S_FALSE;
@@ -402,9 +399,9 @@ bool IPureClient::Connect(pcstr options)
                 return false;
             }
 
-            WCHAR SessionPasswordUNICODE[4096];
-            if (xr_strlen(password_str)) {
-            }
+            //WCHAR SessionPasswordUNICODE[4096];
+            //if (xr_strlen(password_str)) {
+            //}
 
             net_csEnumeration->Enter();
             // real connect
@@ -438,9 +435,14 @@ void IPureClient::Disconnect()
 {
     // Clean up Host _list_
     net_csEnumeration->Enter();
+
+    // XXX: Were we supposed to do something here? Because this code currently does absolutely nothing
+    #if 0
     for (u32 i = 0; i < net_Hosts.size(); i++) {
         HOST_NODE& N = net_Hosts[i];
     }
+    #endif
+
     net_Hosts.clear();
     net_csEnumeration->Leave();
 

--- a/src/xrNetServer/empty/NET_Server.cpp
+++ b/src/xrNetServer/empty/NET_Server.cpp
@@ -49,7 +49,8 @@ void IBannedClient::Load(CInifile& ini, const shared_str& sect)
 
     tm _tm_banned;
     const shared_str& time_to = ini.r_string(sect, "time_to");
-    int res_t = sscanf(time_to.c_str(), "%02d.%02d.%d_%02d:%02d:%02d", &_tm_banned.tm_mday, &_tm_banned.tm_mon,
+
+    [[maybe_unused]] int res_t = sscanf(time_to.c_str(), "%02d.%02d.%d_%02d:%02d:%02d", &_tm_banned.tm_mday, &_tm_banned.tm_mon,
         &_tm_banned.tm_year, &_tm_banned.tm_hour, &_tm_banned.tm_min, &_tm_banned.tm_sec);
     VERIFY(res_t == 6);
 
@@ -286,10 +287,7 @@ IPureServer::EConnect IPureServer::Connect(pcstr options, GameDescriptionData& g
     //-------------------------------------------------------------------
 
     if (!psNET_direct_connect) {
-//---------------------------
-#ifdef DEBUG
-        string1024 tmp;
-#endif // DEBUG
+    //---------------------------
 
         bool bSimulator = false;
         if (strstr(Core.Params, "-netsim"))

--- a/src/xrPhysics/ElevatorState.cpp
+++ b/src/xrPhysics/ElevatorState.cpp
@@ -10,8 +10,8 @@
 #include "debug_output.h"
 #endif
 static const float getting_on_dist = 0.3f;
-static const float getting_out_dist = 0.4f;
-static const float start_climbing_dist = 0.f;
+//static const float getting_out_dist = 0.4f;
+//static const float start_climbing_dist = 0.f;
 static const float stop_climbing_dist = 0.1f;
 static const float out_dist = 1.5f;
 

--- a/src/xrPhysics/PHElement.cpp
+++ b/src/xrPhysics/PHElement.cpp
@@ -468,8 +468,7 @@ void CPHElement::PhDataUpdate(dReal step)
         angular_velocity_mag = _sqrt(angular_velocity_smag);
     }
     ////////////////secure position///////////////////////////////////////////////////////////////////////////////////
-    const dReal* position = dBodyGetPosition(m_body);
-    VERIFY(dV_valid(position));
+    VERIFY(dV_valid(dBodyGetPosition(m_body)));
     /////////////////limit & secure angular
     /// vel///////////////////////////////////////////////////////////////////////////////
     VERIFY(dV_valid(angular_velocity));

--- a/src/xrPhysics/PHShellSplitter.cpp
+++ b/src/xrPhysics/PHShellSplitter.cpp
@@ -401,11 +401,14 @@ void CPHShellSplitterHolder::SplitElement(u16 aspl, PHSHELL_PAIR_VECTOR& out_she
     for (; i != e; ++i)
     {
         out_shels.push_back(ElementSingleSplit(*i, E));
+
+#ifdef DEBUG
         CPhysicsElement* ee = out_shels.back().first->get_ElementByStoreOrder(0);
         VERIFY(ee);
         VERIFY(smart_cast<CPHElement*>(ee));
         CPHElement* e2 = static_cast<CPHElement*>(ee);
         VERIFY(dBodyStateValide(e2->get_body()));
+#endif
     }
 
     if (!E->FracturesHolder())

--- a/src/xrPhysics/PHSimpleCharacter.cpp
+++ b/src/xrPhysics/PHSimpleCharacter.cpp
@@ -30,7 +30,7 @@
 
 const float LOSE_CONTROL_DISTANCE = 0.5f; // fly distance to lose control
 const float CLAMB_DISTANCE = 0.5f;
-const float CLIMB_GETUP_HEIGHT = 0.3f;
+//const float CLIMB_GETUP_HEIGHT = 0.3f;
 
 float IC sgn(float v) { return v < 0.f ? -1.f : 1.f; }
 bool test_sides(const Fvector& center, const Fvector& side_dir, const Fvector& fv_dir, const Fvector& box, int tri_id)
@@ -808,7 +808,7 @@ void CPHSimpleCharacter::PhTune(dReal step)
 
 const float CHWON_ACCLEL_SHIFT = 0.4f;
 const float CHWON_AABB_FACTOR = 1.f;
-const float CHWON_ANG_COS = M_SQRT1_2;
+//const float CHWON_ANG_COS = M_SQRT1_2;
 const float CHWON_CALL_UP_SHIFT = 0.05f;
 const float CHWON_CALL_FB_HIGHT = 1.5f;
 const float CHWON_AABB_FB_FACTOR = 1.f;
@@ -1874,8 +1874,10 @@ void CPHSimpleCharacter::TestRestrictorContactCallbackFun(
     CPHActorCharacter* actor_character = (static_cast<CPHCharacter*>(obj_data->ph_object))->CastActorCharacter();
     if (!actor_character)
         return;
-    CPHSimpleCharacter* ch_this = static_cast<CPHSimpleCharacter*>(retrieveGeomUserData(g_this)->ph_object);
+
+    [[maybe_unused]] CPHSimpleCharacter* ch_this = static_cast<CPHSimpleCharacter*>(retrieveGeomUserData(g_this)->ph_object);
     VERIFY(ch_this);
+
     save_max(restrictor_depth, c.geom.depth);
     do_colide = true;
     c.surface.mu = 0.f;

--- a/src/xrPhysics/PhysicsShell.cpp
+++ b/src/xrPhysics/PhysicsShell.cpp
@@ -290,7 +290,7 @@ void phys_shell_verify_object_model(IPhysicsShellHolder& O)
 
     // IKinematics		*K = V->dcast_PKinematics();
 
-    IKinematics* K = O.ObjectKinematics();
+    [[maybe_unused]] IKinematics* K = O.ObjectKinematics();
 
     VERIFY2(K, make_string("Can not create physics shell for object %s, model %s is not skeleton", O.ObjectName(),
                    O.ObjectNameVisual()));

--- a/src/xrPhysics/PhysicsShellAnimator.cpp
+++ b/src/xrPhysics/PhysicsShellAnimator.cpp
@@ -46,7 +46,8 @@ CPhysicsShellAnimator::~CPhysicsShellAnimator()
 }
 void CPhysicsShellAnimator::CreateJoints(LPCSTR controled)
 {
-    IPhysicsShellHolder* obj = (*(m_pPhysicsShell->Elements().begin()))->PhysicsRefObject();
+    [[maybe_unused]] IPhysicsShellHolder* obj = (*(m_pPhysicsShell->Elements().begin()))->PhysicsRefObject();
+
     const u16 nb = (u16)_GetItemCount(controled);
     for (u16 i = 0; nb > i; ++i)
     {

--- a/src/xrScriptEngine/script_engine.cpp
+++ b/src/xrScriptEngine/script_engine.cpp
@@ -431,7 +431,8 @@ bool CScriptEngine::load_file_into_namespace(LPCSTR caScriptName, LPCSTR caNames
 
 bool CScriptEngine::namespace_loaded(LPCSTR name, bool remove_from_stack)
 {
-    int start = lua_gettop(lua());
+    [[maybe_unused]] int start = lua_gettop(lua());
+
     lua_pushstring(lua(), GlobalNamespace);
     lua_rawget(lua(), LUA_GLOBALSINDEX);
     string256 S2 = { 0 };
@@ -487,7 +488,8 @@ bool CScriptEngine::namespace_loaded(LPCSTR name, bool remove_from_stack)
 
 bool CScriptEngine::object(LPCSTR identifier, int type)
 {
-    int start = lua_gettop(lua());
+    [[maybe_unused]] int start = lua_gettop(lua());
+
     lua_pushnil(lua());
     while (lua_next(lua(), -2))
     {
@@ -508,7 +510,8 @@ bool CScriptEngine::object(LPCSTR identifier, int type)
 
 bool CScriptEngine::object(LPCSTR namespace_name, LPCSTR identifier, int type)
 {
-    int start = lua_gettop(lua());
+    [[maybe_unused]] int start = lua_gettop(lua());
+
     if (xr_strlen(namespace_name) && !namespace_loaded(namespace_name, false))
     {
         VERIFY(lua_gettop(lua()) == start);
@@ -616,8 +619,8 @@ bool CScriptEngine::print_output(lua_State* L, pcstr caScriptFileName, int error
 
 void CScriptEngine::print_error(lua_State* L, int iErrorCode)
 {
-    CScriptEngine* scriptEngine = GetInstance(L);
-    VERIFY(scriptEngine);
+    VERIFY(GetInstance(L));
+
     switch (iErrorCode)
     {
     case LUA_ERRRUN:
@@ -657,8 +660,10 @@ void CScriptEngine::flush_log()
 #include "LuaStudio/LuaStudio.hpp"
 typedef cs::lua_studio::create_world_function_type create_world_function_type;
 typedef cs::lua_studio::destroy_world_function_type destroy_world_function_type;
+#ifdef XR_PLATFORM_WINDOWS
 static create_world_function_type s_create_world = nullptr;
 static destroy_world_function_type s_destroy_world = nullptr;
+#endif
 static LogCallback s_old_log_callback = nullptr;
 #endif
 #endif
@@ -1243,7 +1248,7 @@ void CScriptEngine::collect_all_garbage()
 
 void CScriptEngine::on_error(lua_State* state)
 {
-    CScriptEngine* scriptEngine = GetInstance(state);
+    [[maybe_unused]] CScriptEngine* scriptEngine = GetInstance(state);
     VERIFY(scriptEngine);
 #if defined(USE_DEBUGGER) && defined(USE_LUA_STUDIO)
     if (!scriptEngine->debugger())

--- a/src/xrScriptEngine/script_lua_helper.cpp
+++ b/src/xrScriptEngine/script_lua_helper.cpp
@@ -169,7 +169,7 @@ int CDbgLuaHelper::hookLuaBind(lua_State* l)
     if (!m_pThis)
         return LUA_OK; // XXX: Is it correct to return LUA_OK?
     L = l;
-    int top1 = lua_gettop(L);
+    [[maybe_unused]] int top1 = lua_gettop(L);
     Msg("hookLuaBind start");
     print_stack(L);
     if (lua_isstring(L, -1))
@@ -183,7 +183,7 @@ int CDbgLuaHelper::hookLuaBind(lua_State* l)
     print_stack(L);
     if (lua_isstring(L, -1))
         Msg("Tope string %s", lua_tostring(L, -1));
-    int top2 = lua_gettop(L);
+    [[maybe_unused]] int top2 = lua_gettop(L);
     VERIFY(top2 == top1);
     return LUA_OK; // XXX: Probably, we should show message asking what value we should return.
 }
@@ -193,7 +193,8 @@ void CDbgLuaHelper::hookLua(lua_State* l, lua_Debug* ar)
     if (!m_pThis)
         return;
     L = l;
-    int top1 = lua_gettop(L);
+
+    [[maybe_unused]] int top1 = lua_gettop(L);
     // Msg("hookLua start");
     // print_stack(L);
     switch (ar->event)
@@ -205,7 +206,7 @@ void CDbgLuaHelper::hookLua(lua_State* l, lua_Debug* ar)
     }
     // Msg("hookLua end");
     // print_stack(L);
-    int top2 = lua_gettop(L);
+    [[maybe_unused]] int top2 = lua_gettop(L);
     VERIFY(top2 == top1);
 }
 

--- a/src/xrSound/OpenALDeviceList.cpp
+++ b/src/xrSound/OpenALDeviceList.cpp
@@ -29,8 +29,10 @@
 #include <al.h>
 #include <alc.h>
 
+#ifdef XR_PLATFORM_WINDOWS
 constexpr pcstr AL_GENERIC_HARDWARE = "Generic Hardware";
 constexpr pcstr AL_GENERIC_SOFTWARE = "Generic Software";
+#endif
 
 ALDeviceList::ALDeviceList()
 {

--- a/src/xrSound/SoundRender_Core.cpp
+++ b/src/xrSound/SoundRender_Core.cpp
@@ -163,7 +163,7 @@ void CSoundRender_Core::set_geometry_som(IReader* I)
 
     // check version
     R_ASSERT(I->find_chunk(0));
-    u32 version = I->r_u32();
+    [[maybe_unused]] u32 version = I->r_u32();
     VERIFY2(version == 0, "Invalid SOM version");
 
     struct SOM_poly

--- a/src/xrSound/SoundRender_CoreA.cpp
+++ b/src/xrSound/SoundRender_CoreA.cpp
@@ -47,7 +47,7 @@ void CSoundRender_CoreA::_initialize()
     }
 
     // Get the device specifier.
-    const ALCchar* deviceSpecifier = alcGetString(pDevice, ALC_DEVICE_SPECIFIER);
+    //const ALCchar* deviceSpecifier = alcGetString(pDevice, ALC_DEVICE_SPECIFIER);
 
     // Create context
     pContext = alcCreateContext(pDevice, nullptr);

--- a/src/xrSound/SoundRender_Core_SourceManager.cpp
+++ b/src/xrSound/SoundRender_Core_SourceManager.cpp
@@ -67,10 +67,10 @@ void CSoundRender_Core::i_create_all_sources()
 #ifndef MASTER_GOLD
     CTimer T;
     T.Start();
+    const size_t sizeBefore = s_sources.size();
 #endif
     FS_FileSet flist;
     FS.file_list(flist, "$game_sounds$", FS_ListFiles, "*.ogg");
-    const size_t sizeBefore = s_sources.size();
 
     const auto processFile = [&](const FS_File& file)
     {

--- a/src/xrSound/SoundRender_TargetA.cpp
+++ b/src/xrSound/SoundRender_TargetA.cpp
@@ -153,7 +153,7 @@ void CSoundRender_TargetA::update()
 
 void CSoundRender_TargetA::fill_parameters()
 {
-    CSoundRender_Emitter* SE = m_pEmitter;
+    [[maybe_unused]] CSoundRender_Emitter* SE = m_pEmitter;
     VERIFY(SE);
 
     inherited::fill_parameters();

--- a/src/xrUICore/ListWnd/UIListWnd.cpp
+++ b/src/xrUICore/ListWnd/UIListWnd.cpp
@@ -8,7 +8,7 @@
 //#define ACTIVE_BACKGROUND_HEIGHT	16
 
 // разделитель для интерактивных строк в листе
-static const char cSeparatorChar = '%';
+//static const char cSeparatorChar = '%';
 
 CUIListWnd::CUIListWnd() : CUIWindow("CUIListWnd")
 {


### PR DESCRIPTION
Mostly resorted to commenting out variables in case they might still be useful to someone someway.

What confused me is the bit in `IPureClient::Disconnect()`. This almost looks like we're missing some cleanup here.