### PR TITLE
GitHub Actions: Allow dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - External (3rd party)
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  labels:
+  - External (3rd party)


### PR DESCRIPTION
Dependabot is also able to automatically update the GitHub actions we use so why not :^)