### PR TITLE
Disable address sanitizer by default for debug builds with MSVC

### DIFF
--- a/src/xray_build.props
+++ b/src/xray_build.props
@@ -49,7 +49,6 @@
   <!-- Common debug settings -->
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-	<EnableASAN>true</EnableASAN>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes #1531 