### PR TITLE
Fix definitions of `type_min` and `type_zero` in `xr_types.h`

### DIFF
--- a/src/Layers/xrRenderPC_R1/LightProjector.cpp
+++ b/src/Layers/xrRenderPC_R1/LightProjector.cpp
@@ -243,7 +243,7 @@ void CLightProjector::calculate()
         v.sub(v_Cs, v_C);
         ;
 #ifdef DEBUG
-        if ((v.x * v.x + v.y * v.y + v.z * v.z) <= flt_zero)
+        if ((v.x * v.x + v.y * v.y + v.z * v.z) <= flt_min)
         {
             IGameObject* OO = dynamic_cast<IGameObject*>(R.O);
             Msg("Object[%s] Visual[%s] has invalid position. ", *OO->cName(), *OO->cNameVisual());
@@ -274,7 +274,7 @@ void CLightProjector::calculate()
         }
 #endif
         // handle invalid object-bug
-        if ((v.x * v.x + v.y * v.y + v.z * v.z) <= flt_zero)
+        if ((v.x * v.x + v.y * v.y + v.z * v.z) <= flt_min)
         {
             // invalidate record, so that object will be unshadowed, but doesn't crash
             R.dwTimeValid = Device.dwTimeGlobal;

--- a/src/utils/xrAI/space_restrictor_wrapper.cpp
+++ b/src/utils/xrAI/space_restrictor_wrapper.cpp
@@ -147,7 +147,7 @@ void CSpaceRestrictorWrapper::fill_shape(const CShapeData::shape_def& shape)
             Fvector().set(-.5f, +.5f, -.5f), Fvector().set(-.5f, +.5f, +.5f), Fvector().set(+.5f, -.5f, -.5f),
             Fvector().set(+.5f, -.5f, +.5f), Fvector().set(+.5f, +.5f, -.5f), Fvector().set(+.5f, +.5f, +.5f)};
         start = Fvector().set(flt_max, flt_max, flt_max);
-        dest = Fvector().set(flt_min, flt_min, flt_min);
+        dest = Fvector().set(flt_lowest, flt_lowest, flt_lowest);
         Fmatrix Q;
         Q.mul_43(m_xform, shape.data.box);
         Fvector temp;

--- a/src/utils/xrLC/OGF_Face.cpp
+++ b/src/utils/xrLC/OGF_Face.cpp
@@ -210,7 +210,7 @@ void OGF::Optimize()
                 // 1. Calc bounds
                 Fvector2 Tmin,Tmax;
                 Tmin.set(flt_max,flt_max);
-                Tmax.set(flt_min,flt_min);
+                Tmax.set(flt_lowest,flt_lowest);
                 for (size_t j=0; j<x_vertices.size(); j++)			{
                     x_vertex& V = x_vertices[j];
                     //Tmin.min	(V.UV);
@@ -291,7 +291,7 @@ void OGF::Optimize()
         {
             Fvector2 Tmin, Tmax;
             Tmin.set(flt_max, flt_max);
-            Tmax.set(flt_min, flt_min);
+            Tmax.set(flt_lowest, flt_lowest);
             for (size_t j = 0; j < selection.size(); j++)
             {
                 OGF_Vertex& V = data.vertices[selection[j]];

--- a/src/utils/xrLC_Light/MeshStructure.h
+++ b/src/utils/xrLC_Light/MeshStructure.h
@@ -198,7 +198,7 @@ public:
         t2.sub(v2, v1);
         dN.crossproduct(t1, t2);
         double mag = dN.magnitude();
-        if (mag < dbl_zero)
+        if (mag < dbl_min)
         {
             Failure();
             Dvector Nabs;

--- a/src/utils/xrMiscMath/matrix.cpp
+++ b/src/utils/xrMiscMath/matrix.cpp
@@ -155,7 +155,7 @@ _matrix<T>& _matrix<T>::invert(const _matrix<T>& a)   // important: this is 4x3 
 		a._12 * (a._21 * a._33 - a._23 * a._31) +
 		a._13 * (a._21 * a._32 - a._22 * a._31));
 
-	VERIFY(_abs(fDetInv) > flt_zero);
+	VERIFY(_abs(fDetInv) > flt_min);
 	fDetInv = 1.0f / fDetInv;
 
 	_11 = fDetInv * (a._22 * a._33 - a._23 * a._32);
@@ -188,7 +188,7 @@ bool _matrix<T>::invert_b(const _matrix<T>& a)   // important: this is 4x3 inver
 		a._12 * (a._21 * a._33 - a._23 * a._31) +
 		a._13 * (a._21 * a._32 - a._22 * a._31));
 
-	if (_abs(fDetInv) <= flt_zero) return false;
+	if (_abs(fDetInv) <= flt_min) return false;
 	fDetInv = 1.0f / fDetInv;
 
 	_11 = fDetInv * (a._22 * a._33 - a._23 * a._32);
@@ -234,7 +234,7 @@ _matrix<T>& _matrix<T>::invert_44(const _matrix<T>& a)
     T A14 = -(a21 * mn3 - a22 * mn5 + a23 * mn6);
 
     T detInv = a11 * A11 + a12 * A12 + a13 * A13 + a14 * A14;
-    VERIFY(_abs(detInv) > flt_zero);
+    VERIFY(_abs(detInv) > flt_min);
 
     detInv = 1.f / detInv;
 

--- a/src/utils/xrMiscMath/vector.cpp
+++ b/src/utils/xrMiscMath/vector.cpp
@@ -315,7 +315,7 @@ _vector3<T>& _vector3<T>::normalize_safe()
 template <typename T>
 _vector3<T>& _vector3<T>::normalize(const _vector3<T>& v)
 {
-	VERIFY((v.x*v.x + v.y*v.y + v.z*v.z) > flt_zero);
+	VERIFY((v.x*v.x + v.y*v.y + v.z*v.z) > flt_min);
 	T mag = _sqrt(1 / (v.x*v.x + v.y*v.y + v.z*v.z));
 	x = v.x*mag;
 	y = v.y*mag;

--- a/src/xrCDB/Frustum.cpp
+++ b/src/xrCDB/Frustum.cpp
@@ -307,7 +307,7 @@ void CFrustum::SimplifyPoly_AABB(sPoly* poly, Fplane& plane)
     // Project and find extents
     Fvector2 min, max;
     min.set(flt_max, flt_max);
-    max.set(flt_min, flt_min);
+    max.set(flt_lowest, flt_lowest);
     for (auto& v : *poly)
     {
         Fvector2 tmp;

--- a/src/xrCore/_fbox.h
+++ b/src/xrCore/_fbox.h
@@ -67,7 +67,7 @@ public:
     auto& invalidate()
     {
         vMin.set(type_max<float>, type_max<float>, type_max<float>);
-        vMax.set(type_min<float>, type_min<float>, type_min<float>);
+        vMax.set(type_lowest<float>, type_lowest<float>, type_lowest<float>);
         return *this;
     }
 

--- a/src/xrCore/_fbox2.h
+++ b/src/xrCore/_fbox2.h
@@ -57,7 +57,7 @@ struct Fbox2
     auto& invalidate()
     {
         min.set(type_max<float>, type_max<float>);
-        max.set(type_min<float>, type_min<float>);
+        max.set(type_lowest<float>, type_lowest<float>);
         return *this;
     }
 

--- a/src/xrCore/_rect.h
+++ b/src/xrCore/_rect.h
@@ -70,8 +70,8 @@ public:
     {
         lt.x = type_max<T>;
         lt.y = type_max<T>;
-        rb.x = type_min<T>;
-        rb.y = type_min<T>;
+        rb.x = type_lowest<T>;
+        rb.y = type_lowest<T>;
         return *this;
     };
     IC bool valide() { return lt.x1 < rb.x && lt.y < rb.y; }

--- a/src/xrCore/xr_types.h
+++ b/src/xrCore/xr_types.h
@@ -29,10 +29,13 @@ template <typename T>
 constexpr auto type_max = std::numeric_limits<T>::max();
 
 template <typename T>
-constexpr auto type_min = -std::numeric_limits<T>::max();
+constexpr auto type_lowest = std::numeric_limits<T>::lowest();
 
 template <typename T>
-constexpr auto type_zero = std::numeric_limits<T>::min();
+constexpr auto type_min = std::numeric_limits<T>::min();
+
+template <typename T>
+constexpr auto type_zero = T(0);
 
 template <typename T>
 constexpr auto type_epsilon = std::numeric_limits<T>::epsilon();
@@ -43,16 +46,18 @@ constexpr int int_zero = type_zero<int>;
 
 constexpr float flt_max = type_max<float>;
 constexpr float flt_min = type_min<float>;
+constexpr float flt_lowest = type_lowest<float>;
 constexpr float flt_zero = type_zero<float>;
 constexpr float flt_eps = type_epsilon<float>;
 
 #undef FLT_MAX
 #undef FLT_MIN
 #define FLT_MAX flt_max
-#define FLT_MIN flt_min
+#define FLT_MIN flt_lowest
 
 constexpr double dbl_max = type_max<double>;
 constexpr double dbl_min = type_min<double>;
+constexpr double dbl_lowest = type_lowest<double>;
 constexpr double dbl_zero = type_zero<double>;
 constexpr double dbl_eps = type_epsilon<double>;
 

--- a/src/xrEngine/FDemoPlay.cpp
+++ b/src/xrEngine/FDemoPlay.cpp
@@ -114,7 +114,7 @@ void CDemoPlay::stat_Stop()
 
     // min/max/average
     rfps_min = flt_max;
-    rfps_max = flt_min;
+    rfps_max = flt_lowest;
     rfps_middlepoint = 0;
 
     // Filtered FPS

--- a/src/xrEngine/xrSASH.cpp
+++ b/src/xrEngine/xrSASH.cpp
@@ -160,7 +160,7 @@ void xrSASH::ReportNative(pcstr pszTestName)
 
     // min/max/average
     float fMinFps = flt_max;
-    float fMaxFps = flt_min;
+    float fMaxFps = flt_lowest;
 
     const u32 iWindowSize = 15;
 

--- a/src/xrGame/DynamicHeightMap.cpp
+++ b/src/xrGame/DynamicHeightMap.cpp
@@ -211,7 +211,7 @@ float CHM_Static::Query(float x, float z)
 
 //
 void CHM_Dynamic::Update() {}
-float CHM_Dynamic::Query(float x, float z) { return flt_min; }
+float CHM_Dynamic::Query(float x, float z) { return flt_lowest; }
 //
 float CHeightMap::Query(float x, float z)
 {

--- a/src/xrGame/DynamicHeightMap.h
+++ b/src/xrGame/DynamicHeightMap.h
@@ -31,7 +31,7 @@ class CHM_Static
         {
             for (u32 i = 0; i < dhm_precision; ++i)
                 for (u32 j = 0; j < dhm_precision; ++j)
-                    data[i][j] = flt_min;
+                    data[i][j] = flt_lowest;
         }
         Slot()
         {

--- a/src/xrGame/Level_bullet_manager_firetrace.cpp
+++ b/src/xrGame/Level_bullet_manager_firetrace.cpp
@@ -237,7 +237,7 @@ void CBulletManager::FireShotmark(SBullet* bullet, const Fvector& vDir, const Fv
     if ((ps_name && ShowMark) || (bullet->flags.explosive && bStatic))
     {
         VERIFY2((particle_dir.x * particle_dir.x + particle_dir.y * particle_dir.y + particle_dir.z * particle_dir.z) >
-                flt_zero,
+                flt_min,
             make_string("[%f][%f][%f]", VPUSH(particle_dir)));
         Fmatrix pos;
         pos.k.normalize(particle_dir);

--- a/src/xrGame/WeaponBinocularsVision.cpp
+++ b/src/xrGame/WeaponBinocularsVision.cpp
@@ -89,7 +89,7 @@ void SBinocVisibleObj::Update()
 
     Fmatrix xform;
     xform.mul(Device.mFullTransform, m_object->XFORM());
-    Fvector2 mn = {flt_max, flt_max}, mx = {flt_min, flt_min};
+    Fvector2 mn = {flt_max, flt_max}, mx = {flt_lowest, flt_lowest};
 
     for (u32 k = 0; k < 8; ++k)
     {

--- a/src/xrGame/ai/monsters/basemonster/base_monster.cpp
+++ b/src/xrGame/ai/monsters/basemonster/base_monster.cpp
@@ -1037,7 +1037,7 @@ float CBaseMonster::get_screen_space_coverage_diagonal()
 
     Fmatrix xform;
     xform.mul(Device.mFullTransform, XFORM());
-    Fvector2 mn = {flt_max, flt_max}, mx = {flt_min, flt_min};
+    Fvector2 mn = {flt_max, flt_max}, mx = {flt_lowest, flt_lowest};
 
     for (u32 k = 0; k < 8; ++k)
     {

--- a/src/xrGame/ai_obstacle.cpp
+++ b/src/xrGame/ai_obstacle.cpp
@@ -164,7 +164,7 @@ void ai_obstacle::compute_matrix(Fmatrix& result, const Fvector& additional)
 void ai_obstacle::prepare_inside(Fvector& min, Fvector& max)
 {
     min = Fvector().set(flt_max, flt_max, flt_max);
-    max = Fvector().set(flt_min, flt_min, flt_min);
+    max = Fvector().set(flt_lowest, flt_lowest, flt_lowest);
 
     Fmatrix matrix;
     float half_cell_size = (use_additional_radius ? 1.f : 0.f) * ai().level_graph().header().cell_size() * .5f;

--- a/src/xrGame/inventory_upgrade_manager.cpp
+++ b/src/xrGame/inventory_upgrade_manager.cpp
@@ -493,7 +493,7 @@ LPCSTR Manager::get_upgrade_by_index(CInventoryItem& item, Ivector2 const& index
 bool Manager::compute_range(LPCSTR parameter, float& low, float& high)
 {
     low = flt_max;
-    high = flt_min;
+    high = flt_lowest;
 
     Roots_type::iterator ib = m_roots.begin();
     Roots_type::iterator ie = m_roots.end();
@@ -509,7 +509,7 @@ bool Manager::compute_range(LPCSTR parameter, float& low, float& high)
         compute_range_section(((*uib).second)->section(), parameter, low, high);
     }
 
-    return (low != flt_max) && (high != flt_min);
+    return (low != flt_max) && (high != flt_lowest);
 }
 
 void Manager::compute_range_section(LPCSTR section, LPCSTR parameter, float& low, float& high)

--- a/src/xrGame/smart_cover_detail.h
+++ b/src/xrGame/smart_cover_detail.h
@@ -19,10 +19,10 @@ namespace detail
 {
 typedef RestrictionSpace::CTimeIntrusiveBase intrusive_base_time;
 
-float parse_float(luabind::adl::object const& table, LPCSTR identifier, float const& min_threshold = flt_min,
+float parse_float(luabind::adl::object const& table, LPCSTR identifier, float const& min_threshold = flt_lowest,
     float const& max_threshold = flt_max);
 bool parse_float(float& output, luabind::adl::object const& table, LPCSTR identifier,
-    float const& min_threshold = flt_min, float const& max_threshold = flt_max);
+    float const& min_threshold = flt_lowest, float const& max_threshold = flt_max);
 LPCSTR parse_string(luabind::adl::object const& table, LPCSTR identifier);
 void parse_table(luabind::adl::object const& table, LPCSTR identifier, luabind::adl::object& result);
 bool parse_bool(luabind::adl::object const& table, LPCSTR identifier);

--- a/src/xrGame/space_restriction_shape.cpp
+++ b/src/xrGame/space_restriction_shape.cpp
@@ -61,7 +61,7 @@ void CSpaceRestrictionShape::fill_shape(const CCF_Shape::shape_def& shape)
             Fvector().set(-.5f, +.5f, -.5f), Fvector().set(-.5f, +.5f, +.5f), Fvector().set(+.5f, -.5f, -.5f),
             Fvector().set(+.5f, -.5f, +.5f), Fvector().set(+.5f, +.5f, -.5f), Fvector().set(+.5f, +.5f, +.5f)};
         start = Fvector().set(flt_max, flt_max, flt_max);
-        dest = Fvector().set(flt_min, flt_min, flt_min);
+        dest = Fvector().set(flt_lowest, flt_lowest, flt_lowest);
         Fmatrix Q;
         Q.mul_43(m_restrictor->XFORM(), shape.data.box);
         Fvector temp;

--- a/src/xrServerEntities/PropertiesListHelper.h
+++ b/src/xrServerEntities/PropertiesListHelper.h
@@ -84,9 +84,9 @@ public:
         PropItemVec& items, shared_str key, float* val, float mn = 0.f, float mx = 86400.f);
     virtual ShortcutValue* CreateShortcut(PropItemVec& items, shared_str key, xr_shortcut* val);
 
-    virtual FloatValue* CreateAngle(PropItemVec& items, shared_str key, float* val, float mn = flt_min,
+    virtual FloatValue* CreateAngle(PropItemVec& items, shared_str key, float* val, float mn = flt_lowest,
         float mx = flt_max, float inc = 0.01f, int decim = 2);
-    virtual VectorValue* CreateAngle3(PropItemVec& items, shared_str key, Fvector* val, float mn = flt_min,
+    virtual VectorValue* CreateAngle3(PropItemVec& items, shared_str key, Fvector* val, float mn = flt_lowest,
         float mx = flt_max, float inc = 0.01f, int decim = 2);
     virtual RTextValue* CreateName(PropItemVec& items, shared_str key, shared_str* val, ListItem* owner);
     virtual RTextValue* CreateNameCB(PropItemVec& items, shared_str key, shared_str* val,

--- a/src/xrServerEntities/alife_monster_brain.cpp
+++ b/src/xrServerEntities/alife_monster_brain.cpp
@@ -107,7 +107,7 @@ void CALifeMonsterBrain::select_task(const bool forced)
 
     m_last_search_time = current_time;
 
-    float best_value = flt_min;
+    float best_value = flt_lowest;
     CALifeSmartTerrainRegistry::OBJECTS::const_iterator I = ai().alife().smart_terrains().objects().begin();
     CALifeSmartTerrainRegistry::OBJECTS::const_iterator E = ai().alife().smart_terrains().objects().end();
     for (; I != E; ++I)

--- a/src/xrServerEntities/xrEProps.h
+++ b/src/xrServerEntities/xrEProps.h
@@ -138,9 +138,9 @@ public:
         PropItemVec& items, shared_str key, float* val, float mn = 0.f, float mx = 86400.f) = 0;
     virtual ShortcutValue* CreateShortcut(PropItemVec& items, shared_str key, xr_shortcut* val) = 0;
 
-    virtual FloatValue* CreateAngle(PropItemVec& items, shared_str key, float* val, float mn = flt_min,
+    virtual FloatValue* CreateAngle(PropItemVec& items, shared_str key, float* val, float mn = flt_lowest,
         float mx = flt_max, float inc = 0.01f, int decim = 2) = 0;
-    virtual VectorValue* CreateAngle3(PropItemVec& items, shared_str key, Fvector* val, float mn = flt_min,
+    virtual VectorValue* CreateAngle3(PropItemVec& items, shared_str key, Fvector* val, float mn = flt_lowest,
         float mx = flt_max, float inc = 0.01f, int decim = 2) = 0;
     virtual RTextValue* CreateName(PropItemVec& items, shared_str key, shared_str* val, ListItem* owner) = 0;
     virtual RTextValue* CreateNameCB(PropItemVec& items, shared_str key, shared_str* val,

--- a/src/xrServerEntities/xrServer_Objects_Alife_Smartcovers.cpp
+++ b/src/xrServerEntities/xrServer_Objects_Alife_Smartcovers.cpp
@@ -194,7 +194,7 @@ Fvector parse_fvector(luabind::object const& table, LPCSTR identifier)
     return (luabind::object_cast<Fvector>(result));
 }
 
-float parse_float(luabind::object const& table, LPCSTR identifier, float const& min_threshold = flt_min,
+float parse_float(luabind::object const& table, LPCSTR identifier, float const& min_threshold = flt_lowest,
     float const& max_threshold = flt_max)
 {
     VERIFY2(luabind::type(table) == LUA_TTABLE, "invalid loophole description passed");


### PR DESCRIPTION
While looking at the code inside `xr_types.h` I've notices some very strange definitions which are used later in the code to define constants.

```cpp
// Type limits
template <typename T>
constexpr auto type_max = std::numeric_limits<T>::max();

template <typename T>
constexpr auto type_min = -std::numeric_limits<T>::max();

template <typename T>
constexpr auto type_zero = std::numeric_limits<T>::min();
```

`type_min` is not the minimum value of integer types it is actually the minimum + 1. This only works for floating point types.
`type_zero` is the actual minimum of a type. But is only 0 for unsigned types. For signed types its a negative value.

Thus we have some very strange constants.

```cpp
constexpr int int_min = type_min<int>;         // actually -2147483647 not -2147483648
constexpr int int_zero = type_zero<int>;       // actually -2147483648 not 0
...
constexpr float flt_zero = type_zero<float>;   // actually 1.175494e-38 not 0.0
...
constexpr double dbl_zero = type_zero<double>; // actually 2.225074e-308 not 0.0
```

Fixes #195
