### PR TITLE
Fixed get count threads for multiprocessor system with NUMA architecture 

### DIFF
--- a/src/xrCore/Debug/MiniDump.cpp
+++ b/src/xrCore/Debug/MiniDump.cpp
@@ -126,6 +126,7 @@ WriteMiniDumpResult __stdcall WriteMiniDumpW(
     if ((HANDLE)-1 != hThread)
     {
         // The thread is running.  Block until the thread ends.
+        CPU::setThreadAffinityAllGroupCores(hThread);
         WaitForSingleObject(hThread, INFINITE);
         CloseHandle(hThread);
     }

--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -218,7 +218,7 @@ TaskManager::TaskManager()
     s_main_thread_worker = &s_tl_worker;
     s_main_thread_worker->id = 0;
 
-    const u32 threads = std::thread::hardware_concurrency() - OTHER_THREADS_COUNT;
+    const u32 threads = CPU::GetThreadsCounts() - OTHER_THREADS_COUNT;
     workers.reserve(threads);
     for (u32 i = 0; i < threads; ++i)
     {

--- a/src/xrCore/Threading/ThreadUtil.cpp
+++ b/src/xrCore/Threading/ThreadUtil.cpp
@@ -84,6 +84,7 @@ bool SpawnThread(EntryFuncType entry, pcstr name, u32 stack, void* arglist)
         return false;
     }
 
+    CPU::setThreadAffinityAllGroupCores(threadHandle);
     ResumeThread(threadHandle);
     return true;
 }

--- a/src/xrCore/_math.h
+++ b/src/xrCore/_math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "xr_types.h"
+#include <thread>
 
 namespace FPU
 {
@@ -22,6 +23,11 @@ XRCORE_API extern u32 qpc_counter;
 XRCORE_API extern u64 QPC() noexcept;
 
 XRCORE_API u32 GetTicks();
+
+// GermanAizek: This implementation supports both conventional single-cpu PC configurations
+//              and multi-cpu system on NUMA (Non-uniform_memory_access) architecture
+XRCORE_API size_t GetThreadsCounts() noexcept;
+XRCORE_API void setThreadAffinityAllGroupCores(HANDLE handle) noexcept;
 }
 
 extern XRCORE_API void _initialize_cpu();


### PR DESCRIPTION
Fixed very old problem that only on any Windows NT and modern Windows Server 😆 

https://developercommunity.visualstudio.com/t/hardware-concurrency-returns-an-incorrect-result/350854

https://stackoverflow.com/questions/31209256/reliable-way-to-programmatically-get-the-number-of-hardware-threads-on-windows

Why this commit is useful not only for server configurations, now a very cheap PC configuration is building from Xeon E54xx, X34xx, E3-xxxx, E5-xxxx, E7-xxx, any Silver, any Gold, any Platinum series, cheapest on LGA 2011v3 socket two-socket board with NUMA support is cheap on Aliexpress, Baidu or Alibaba.

https://aliexpress.ru/item/1005004510711777.html