### PR TITLE
Let the compiler assume that `VERIFY` expressions are true in release builds

### DIFF
--- a/src/xrAICore/Navigation/PatrolPath/patrol_point_inline.h
+++ b/src/xrAICore/Navigation/PatrolPath/patrol_point_inline.h
@@ -16,27 +16,33 @@ inline bool CPatrolPoint::operator==(const CPatrolPoint& rhs) const
 
 IC const Fvector& CPatrolPoint::position() const
 {
+#ifdef DEBUG
     VERIFY(m_initialized);
+#endif
     return (m_position);
 }
 
 IC const u32& CPatrolPoint::flags() const
 {
+#ifdef DEBUG
     VERIFY(m_initialized);
+#endif
     return (m_flags);
 }
 
 IC const shared_str& CPatrolPoint::name() const
 {
+#ifdef DEBUG
     VERIFY(m_initialized);
+#endif
     return (m_name);
 }
 
 IC const u32& CPatrolPoint::level_vertex_id(
     const CLevelGraph* level_graph, const CGameLevelCrossTable* cross, const CGameGraph* game_graph) const
 {
-    VERIFY(m_initialized);
 #ifdef DEBUG
+    VERIFY(m_initialized);
     verify_vertex_id(level_graph, cross, game_graph);
 #endif
     return (m_level_vertex_id);
@@ -45,8 +51,8 @@ IC const u32& CPatrolPoint::level_vertex_id(
 IC const GameGraph::_GRAPH_ID& CPatrolPoint::game_vertex_id(
     const CLevelGraph* level_graph, const CGameLevelCrossTable* cross, const CGameGraph* game_graph) const
 {
-    VERIFY(m_initialized);
 #ifdef DEBUG
+    VERIFY(m_initialized);
     verify_vertex_id(level_graph, cross, game_graph);
 #endif
     return (m_game_vertex_id);

--- a/src/xrCore/xrDebug_macros.h
+++ b/src/xrCore/xrDebug_macros.h
@@ -175,10 +175,10 @@
 #else
 #define NODEFAULT XR_ASSUME(0)
 #endif
-#define VERIFY(expr) do {} while (false)
-#define VERIFY2(expr, desc) do {} while (false)
-#define VERIFY3(expr, desc, arg1) do {} while (false)
-#define VERIFY4(expr, desc, arg1, arg2) do {} while (false)
+#define VERIFY(expr) XR_ASSUME(expr)
+#define VERIFY2(expr, desc) XR_ASSUME(expr)
+#define VERIFY3(expr, desc, arg1) XR_ASSUME(expr)
+#define VERIFY4(expr, desc, arg1, arg2) XR_ASSUME(expr)
 #define CHK_DX(expr) expr
 #define CHK_GL(expr) expr
 #endif // DEBUG

--- a/src/xrEngine/xr_collide_form.cpp
+++ b/src/xrEngine/xr_collide_form.cpp
@@ -131,8 +131,10 @@ void CCF_Skeleton::BuildState()
         Fmatrix ME, T, TW;
         const Fmatrix& Mbone = K->LL_GetTransform(I->elem_id);
 
+#ifdef DEBUG
         VERIFY2(DET(Mbone) > EPS,
             (make_string("0 scale bone matrix, %d \n", I->elem_id) + dbg_object_full_dump_string(owner)).c_str());
+#endif
 
         switch (I->type)
         {

--- a/src/xrEngine/xr_object_list.cpp
+++ b/src/xrEngine/xr_object_list.cpp
@@ -141,7 +141,9 @@ void CObjectList::SingleUpdate(IGameObject* O)
 
     O->UpdateCL();
 
+#ifdef DEBUG
     VERIFY3(O->GetDbgUpdateFrame() == Device.dwFrame, "Broken sequence of calls to 'UpdateCL'", *O->cName());
+#endif
 #if 0 // ndef DEBUG
     __try
     {
@@ -587,7 +589,10 @@ bool CObjectList::dump_all_objects()
 
 void CObjectList::register_object_to_destroy(IGameObject* object_to_destroy)
 {
+#ifdef DEBUG
     VERIFY(!registered_object_to_destroy(object_to_destroy));
+#endif
+
     // Msg("CObjectList::register_object_to_destroy [%x]", object_to_destroy);
     destroy_queue.push_back(object_to_destroy);
 

--- a/src/xrGame/Actor_Network.cpp
+++ b/src/xrGame/Actor_Network.cpp
@@ -513,7 +513,9 @@ void CActor::net_Import_Physic(NET_Packet& P)
             }
             else
             {
+#ifdef DEBUG
                 VERIFY(valid_pos(N_A.State.position, ph_boundaries()));
+#endif
                 NET_A.push_back(N_A);
                 if (NET_A.size() > 5)
                     NET_A.pop_front();

--- a/src/xrGame/Car.cpp
+++ b/src/xrGame/Car.cpp
@@ -125,7 +125,9 @@ void CCar::reload(LPCSTR section)
 
 void CCar::cb_Steer(CBoneInstance* B)
 {
+#ifdef DEBUG
     VERIFY2(fsimilar(DET(B->mTransform), 1.f, DET_CHECK_EPS), "Bones receive returns 0 matrix");
+#endif
     CCar* C = static_cast<CCar*>(B->callback_param());
     Fmatrix m;
 

--- a/src/xrGame/CarCameras.cpp
+++ b/src/xrGame/CarCameras.cpp
@@ -18,7 +18,9 @@
 bool CCar::HUDView() const { return active_camera->tag == ectFirst; }
 void CCar::cam_Update(float dt, float fov)
 {
+#ifdef DEBUG
     VERIFY(!physics_world()->Processing());
+#endif
     Fvector P, Da;
     Da.set(0, 0, 0);
     // bool							owner = !!Owner();

--- a/src/xrGame/DestroyablePhysicsObject.cpp
+++ b/src/xrGame/DestroyablePhysicsObject.cpp
@@ -89,7 +89,10 @@ void CDestroyablePhysicsObject::Hit(SHit* pHDS)
 }
 void CDestroyablePhysicsObject::Destroy()
 {
+#ifdef DEBUG
     VERIFY(!physics_world()->Processing());
+#endif
+
     const CGameObject* who_object = smart_cast<const CGameObject*>(FatalHit().initiator());
     callback(GameObject::eDeath)(lua_game_object(), who_object ? who_object->lua_game_object() : 0);
     CPHDestroyable::Destroy(ID(), "physic_destroyable_object");

--- a/src/xrGame/GameObject.cpp
+++ b/src/xrGame/GameObject.cpp
@@ -1039,8 +1039,10 @@ void CGameObject::setDestroy(bool _destroy)
         Msg("cl setDestroy [%d][%d]", ID(), Device.dwFrame);
 #endif //#ifdef MP_LOGGING
     }
+#ifdef DEBUG
     else
         VERIFY(!g_pGameLevel->Objects.registered_object_to_destroy(this));
+#endif
 }
 
 Fvector CGameObject::get_new_local_point_on_mesh(u16& bone_id) const

--- a/src/xrGame/Level_Bullet_Manager.cpp
+++ b/src/xrGame/Level_Bullet_Manager.cpp
@@ -179,7 +179,9 @@ void CBulletManager::AddBullet(const Fvector& position, const Fvector& direction
     // Always called in Primary thread
     // Uncomment below if you will change the behaviour
     // if (!g_mt_config.test(mtBullets))
+#ifdef DEBUG
     VERIFY(Threading::ThreadIdsAreEqual(m_thread_id, Threading::GetCurrThreadId()));
+#endif
 
     VERIFY(u16(-1) != cartridge.bullet_material_idx);
     //	u32 CurID					= Level().CurrentControlEntity()->ID();
@@ -200,7 +202,9 @@ void CBulletManager::AddBullet(const Fvector& position, const Fvector& direction
 
 void CBulletManager::UpdateWorkload()
 {
+#ifdef DEBUG
     VERIFY(g_mt_config.test(mtBullets) || Threading::ThreadIdsAreEqual(m_thread_id, Threading::GetCurrThreadId()));
+#endif
 
     rq_storage.r_clear();
 

--- a/src/xrGame/Level_network.cpp
+++ b/src/xrGame/Level_network.cpp
@@ -98,7 +98,9 @@ void CLevel::remove_objects()
 #endif // DEBUG
     if (!GEnv.isDedicatedServer)
     {
+#ifdef DEBUG
         VERIFY(client_spawn_manager().registry().empty());
+#endif
         client_spawn_manager().clear();
     }
 

--- a/src/xrGame/PHDestroyable.cpp
+++ b/src/xrGame/PHDestroyable.cpp
@@ -337,7 +337,9 @@ void CPHDestroyable::NotificatePart(CPHDestroyableNotificate* dn)
 void CPHDestroyable::NotificateDestroy(CPHDestroyableNotificate* dn)
 {
     VERIFY(m_depended_objects);
+#ifdef DEBUG
     VERIFY(!physics_world()->Processing());
+#endif
     m_depended_objects--;
     PhysicallyRemovePart(dn);
     m_notificate_objects.push_back(dn);

--- a/src/xrGame/attachable_item.cpp
+++ b/src/xrGame/attachable_item.cpp
@@ -114,13 +114,17 @@ bool CAttachableItem::can_be_attached() const
 
 void CAttachableItem::afterAttach()
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     object().processing_activate();
 }
 
 void CAttachableItem::afterDetach()
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     object().processing_deactivate();
 }
 

--- a/src/xrGame/attachable_item_inline.h
+++ b/src/xrGame/attachable_item_inline.h
@@ -22,25 +22,33 @@ IC CAttachableItem::CAttachableItem()
 
 IC shared_str CAttachableItem::bone_name() const
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     return (m_bone_name);
 }
 
 IC const Fmatrix& CAttachableItem::offset() const
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     return (m_offset);
 }
 
 IC u16 CAttachableItem::bone_id() const
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     return (m_bone_id);
 }
 
 IC void CAttachableItem::set_bone_id(u16 bone_id)
 {
+#ifdef DEBUG
     VERIFY(m_valid);
+#endif
     m_bone_id = bone_id;
 }
 

--- a/src/xrGame/ik/IKLimb.cpp
+++ b/src/xrGame/ik/IKLimb.cpp
@@ -494,8 +494,10 @@ void CIKLimb::SetNewGoal(const SIKCollideData& cld, SCalculateData& cd)
     cd.state.foot_step =
         m_foot.GetFootStepMatrix(cd.state.goal, cd, cld, true, !!ik_allign_free_foot) && cd.state.foot_step;
 
+#ifdef DEBUG
     VERIFY2(fsimilar(1.f, DET(cd.state.goal.get()), det_tolerance),
         dump_string("cd.state.goal", cd.state.goal.get()).c_str());
+#endif
 
     cd.state.blend_to = cd.state.goal;
     sv_state.get_calculate_state(cd.state);
@@ -671,27 +673,36 @@ void CIKLimb::Blending(SCalculateData& cd)
     {
         blend_speed_accel(cd);
         ik_goal_matrix m;
+
+#ifdef DEBUG
         VERIFY(fsimilar(1.f, DET(sv_state.goal(m).get()), det_tolerance));
         VERIFY(fsimilar(1.f, DET(sv_state.blend_to(m).get()), det_tolerance));
+#endif
 
         Fmatrix diff;
         diff.mul_43(Fmatrix().invert(sv_state.blend_to(m).get()), Fmatrix(sv_state.goal(m).get()));
 
+#ifdef DEBUG
         VERIFY(fsimilar(1.f, DET(diff), det_tolerance));
+#endif
 
         Fmatrix blend = Fidentity; // cd.state.blend_to;
         cd.state.blending =
             !clamp_change(blend, diff, cd.l, cd.a, linear_tolerance, angualar_tolerance); // 0.01f //0.005f
 
+#ifdef DEBUG
         VERIFY(fsimilar(1.f, DET(blend), det_tolerance));
         VERIFY(fsimilar(1.f, DET(cd.state.blend_to.get()), det_tolerance));
+#endif
 
         Fmatrix fm = Fmatrix().mul_43(cd.state.blend_to.get(), blend);
         if (ik_collide_blend)
             m_foot.GetFootStepMatrix(cd.state.goal, fm, collide_data, true, true);
         else
             cd.state.goal.set(fm, cd.state.blend_to.collide_state());
+#ifdef DEBUG
         VERIFY(fsimilar(DET(cd.state.goal.get()), 1.f, det_tolerance));
+#endif
     }
     else
     {

--- a/src/xrGame/moving_objects.cpp
+++ b/src/xrGame/moving_objects.cpp
@@ -23,10 +23,10 @@ void moving_objects::on_level_load()
 
 void moving_objects::register_object(moving_object* moving_object)
 {
+#ifdef DEBUG
     VERIFY2(m_objects.find(moving_object) == m_objects.end(),
         make_string("moving object %s is registers twice", *moving_object->id()));
 
-#ifdef DEBUG
     m_objects.insert(moving_object);
 #endif // DEBUG
 
@@ -36,10 +36,10 @@ void moving_objects::register_object(moving_object* moving_object)
 
 void moving_objects::unregister_object(moving_object* moving_object)
 {
+#ifdef DEBUG
     VERIFY2(m_objects.find(moving_object) != m_objects.end(),
         make_string("moving object %s is not yet registered or unregisters twice", *moving_object->id()));
 
-#ifdef DEBUG
     m_objects.erase(m_objects.find(moving_object));
 #endif // DEBUG
 
@@ -49,8 +49,10 @@ void moving_objects::unregister_object(moving_object* moving_object)
 
 void moving_objects::on_object_move(moving_object* moving_object)
 {
+#ifdef DEBUG
     VERIFY2(m_objects.find(moving_object) != m_objects.end(),
         make_string("moving object %s is not yet registered", *moving_object->id()));
+#endif
 
 #pragma todo("this place can be optimized in case of slowdowns")
     VERIFY(m_tree);

--- a/src/xrGame/xrServer.cpp
+++ b/src/xrGame/xrServer.cpp
@@ -198,7 +198,9 @@ void xrServer::Update()
     stats.Update.Begin();
     NET_Packet Packet;
 
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
 
     ProceedDelayedPackets();
     // game update
@@ -229,7 +231,9 @@ void xrServer::Update()
     if (game->sv_force_sync)
         Perform_game_export();
 
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
     //-----------------------------------------------------
 
     PerformCheckClientsForMaxPing();
@@ -351,7 +355,9 @@ void xrServer::SendUpdatesToAll()
 #endif
         if (game->sv_force_sync)
             Perform_game_export();
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
         m_last_update_time = Device.dwTimeGlobal;
     }
     if (m_file_transfers)
@@ -370,7 +376,9 @@ u32 xrServer::OnDelayedMessage(NET_Packet& P, ClientID sender) // Non-Zero means
 
     // csPlayers.Enter			();
 
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
     xrClientData* CL = ID_to_client(sender);
     // R_ASSERT2						(CL, make_string("packet type [%d]",type).c_str());
 
@@ -421,7 +429,9 @@ u32 xrServer::OnDelayedMessage(NET_Packet& P, ClientID sender) // Non-Zero means
     }
     break;
     }
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
 
     // csPlayers.Leave					();
     return 0;
@@ -441,7 +451,9 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
     u16 type;
     P.r_begin(type);
 
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
     xrClientData* CL = ID_to_client(sender);
 
     switch (type)
@@ -449,7 +461,9 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
     case M_UPDATE:
     {
         Process_update(P, sender); // No broadcast
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_SPAWN:
@@ -457,13 +471,17 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
         if (CL->flags.bLocal)
             Process_spawn(P, sender);
 
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_EVENT:
     {
         Process_event(P, sender);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_EVENT_PACK:
@@ -493,7 +511,9 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
         //-------------------------------------------------------------------
         if (SV_Client)
             SendTo(SV_Client->ID, P, net_flags(TRUE, TRUE));
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_MOVE_PLAYERS_RESPOND:
@@ -513,26 +533,34 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
             CL->net_Ready = TRUE;
         if (SV_Client)
             SendTo(SV_Client->ID, P, net_flags(TRUE, TRUE));
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_GAMEMESSAGE:
     {
         SendBroadcast(BroadcastCID, P, net_flags(TRUE, TRUE));
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_CLIENTREADY:
     {
         game->OnPlayerConnectFinished(sender);
         // game->signal_Syncronize	();
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_SWITCH_DISTANCE:
     {
         game->switch_distance(P, sender);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_CHANGE_LEVEL:
@@ -541,32 +569,42 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
         {
             SendBroadcast(BroadcastCID, P, net_flags(TRUE, TRUE));
         }
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_SAVE_GAME:
     {
         game->save_game(P, sender);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_LOAD_GAME:
     {
         game->load_game(P, sender);
         SendBroadcast(BroadcastCID, P, net_flags(TRUE, TRUE));
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_RELOAD_GAME:
     {
         SendBroadcast(BroadcastCID, P, net_flags(TRUE, TRUE));
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_SAVE_PACKET:
     {
         Process_save(P, sender);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case M_CLIENT_REQUEST_CONNECTION_DATA: { AddDelayedPacket(P, sender);
@@ -694,7 +732,9 @@ u32 xrServer::OnMessage(NET_Packet& P, ClientID sender) // Non-Zero means broadc
     break;
     }
 
+#ifdef DEBUG
     VERIFY(verify_entities());
+#endif
 
     return IPureServer::OnMessage(P, sender);
 }

--- a/src/xrGame/xrServer_process_event.cpp
+++ b/src/xrGame/xrServer_process_event.cpp
@@ -91,13 +91,17 @@ void xrServer::Process_event(NET_Packet& P, ClientID sender)
     case GE_OWNERSHIP_TAKE:
     {
         Process_event_ownership(P, sender, timestamp, destination);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_OWNERSHIP_TAKE_MP_FORCED:
     {
         Process_event_ownership(P, sender, timestamp, destination, TRUE);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_TRADE_SELL:
@@ -105,13 +109,17 @@ void xrServer::Process_event(NET_Packet& P, ClientID sender)
     case GE_LAUNCH_ROCKET:
     {
         Process_event_reject(P, sender, timestamp, destination, P.r_u16());
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_DESTROY:
     {
         Process_event_destroy(P, sender, timestamp, destination, NULL);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_TRANSFER_AMMO:
@@ -133,7 +141,9 @@ void xrServer::Process_event(NET_Packet& P, ClientID sender)
 
         // Perfrom real destroy
         entity_Destroy(e_entity);
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_HIT:
@@ -254,7 +264,9 @@ void xrServer::Process_event(NET_Packet& P, ClientID sender)
         }
         //////////////////////////////////////////////////////////////////////////
 
+#ifdef DEBUG
         VERIFY(verify_entities());
+#endif
     }
     break;
     case GE_ADDON_ATTACH:

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -815,7 +815,9 @@ bool CUIXmlInitBase::InitFrameLine(CUIXml& xml_doc, LPCSTR path, int index, CUIF
     strconcat(sizeof(buf), buf, path, ":texture");
     shared_str base_name = xml_doc.Read(buf, index, NULL);
 
+#ifdef DEBUG
     VERIFY(base_name);
+#endif
 
     u32 color = GetColor(xml_doc, buf, index, 0xff);
     pWnd->SetTextureColor(color);


### PR DESCRIPTION
Should allow the compiler to generate better code.

Small caparison of file sizes with gcc-13.2 with and without this patch.
Note: That file size is not a really good metric for comparison when it comes to performance. This rather shows that the patch actually **does** make some difference.

| File              | Before   | After    | diff   | Diff %              |
| ----------------- | -------- | -------- | ------ | ------------------- |
| xrAICore.so       | 558944   | 559040   | -96    | -0.017175244747238% |
| xrAPI.so          | 7664     | 7664     | 0      | 0%                  |
| xrCDB.so          | 287112   | 283136   | -3976  | -1.384825433977%    |
| xrCore.so         | 684664   | 684656   | -8     | -0.001168456352313% |
| xrEngine.so       | 2312128  | 2308000  | -4128  | -0.17853682841088%  |
| xrGame.so         | 44601216 | 44562992 | -38224 | -0.085701699254119% |
| xrLCUtil.so       | 13392    | 13392    | 0      | 0%                  |
| xrLuabind.so      | 173480   | 173480   | 0      | 0%                  |
| xrLuajit.so       | 620768   | 620768   | 0      | 0%                  |
| xrNetServer.so    | 103936   | 103936   | 0      | 0%                  |
| xrParticles.so    | 204440   | 204440   | 0      | 0%                  |
| xrRender_GL.so    | 3700032  | 3707784  | +7752  | +0.20951170152042%  |
| xrScriptEngine.so | 511144   | 511264   | +120   | +0.023476750191727% |
| xrSound.so        | 202240   | 198224   | -4016  | -1.9857594936709%   |
| xrUICore.so       | 2412280  | 2416448  | +4168  | +0.17278259571857%  |
| xr_3da            | 13736    | 13736    | 0      | 0%                  |
| Total             | 56407176 | 56368960 | -38216 | -0.067750245110658% |
