### PR TITLE
xrCore: Mark functions as `[[noreturn]]`

### DIFF
--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -565,6 +565,7 @@ AssertionResult xrDebug::Fail(bool& ignoreAlways, const ErrorLocation& loc, cons
     return Fail(ignoreAlways, loc, expr, desc.c_str(), arg1, arg2);
 }
 
+[[noreturn]]
 void xrDebug::DoExit(const std::string& message)
 {
     ScopeLock lock(&failLock);
@@ -848,6 +849,7 @@ LONG WINAPI xrDebug::UnhandledFilter(EXCEPTION_POINTERS* exPtrs)
 }
 
 #ifndef USE_BUG_TRAP
+[[noreturn]]
 void _terminate()
 {
 #if defined(XR_PLATFORM_WINDOWS)

--- a/src/xrCore/xrDebug.h
+++ b/src/xrCore/xrDebug.h
@@ -113,6 +113,7 @@ public:
                      const char* desc = "assertion failed", const char* arg1 = nullptr, const char* arg2 = nullptr);
     static AssertionResult Fail(bool& ignoreAlways, const ErrorLocation& loc, const char* expr, const std::string& desc,
                      const char* arg1 = nullptr, const char* arg2 = nullptr);
+    [[noreturn]]
     static void DoExit(const std::string& message);
 
     static AssertionResult ShowMessage(pcstr title, pcstr message, bool simpleMode = true);


### PR DESCRIPTION
Since they call `exit` we can safely mark them as `noreturn` to help static analyzers.