### PR TITLE
Revert "xrCDB/Frustum.cpp: reduced testSphere_dirty function code size"

### DIFF
--- a/src/xrCDB/Frustum.cpp
+++ b/src/xrCDB/Frustum.cpp
@@ -101,10 +101,48 @@ EFC_Visible CFrustum::testSphere(Fvector& c, float r, u32& test_mask) const
 
 bool CFrustum::testSphere_dirty(const Fvector& c, float r) const
 {
-	VERIFY(p_count <= FRUSTUM_MAXPLANES); // '<=' is not a typo, this check is correct
-    if (p_count == 0)
-        return true;
-    return planes[p_count - 1].classify(c) <= r;
+    switch (p_count)
+    {
+    case 12:
+        if (planes[11].classify(c) > r)
+            return FALSE;
+    case 11:
+        if (planes[10].classify(c) > r)
+            return FALSE;
+    case 10:
+        if (planes[9].classify(c) > r)
+            return FALSE;
+    case 9:
+        if (planes[8].classify(c) > r)
+            return FALSE;
+    case 8:
+        if (planes[7].classify(c) > r)
+            return FALSE;
+    case 7:
+        if (planes[6].classify(c) > r)
+            return FALSE;
+    case 6:
+        if (planes[5].classify(c) > r)
+            return FALSE;
+    case 5:
+        if (planes[4].classify(c) > r)
+            return FALSE;
+    case 4:
+        if (planes[3].classify(c) > r)
+            return FALSE;
+    case 3:
+        if (planes[2].classify(c) > r)
+            return FALSE;
+    case 2:
+        if (planes[1].classify(c) > r)
+            return FALSE;
+    case 1:
+        if (planes[0].classify(c) > r)
+            return FALSE;
+    case 0: break;
+    default: NODEFAULT;
+    }
+    return TRUE;
 }
 
 EFC_Visible CFrustum::testAABB(const float* mM, u32& test_mask) const


### PR DESCRIPTION
Reverts OpenXRay/xray-16#791 because it changes original function behaviour which is intended.