### PR TITLE
xrPhysics: Fix potential copy-paste error in `SetLimitsActive` for axis `-1`

### DIFF
--- a/src/xrPhysics/PHJoint.cpp
+++ b/src/xrPhysics/PHJoint.cpp
@@ -961,6 +961,7 @@ void CPHJoint::SetLimitsActive(int axis_num)
             dJointSetSliderParam(m_joint, dParamHiStop, axes[0].high);
             dJointSetAMotorParam(m_joint1, dParamLoStop, axes[1].low);
             dJointSetAMotorParam(m_joint1, dParamHiStop, axes[1].high);
+            break;
         case 0:
             dJointSetSliderParam(m_joint, dParamLoStop, axes[0].low);
             dJointSetSliderParam(m_joint, dParamHiStop, axes[0].high);
@@ -982,11 +983,12 @@ void CPHJoint::SetLimitsActive(int axis_num)
         {
         case -1:
             dJointSetAMotorParam(m_joint1, dParamLoStop, axes[0].low);
-            dJointSetAMotorParam(m_joint1, dParamLoStop, axes[0].low);
+            dJointSetAMotorParam(m_joint1, dParamHiStop, axes[0].high);
             dJointSetAMotorParam(m_joint1, dParamLoStop2, axes[1].low);
             dJointSetAMotorParam(m_joint1, dParamHiStop2, axes[1].high);
+            dJointSetAMotorParam(m_joint1, dParamLoStop3, axes[2].low);
             dJointSetAMotorParam(m_joint1, dParamHiStop3, axes[2].high);
-            dJointSetAMotorParam(m_joint1, dParamHiStop3, axes[2].high);
+            break;
         case 0:
             dJointSetAMotorParam(m_joint1, dParamLoStop, axes[0].low);
             dJointSetAMotorParam(m_joint1, dParamHiStop, axes[0].high);


### PR DESCRIPTION
Fair warning I'm not very familiar with Physics programming. But looking at these they seem like classical copy and paste errors.

For example assigning `m_Joint1` `dParamLoStop` to `axis[0].low` twice but never assign `dParamHiStop` to `axis[0].high` like other code paths do.
Also there are 2 cases where due to a missing `break` the same values get assigned again.

But please take a close look at this and correct me if I'm wrong :)