### PR TITLE
xrCore: Fix spurious assertion failures in `FS::FileDownload` for linux

### DIFF
--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -139,7 +139,7 @@ void* FileDownload(pcstr file_name, const int& file_handle, size_t& file_size)
     do
     {
         const ssize_t r_bytes =
-            _read(file_handle, reinterpret_cast<char*>(buffer) + total_r_bytes, file_size - total_r_bytes);
+            _read(file_handle, reinterpret_cast<u8*>(buffer) + total_r_bytes, file_size - total_r_bytes);
         R_ASSERT3(r_bytes > 0, "Can't read from file : ", file_name);
 
         total_r_bytes += r_bytes;

--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -144,10 +144,10 @@ void* FileDownload(pcstr file_name, const int& file_handle, size_t& file_size)
 
         total_r_bytes += r_bytes;
     } while (total_r_bytes < file_size);
-#elif defined(XR_PLATFORM_BSD) || defined(XR_PLATFORM_WINDOWS) || defined(XR_PLATFORM_APPLE)
+#elif defined(XR_PLATFORM_WINDOWS) || defined(XR_PLATFORM_BSD) || defined(XR_PLATFORM_APPLE)
     int total_r_bytes = _read(file_handle, buffer, file_size);
 #else
-#error Select or add implementation for your platform
+#   error Select or add implementation for your platform
 #endif
     R_ASSERT3(total_r_bytes == file_size, "Can't read from file : ", file_name);
 

--- a/src/xrCore/FS.cpp
+++ b/src/xrCore/FS.cpp
@@ -131,13 +131,25 @@ bool file_handle_internal(pcstr file_name, size_t& size, int& file_handle)
 
 void* FileDownload(pcstr file_name, const int& file_handle, size_t& file_size)
 {
+    VERIFY(file_size != 0);
     void* buffer = xr_malloc(file_size);
 
-    int r_bytes = _read(file_handle, buffer, file_size);
-    R_ASSERT3(
-        // !file_size ||
-        // (r_bytes && (file_size >= (u32)r_bytes)),
-        file_size == (u32)r_bytes, "can't read from file : ", file_name);
+#ifdef XR_PLATFORM_LINUX
+    size_t total_r_bytes = 0;
+    do
+    {
+        const ssize_t r_bytes =
+            _read(file_handle, reinterpret_cast<char*>(buffer) + total_r_bytes, file_size - total_r_bytes);
+        R_ASSERT3(r_bytes > 0, "Can't read from file : ", file_name);
+
+        total_r_bytes += r_bytes;
+    } while (total_r_bytes < file_size);
+#elif defined(XR_PLATFORM_BSD) || defined(XR_PLATFORM_WINDOWS) || defined(XR_PLATFORM_APPLE)
+    int total_r_bytes = _read(file_handle, buffer, file_size);
+#else
+#error Select or add implementation for your platform
+#endif
+    R_ASSERT3(total_r_bytes == file_size, "Can't read from file : ", file_name);
 
     // file_size = r_bytes;
 


### PR DESCRIPTION
This was caused by a misuse of the `read` function which was called only once and expected to read the entire `file_size` this is however not correct.

To quote the [man page](https://man7.org/linux/man-pages/man2/read.2.html)

> RETURN VALUE
>
> On success, the number of bytes read is returned (zero indicates
> end of file), and the file position is advanced by this number.
> **It is not an error if this number is smaller than the number of
> bytes requested; this may happen for example because fewer bytes
> are actually available right now (maybe because we were close to
> end-of-file, or because we are reading from a pipe, or from a
> terminal), or because read() was interrupted by a signal.**

Note all other platforms we support do guarantee to read the entire buffer.
- [apple](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/read.2.html)
- [bsd](man.freebsd.org/cgi/man.cgi?read(2))
- [windows](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/read)