### PR TITLE
Make player hud tuner slightly more usable

### DIFF
--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -456,7 +456,7 @@ bool CDemoRecord::ProcessCam(SCamEffectorInfo& info)
 
 void CDemoRecord::IR_OnKeyboardPress(int dik)
 {
-    if (dik == SDL_SCANCODE_KP_MULTIPLY)
+    if (dik == SDL_SCANCODE_PERIOD)
         m_b_redirect_input_to_level = !m_b_redirect_input_to_level;
 
     if (m_b_redirect_input_to_level)

--- a/src/xrGame/player_hud_tune.cpp
+++ b/src/xrGame/player_hud_tune.cpp
@@ -293,10 +293,10 @@ void player_hud::tune(Ivector _values)
     else if (hud_adj_mode == 8 || hud_adj_mode == 9)
     {
         if (hud_adj_mode == 8 && (values.z))
-            _delta_pos += (values.z > 0) ? 0.001f : -0.001f;
+            _delta_pos += (values.z > 0) ? _delta_pos * 0.1f : _delta_pos * -0.1f;
 
         if (hud_adj_mode == 9 && (values.z))
-            _delta_rot += (values.z > 0) ? 0.1f : -0.1f;
+            _delta_rot += (values.z > 0) ? _delta_rot * .1f : _delta_rot * -0.1f;
     }
     else
     {


### PR DESCRIPTION
- Delta pos / delta rot can no longer flip signs, instead they are incremented by a percentage of the current value. This allows for more fine-tune adjustments while making it easier to control the deltas. 
- `SDL_SCANCODE_KP_MULTIPLY` doesn't exist on all keyboards, so switched it to `SDL_SCANCODE_PERIOD` to make level input redirection easier to use. This is so we can move the camera around while using the hud tuner, by using the demo_record functionality.