### PR TITLE
Rewrite of `CInifile`

### DIFF
--- a/src/Layers/xrRender/ModelPool.cpp
+++ b/src/Layers/xrRender/ModelPool.cpp
@@ -425,7 +425,7 @@ void CModelPool::Prefetch()
     for (auto I = sect.Data.cbegin(); I != sect.Data.cend(); ++I)
     {
         const CInifile::Item& item = *I;
-        dxRender_Visual* V = Create(item.first.c_str());
+        dxRender_Visual* V = Create(item.name.c_str());
         Delete(V, FALSE);
     }
     Logging(TRUE);

--- a/src/Layers/xrRender/Texture.cpp
+++ b/src/Layers/xrRender/Texture.cpp
@@ -27,7 +27,7 @@ bool is_enough_address_space_available() { return true; }
 
 int get_texture_load_lod(LPCSTR fn)
 {
-    CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
+    const CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
     auto it_ = sect.Data.cbegin();
     auto it_e_ = sect.Data.cend();
 
@@ -38,7 +38,7 @@ int get_texture_load_lod(LPCSTR fn)
 
     for (; it != it_e; ++it)
     {
-        if (strstr(fn, it->first.c_str()))
+        if (strstr(fn, it->name.c_str()))
         {
             if (psTextureLOD < 1)
             {

--- a/src/Layers/xrRender/TextureDescrManager.cpp
+++ b/src/Layers/xrRender/TextureDescrManager.cpp
@@ -53,11 +53,11 @@ void CTextureDescrMngr::LoadLTX(pcstr initial, bool listTHM)
         const auto processAssociation = [&](const CInifile::Item& item)
         {
             if (listTHM)
-                Msg("\t\t%s = %s", item.first.c_str(), item.second.c_str());
+                Msg("\t\t%s = %s", item.name.c_str(), item.value.c_str());
 
             lock.Enter();
-            texture_desc& desc = m_texture_details[item.first];
-            cl_dt_scaler*& dts = m_detail_scalers[item.first];
+            texture_desc& desc = m_texture_details[item.name];
+            cl_dt_scaler*& dts = m_detail_scalers[item.name];
             lock.Leave();
 
             if (desc.m_assoc)
@@ -68,19 +68,19 @@ void CTextureDescrMngr::LoadLTX(pcstr initial, bool listTHM)
             string_path T;
             float s;
 
-            const int res = sscanf(*item.second, "%[^,],%f", T, &s);
-            R_ASSERT4(res == 2, "Bad texture association", item.first.c_str(), fname);
+            const int res = sscanf(*item.value, "%[^,],%f", T, &s);
+            R_ASSERT4(res == 2, "Bad texture association", item.name.c_str(), fname);
             desc.m_assoc->detail_name = T;
             if (dts)
                 dts->scale = s;
             else
                 dts = xr_new<cl_dt_scaler>(s);
 
-            if (strstr(item.second.c_str(), "usage[diffuse_or_bump]"))
+            if (strstr(item.value.c_str(), "usage[diffuse_or_bump]"))
                 desc.m_assoc->usage.set(texture_assoc::flDiffuseDetail | texture_assoc::flBumpDetail);
-            else if (strstr(item.second.c_str(), "usage[bump]"))
+            else if (strstr(item.value.c_str(), "usage[bump]"))
                 desc.m_assoc->usage.set(texture_assoc::flBumpDetail);
-            else if (strstr(item.second.c_str(), "usage[diffuse]"))
+            else if (strstr(item.value.c_str(), "usage[diffuse]"))
                 desc.m_assoc->usage.set(texture_assoc::flDiffuseDetail);
         };
         xr_parallel_for_each(data.Data, processAssociation);
@@ -97,10 +97,10 @@ void CTextureDescrMngr::LoadLTX(pcstr initial, bool listTHM)
         const auto processSpecification = [&](const CInifile::Item& item)
         {
             if (listTHM)
-                Msg("\t\t%s = %s", item.first.c_str(), item.second.c_str());
+                Msg("\t\t%s = %s", item.name.c_str(), item.value.c_str());
 
             lock.Enter();
-            texture_desc& desc = m_texture_details[item.first];
+            texture_desc& desc = m_texture_details[item.name];
             lock.Leave();
 
             if (desc.m_spec)
@@ -110,8 +110,8 @@ void CTextureDescrMngr::LoadLTX(pcstr initial, bool listTHM)
 
             string_path bmode;
             const int res =
-                    sscanf(item.second.c_str(), "bump_mode[%[^]]], material[%f]", bmode, &desc.m_spec->m_material);
-            R_ASSERT4(res == 2, "Bad texture specification", item.first.c_str(), fname);
+                    sscanf(item.value.c_str(), "bump_mode[%[^]]], material[%f]", bmode, &desc.m_spec->m_material);
+            R_ASSERT4(res == 2, "Bad texture specification", item.name.c_str(), fname);
             if ((bmode[0] == 'u') && (bmode[1] == 's') && (bmode[2] == 'e') && (bmode[3] == ':'))
             {
                 // bump-map specified

--- a/src/Layers/xrRenderDX11/dx11Texture.cpp
+++ b/src/Layers/xrRenderDX11/dx11Texture.cpp
@@ -17,7 +17,7 @@ void fix_texture_name(pstr fn)
 
 int get_texture_load_lod(LPCSTR fn)
 {
-    CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
+    const CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
     auto it_ = sect.Data.cbegin();
     auto it_e_ = sect.Data.cend();
 
@@ -29,7 +29,7 @@ int get_texture_load_lod(LPCSTR fn)
 
     for (; it != it_e; ++it)
     {
-        if (strstr(fn, it->first.c_str()))
+        if (strstr(fn, it->name.c_str()))
         {
             if (psTextureLOD < 1)
             {

--- a/src/Layers/xrRenderGL/glTexture.cpp
+++ b/src/Layers/xrRenderGL/glTexture.cpp
@@ -21,11 +21,11 @@ void fix_texture_name(pstr fn)
 
 int get_texture_load_lod(LPCSTR fn)
 {
-    CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
+    const CInifile::Sect& sect = pSettings->r_section("reduce_lod_texture_list");
 
     for (const auto& item : sect.Data)
     {
-        if (strstr(fn, item.first.c_str()))
+        if (strstr(fn, item.name.c_str()))
         {
             if (psTextureLOD < 1)
                 return 0;

--- a/src/utils/mp_configs_verifyer/configs_dump_verifyer.cpp
+++ b/src/utils/mp_configs_verifyer/configs_dump_verifyer.cpp
@@ -93,17 +93,17 @@ LPCSTR configs_verifyer::get_section_diff(CInifile::Sect* sect_ptr, CInifile& ac
 
     for (auto cit = sect_ptr->Data.cbegin(), ciet = sect_ptr->Data.cend(); cit != ciet; ++cit)
     {
-        shared_str const& tmp_value = cit->second;
+        shared_str const& tmp_value = cit->value;
         shared_str real_value;
         if (tmp_active_param)
         {
-            if (active_params.line_exist(sect_ptr->Name.c_str(), cit->first))
+            if (active_params.line_exist(sect_ptr->Name.c_str(), cit->name))
             {
-                real_value = active_params.r_string(sect_ptr->Name.c_str(), cit->first.c_str());
+                real_value = active_params.r_string(sect_ptr->Name.c_str(), cit->name.c_str());
                 if (tmp_value != real_value)
                 {
                     pcstr tmp_key_str = nullptr;
-                    STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->first.c_str());
+                    STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->name.c_str());
                     STRCONCAT(diff_str, tmp_key_str, " = ", tmp_value.c_str(), ",right = ", real_value.c_str());
                     strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
                     dst_diff[sizeof(dst_diff) - 1] = 0;
@@ -112,18 +112,18 @@ LPCSTR configs_verifyer::get_section_diff(CInifile::Sect* sect_ptr, CInifile& ac
                 continue;
             }
         }
-        if (!pSettings->line_exist(sect_ptr->Name, cit->first))
+        if (!pSettings->line_exist(sect_ptr->Name, cit->name))
         {
-            STRCONCAT(diff_str, "line ", sect_ptr->Name.c_str(), "::", cit->first.c_str(), " not found");
+            STRCONCAT(diff_str, "line ", sect_ptr->Name.c_str(), "::", cit->name.c_str(), " not found");
             strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
             dst_diff[sizeof(dst_diff) - 1] = 0;
             return dst_diff;
         }
-        real_value = pSettings->r_string(sect_ptr->Name.c_str(), cit->first.c_str());
+        real_value = pSettings->r_string(sect_ptr->Name.c_str(), cit->name.c_str());
         if (tmp_value != real_value)
         {
             pcstr tmp_key_str = nullptr;
-            STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->first.c_str());
+            STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->name.c_str());
             STRCONCAT(diff_str, tmp_key_str, " = ", tmp_value.c_str(), ",right = ", real_value.c_str());
             strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
             dst_diff[sizeof(dst_diff) - 1] = 0;

--- a/src/utils/mp_configs_verifyer/mp_config_sections.cpp
+++ b/src/utils/mp_configs_verifyer/mp_config_sections.cpp
@@ -39,9 +39,9 @@ bool mp_config_sections::dump_one(CMemoryWriter& dest)
         return false;
 
     R_ASSERT(pSettings->section_exist(m_current_dump_sect->c_str()));
-    CInifile::Sect& tmp_sect = pSettings->r_section(m_current_dump_sect->c_str());
+    const CInifile::Sect& tmp_sect = pSettings->r_section(m_current_dump_sect->c_str());
 
-    m_tmp_dumper.sections().push_back(&tmp_sect);
+    m_tmp_dumper.sections().push_back(const_cast<CInifile::Sect*>(&tmp_sect));
     m_tmp_dumper.save_as(dest);
     m_tmp_dumper.sections().pop_back();
     ++m_current_dump_sect;

--- a/src/utils/xrCompress/xrCompress.cpp
+++ b/src/utils/xrCompress/xrCompress.cpp
@@ -320,7 +320,7 @@ void xrCompressor::OpenPack(LPCSTR tgt_folder, int num)
         W.w_string(buff);
         for (const auto& it : S.Data)
         {
-            xr_sprintf(buff, "%s = %s", it.first.c_str(), it.second.c_str());
+            xr_sprintf(buff, "%s = %s", it.name.c_str(), it.value.c_str());
             W.w_string(buff);
         }
         W.seek(0);
@@ -470,15 +470,15 @@ bool xrCompressor::IsFolderAccepted(const CInifile& ltx, LPCSTR path, bool& recu
         const auto& ef_sect = ltx.r_section("exclude_folders");
         for (const auto& it : ef_sect.Data)
         {
-            recurse = CInifile::isBool(it.second.c_str());
+            recurse = CInifile::isBool(it.value.c_str());
             if (recurse)
             {
-                if (path == strstr(path, it.first.c_str()))
+                if (path == strstr(path, it.name.c_str()))
                     return false;
             }
             else
             {
-                if (0 == xr_strcmp(path, it.first.c_str()))
+                if (0 == xr_strcmp(path, it.name.c_str()))
                     return false;
             }
         }
@@ -501,11 +501,11 @@ void xrCompressor::ProcessLTX(CInifile& ltx)
         const CInifile::Sect& if_sect = ltx.r_section("include_folders");
         for (const auto& it : if_sect.Data)
         {
-            const BOOL ifRecurse = CInifile::isBool(it.second.c_str());
+            const BOOL ifRecurse = CInifile::isBool(it.value.c_str());
             const u32 folder_mask = FS_ListFolders | (ifRecurse ? 0 : FS_RootOnly);
 
             string_path path;
-            const LPCSTR _path = 0 == xr_strcmp(it.first.c_str(), ".\\") ? "" : it.first.c_str();
+            const LPCSTR _path = 0 == xr_strcmp(it.name.c_str(), ".\\") ? "" : it.name.c_str();
             xr_strcpy(path, _path);
             const size_t path_len = xr_strlen(path);
             if ((0 != path_len) && (path[path_len - 1] != '\\'))
@@ -556,7 +556,7 @@ void xrCompressor::ProcessLTX(CInifile& ltx)
     {
         const CInifile::Sect& if_sect = ltx.r_section("include_files");
         for (const auto& it : if_sect.Data)
-            files_list->push_back(xr_strdup(it.first.c_str()));
+            files_list->push_back(xr_strdup(it.name.c_str()));
     }
 
     PerformWork();

--- a/src/xrCore/Animation/SkeletonMotions.cpp
+++ b/src/xrCore/Animation/SkeletonMotions.cpp
@@ -52,13 +52,13 @@ void CPartition::load(IKinematics* V, LPCSTR model_name)
         for (; it != it_e; ++it)
         {
             const CInifile::Item& I = *it;
-            if (I.first == part_name)
+            if (I.name == part_name)
             {
-                P[i].Name = I.second;
+                P[i].Name = I.value;
             }
             else
             {
-                u32 bid = V->LL_BoneID(I.first.c_str());
+                u32 bid = V->LL_BoneID(I.name.c_str());
                 P[i].bones.push_back(bid);
             }
         }

--- a/src/xrCore/CMakeLists.txt
+++ b/src/xrCore/CMakeLists.txt
@@ -346,6 +346,14 @@ target_sources_grouped(
 
 target_sources_grouped(
     TARGET xrCore
+    NAME "Parsing"
+    FILES
+    ParsingUtils.cpp
+    ParsingUtils.hpp
+)
+
+target_sources_grouped(
+    TARGET xrCore
     NAME "PCH"
     FILES
     stdafx.cpp

--- a/src/xrCore/ParsingUtils.cpp
+++ b/src/xrCore/ParsingUtils.cpp
@@ -1,0 +1,95 @@
+#include "stdafx.h"
+
+#include "ParsingUtils.hpp"
+
+ParseIncludeResult ParseInclude(pstr string, pcstr& out_include_name)
+{
+    VERIFY(string);
+
+    // Skip any whitespace characters
+    string = ParseAllSpaces(string);
+
+    // Check for #include
+    static constexpr pcstr IncludeTag = "#include";
+    if (std::strncmp(string, IncludeTag, 8) != 0)
+        return ParseIncludeResult::NoInclude;
+
+    string += 8;
+
+    // Skip any whitespace characters
+    string = ParseAllSpaces(string);
+
+    // Check that after the tag there is a quote
+    if (*string != '\"')
+        return ParseIncludeResult::Error;
+
+    // Mark the start of the include name
+    ++string;
+    out_include_name = string;
+
+    string = ParseUntil(string, '\"');
+
+    // Check for unterminated or empty include name
+    if (*string == '\0' || out_include_name == string)
+        return ParseIncludeResult::Error;
+
+    // Check for unreasonably long include names
+    const size_t size = string - out_include_name;
+    if (size > 1024)
+        return ParseIncludeResult::Error;
+
+    // NOTE(Andre): Yes this might look scary but it's perfectly fine. Since the include name is already in the string
+    // we are parsing and its not used afterwards we simply replace the closing quote with a null byte and we have a
+    // valid c-string pointed to by 'out_include_name' and safe ourselves the need to copy the string.
+    *string = '\0';
+
+    return ParseIncludeResult::Success;
+}
+
+pcstr ParseAllSpaces(pcstr string)
+{
+    VERIFY(string);
+
+    while (*string != '\0' && std::isspace(*string))
+        ++string;
+
+    return string;
+}
+
+pstr ParseAllSpaces(pstr string) { return const_cast<pstr>(ParseAllSpaces(reinterpret_cast<pcstr>(string))); }
+
+pcstr ParseUntil(pcstr string, const char character)
+{
+    VERIFY(string);
+
+    while (*string != '\0' && *string != character)
+        ++string;
+
+    return string;
+}
+
+pstr ParseUntil(pstr string, const char character)
+{
+    return const_cast<pstr>(ParseUntil(reinterpret_cast<pcstr>(string), character));
+}
+
+void StringCopyLowercase(pstr destination, pcstr src, std::size_t size)
+{
+    VERIFY(destination);
+    VERIFY(src);
+
+    for (std::size_t i = 0; *src != '\0' && i < size; ++i)
+    {
+        *destination = std::tolower(*src);
+        ++src;
+        ++destination;
+    }
+
+    // Ensure the string is null-terminated
+    *destination = '\0';
+}
+
+void StringCopyLowercase(pstr destination, shared_str src, std::size_t size)
+{
+    StringCopyLowercase(destination, *src, size);
+}

--- a/src/xrCore/ParsingUtils.hpp
+++ b/src/xrCore/ParsingUtils.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "xr_types.h"
+#include "xrstring.h"
+
+enum class ParseIncludeResult
+{
+    Success,   /// There is a valid #include and 'out_include_name' contains the filename
+    Error,     /// There is a #include but there is some problem
+    NoInclude, /// There is no #include on this line
+};
+
+// Given a string of the form: '#include "filename"' we try to parse filename into 'out_include_name'
+// Note that the file name is parsed inplace to avoid copying the string
+ParseIncludeResult ParseInclude(pstr string, pcstr& out_include_name);
+
+// Starting from the beginning of the string skips all characters for which 'std::isspace' is 'true'.
+// Returns the first position where 'std::isspace' is 'false'.
+pcstr ParseAllSpaces(pcstr string);
+
+pstr ParseAllSpaces(pstr string);
+
+// Starting from the begging of the string skips all characters until 'character' is found
+// or until the end of the string is reached.
+// Returns the first position where 'character' is found or the end of string if 'character' is not found
+pcstr ParseUntil(pcstr string, const char character);
+
+pstr ParseUntil(pstr string, const char character);
+
+// Copies 'size' characters from 'src' to 'destination' and converts it to lowercase
+void StringCopyLowercase(pstr destination, pcstr src, std::size_t size);
+
+void StringCopyLowercase(pstr destination, shared_str src, std::size_t size);

--- a/src/xrCore/xrCore.vcxproj
+++ b/src/xrCore/xrCore.vcxproj
@@ -80,6 +80,7 @@ call .GitInfo.cmd</Command>
     <ClCompile Include="Memory\xrMemory_align.cpp" />
     <ClCompile Include="NET_utils.cpp" />
     <ClCompile Include="os_clipboard.cpp" />
+    <ClCompile Include="ParsingUtils.cpp" />
     <ClCompile Include="PostProcess\PostProcess.cpp" />
     <ClCompile Include="PostProcess\PPInfo.cpp" />
     <ClCompile Include="stdafx.cpp">
@@ -184,6 +185,7 @@ call .GitInfo.cmd</Command>
     <ClInclude Include="Memory\xrMemory_align.h" />
     <ClInclude Include="net_utils.h" />
     <ClInclude Include="os_clipboard.h" />
+    <ClInclude Include="ParsingUtils.hpp" />
     <ClInclude Include="PostProcess\PostProcess.hpp" />
     <ClInclude Include="PostProcess\PPInfo.hpp" />
     <ClInclude Include="resource.h" />

--- a/src/xrCore/xrCore.vcxproj.filters
+++ b/src/xrCore/xrCore.vcxproj.filters
@@ -118,6 +118,9 @@
     <Filter Include="Threading\Util">
       <UniqueIdentifier>{14c94737-f2c7-482d-9033-775a3da068cb}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Parsing">
+      <UniqueIdentifier>{3116121d-205f-4de2-be5a-da1dbf9919e7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FTimer.cpp">
@@ -326,6 +329,9 @@
     </ClCompile>
     <ClCompile Include="_cylinder.cpp">
       <Filter>Math</Filter>
+    </ClCompile>
+    <ClCompile Include="ParsingUtils.cpp">
+      <Filter>Parsing</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -703,6 +709,9 @@
     </ClInclude>
     <ClInclude Include="Threading\ParallelForEach.hpp">
       <Filter>Threading</Filter>
+    </ClInclude>
+    <ClInclude Include="ParsingUtils.hpp">
+      <Filter>Parsing</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/xrEngine/IGame_ObjectPool.cpp
+++ b/src/xrEngine/IGame_ObjectPool.cpp
@@ -20,11 +20,11 @@ void IGame_ObjectPool::prefetch()
     CInifile::Sect const& sect = pSettings->r_section(section);
     for (const auto& item : sect.Data)
     {
-        CLASS_ID CLS = pSettings->r_clsid(item.first.c_str(), "class");
+        CLASS_ID CLS = pSettings->r_clsid(item.name.c_str(), "class");
         p_count++;
         IGameObject* pObject = smart_cast<IGameObject*>(NEW_INSTANCE(CLS));
-        pObject->Load(item.first.c_str());
-        VERIFY2(pObject->cNameSect().c_str(), item.first.c_str());
+        pObject->Load(item.name.c_str());
+        VERIFY2(pObject->cNameSect().c_str(), item.name.c_str());
         m_PrefetchObjects.push_back(pObject);
     }
 

--- a/src/xrEngine/x_ray.cpp
+++ b/src/xrEngine/x_ray.cpp
@@ -131,11 +131,9 @@ void InitSettings()
     CInifile::allow_include_func_t includeFilter;
     includeFilter.bind(&includePred, &PathIncludePred::IsIncluded);
 
-    InitConfig(pSettings, "system.ltx");
-    InitConfig(pSettingsAuth, "system.ltx", true, true, true, false, 0, includeFilter);
     InitConfig(pSettingsOpenXRay, "openxray.ltx", false, true, true, false);
-    InitConfig(pGameIni, "game.ltx");
 
+    // Determine game mode
     if (strstr(Core.Params, "-shoc") || strstr(Core.Params, "-soc"))
         set_shoc_mode();
     else if (strstr(Core.Params, "-cs"))
@@ -156,6 +154,13 @@ void InitSettings()
         else if (xr_strcmpi("unlock", gameMode) == 0)
             set_free_mode();
     }
+
+    ltx_multiline_values_enabled =
+        pSettingsOpenXRay->read_if_exists<bool>("compatibility", "ltx_multiline_values", !ShadowOfChernobylMode);
+
+    InitConfig(pSettings, "system.ltx");
+    InitConfig(pSettingsAuth, "system.ltx", true, true, true, false, 0, includeFilter);
+    InitConfig(pGameIni, "game.ltx");
 }
 
 void InitConsole()

--- a/src/xrGame/BoneProtections.cpp
+++ b/src/xrGame/BoneProtections.cpp
@@ -47,30 +47,30 @@ void SBoneProtections::reload(const shared_str& bone_sect, IKinematics* kinemati
     m_default.armor = 0.0f;
     m_default.BonePassBullet = FALSE;
 
-    CInifile::Sect& protections = pSettings->r_section(bone_sect);
+    const CInifile::Sect& protections = pSettings->r_section(bone_sect);
     for (auto i = protections.Data.cbegin(); protections.Data.cend() != i; ++i)
     {
         string256 buffer;
 
         BoneProtection BP;
 
-        BP.koeff = (float)atof(_GetItem(i->second.c_str(), 0, buffer));
-        BP.armor = (float)atof(_GetItem(i->second.c_str(), 1, buffer));
-        BP.BonePassBullet = (bool)(atof(_GetItem(i->second.c_str(), 2, buffer)) > 0.5f);
+        BP.koeff = (float)atof(_GetItem(i->value.c_str(), 0, buffer));
+        BP.armor = (float)atof(_GetItem(i->value.c_str(), 1, buffer));
+        BP.BonePassBullet = (bool)(atof(_GetItem(i->value.c_str(), 2, buffer)) > 0.5f);
 
-        if (!xr_strcmp(i->first.c_str(), "default"))
+        if (!xr_strcmp(i->name.c_str(), "default"))
         {
             m_default = BP;
         }
         else
         {
-            if (!xr_strcmp(i->first.c_str(), "hit_fraction"))
+            if (!xr_strcmp(i->name.c_str(), "hit_fraction"))
                 continue;
 
-            s16 bone_id = kinematics->LL_BoneID(i->first);
+            s16 bone_id = kinematics->LL_BoneID(i->name);
             // TODO: fix that warning
             // warning: result of comparison of constant 65535 with expression of type 's16' (aka 'short') is always true
-            R_ASSERT2(BI_NONE != bone_id, i->first.c_str());
+            R_ASSERT2(BI_NONE != bone_id, i->name.c_str());
             m_bones_koeff.insert(std::make_pair(bone_id, BP));
         }
     }
@@ -90,28 +90,28 @@ void SBoneProtections::add(const shared_str& bone_sect, IKinematics* kinematics)
     }
     m_fHitFracNpc += READ_IF_EXISTS(pSettings, r_float, bone_sect.c_str(), "hit_fraction_npc", defaultHitFraction);
 
-    CInifile::Sect& protections = pSettings->r_section(bone_sect);
+    const CInifile::Sect& protections = pSettings->r_section(bone_sect);
     for (auto i = protections.Data.cbegin(); protections.Data.cend() != i; ++i)
     {
-        if (!xr_strcmp(i->first.c_str(), "hit_fraction"))
+        if (!xr_strcmp(i->name.c_str(), "hit_fraction"))
             continue;
 
         string256 buffer;
-        if (!xr_strcmp(i->first.c_str(), "default"))
+        if (!xr_strcmp(i->name.c_str(), "default"))
         {
             BoneProtection& BP = m_default;
-            BP.koeff += (float)atof(_GetItem(i->second.c_str(), 0, buffer));
-            BP.armor += (float)atof(_GetItem(i->second.c_str(), 1, buffer));
+            BP.koeff += (float)atof(_GetItem(i->value.c_str(), 0, buffer));
+            BP.armor += (float)atof(_GetItem(i->value.c_str(), 1, buffer));
         }
         else
         {
-            s16 bone_id = kinematics->LL_BoneID(i->first);
+            s16 bone_id = kinematics->LL_BoneID(i->name);
             // TODO: fix that warning
             // warning: result of comparison of constant 65535 with expression of type 's16' (aka 'short') is always true
-            R_ASSERT2(BI_NONE != bone_id, i->first.c_str());
+            R_ASSERT2(BI_NONE != bone_id, i->name.c_str());
             BoneProtection& BP = m_bones_koeff[bone_id];
-            BP.koeff += (float)atof(_GetItem(i->second.c_str(), 0, buffer));
-            BP.armor += (float)atof(_GetItem(i->second.c_str(), 1, buffer));
+            BP.koeff += (float)atof(_GetItem(i->value.c_str(), 0, buffer));
+            BP.armor += (float)atof(_GetItem(i->value.c_str(), 1, buffer));
         }
     }
 }

--- a/src/xrGame/Car.cpp
+++ b/src/xrGame/Car.cpp
@@ -949,17 +949,17 @@ void CCar::Init()
         for (auto I = data.Data.cbegin(); I != data.Data.cend(); ++I)
         {
             const CInifile::Item& item = *I;
-            u16 index = pKinematics->LL_BoneID(*item.first);
-            R_ASSERT3(index != BI_NONE, "Wrong bone name", *item.first);
+            u16 index = pKinematics->LL_BoneID(*item.name);
+            R_ASSERT3(index != BI_NONE, "Wrong bone name", *item.name);
             xr_map<u16, SWheel>::iterator i = m_wheels_map.find(index);
 
             if (i != m_wheels_map.end())
-                i->second.CDamagableHealthItem::Init(float(atof(*item.second)), 2);
+                i->second.CDamagableHealthItem::Init(float(atof(*item.value)), 2);
             else
             {
                 xr_map<u16, SDoor>::iterator i = m_doors.find(index);
-                R_ASSERT3(i != m_doors.end(), "only wheel and doors bones allowed for damage defs", *item.first);
-                i->second.CDamagableHealthItem::Init(float(atof(*item.second)), 1);
+                R_ASSERT3(i != m_doors.end(), "only wheel and doors bones allowed for damage defs", *item.name);
+                i->second.CDamagableHealthItem::Init(float(atof(*item.value)), 1);
             }
         }
     }

--- a/src/xrGame/ContextMenu.cpp
+++ b/src/xrGame/ContextMenu.cpp
@@ -22,9 +22,9 @@ void CContextMenu::Load(CInifile* INI, LPCSTR SECT)
         char Event[128], Param[128];
         Event[0] = 0;
         Param[0] = 0;
-        sscanf(*I->second, "%[^,],%s", Event, Param);
+        sscanf(*I->value, "%[^,],%s", Event, Param);
         MenuItem Item;
-        Item.Name = xr_strdup(*I->first);
+        Item.Name = xr_strdup(*I->name);
         Item.Event = Engine.Event.Create(Event);
         Item.Param = xr_strdup(Param);
         Items.push_back(Item);

--- a/src/xrGame/Level_load.cpp
+++ b/src/xrGame/Level_load.cpp
@@ -102,12 +102,12 @@ bool CLevel::Load_GameSpecific_After()
         // loading random (around player) sounds
         if (pSettings->section_exist("sounds_random"))
         {
-            CInifile::Sect& S = pSettings->r_section("sounds_random");
+            const CInifile::Sect& S = pSettings->r_section("sounds_random");
             Sounds_Random.reserve(S.Data.size());
             for (auto I = S.Data.cbegin(); S.Data.cend() != I; ++I)
             {
                 Sounds_Random.push_back(ref_sound());
-                Sounds_Random.back().create(*I->first, st_Effect, sg_SourceType);
+                Sounds_Random.back().create(*I->name, st_Effect, sg_SourceType);
             }
             Sounds_Random_dwNextTime = Device.TimerAsync() + 50000;
             Sounds_Random_Enabled = FALSE;

--- a/src/xrGame/PHCollisionDamageReceiver.cpp
+++ b/src/xrGame/PHCollisionDamageReceiver.cpp
@@ -23,9 +23,9 @@ void CPHCollisionDamageReceiver::Init()
         CInifile::Sect& data = ini->r_section("collision_damage");
         for (const auto& item : data.Data)
         {
-            u16 index = K->LL_BoneID(*item.first);
-            R_ASSERT3(index != BI_NONE, "Wrong bone name", *item.first);
-            BoneInsert(index, float(atof(*item.second)));
+            u16 index = K->LL_BoneID(*item.name);
+            R_ASSERT3(index != BI_NONE, "Wrong bone name", *item.name);
+            BoneInsert(index, float(atof(*item.value)));
             CODEGeom* og = sh->PPhysicsShell()->get_GeomByID(index);
             // R_ASSERT3(og, "collision damage bone has no physics collision", *item.first);
             if (og)

--- a/src/xrGame/PHDestroyable.cpp
+++ b/src/xrGame/PHDestroyable.cpp
@@ -173,8 +173,8 @@ void CPHDestroyable::Load(CInifile* ini, LPCSTR section)
         if (data.Data.size() > 0)
             m_flags.set(fl_destroyable, true);
         for (const auto& I : data.Data)
-            if (I.first.size())
-                m_destroyed_obj_visual_names.push_back(I.first);
+            if (I.name.size())
+                m_destroyed_obj_visual_names.push_back(I.name);
     }
 }
 void CPHDestroyable::Load(LPCSTR section)

--- a/src/xrGame/ParticlesPlayer.cpp
+++ b/src/xrGame/ParticlesPlayer.cpp
@@ -84,10 +84,10 @@ void CParticlesPlayer::LoadParticles(IKinematics* K)
         CInifile::Sect& data = ini->r_section("particle_bones");
         for (const auto& item : data.Data)
         {
-            u16 index = K->LL_BoneID(*item.first);
-            R_ASSERT3(index != BI_NONE, "Particles bone not found", *item.first);
+            u16 index = K->LL_BoneID(*item.name);
+            R_ASSERT3(index != BI_NONE, "Particles bone not found", *item.name);
             Fvector offs;
-            sscanf(*item.second, "%f,%f,%f", &offs.x, &offs.y, &offs.z);
+            sscanf(*item.value, "%f,%f,%f", &offs.x, &offs.y, &offs.z);
             m_Bones.push_back(SBoneInfo(index, offs));
             bone_mask |= u64(1) << u64(index);
         }

--- a/src/xrGame/UIGameCustom.cpp
+++ b/src/xrGame/UIGameCustom.cpp
@@ -387,7 +387,7 @@ void CMapListHelper::LoadMapInfo(const char* cfgName, const xr_string& levelName
             shLevelVer = levelCfg.r_string("map_usage", "ver");
         for (CInifile::Item& kv : levelCfg.r_section("map_usage").Data)
         {
-            const shared_str& gameType = kv.first;
+            const shared_str& gameType = kv.name;
             if (gameType == "ver")
                 continue;
             SGameTypeMaps* suitableLevels = GetMapListInt(gameType);
@@ -430,8 +430,8 @@ void CMapListHelper::Load()
     for (CInifile::Item& weatherDesc : weatherCfg.Data)
     {
         MPWeatherDesc gw;
-        gw.Name = weatherDesc.first;
-        gw.StartTime = weatherDesc.second;
+        gw.Name = weatherDesc.name;
+        gw.StartTime = weatherDesc.value;
         m_weathers.push_back(gw);
     }
     // scan for additional maps

--- a/src/xrGame/ai/monsters/basemonster/base_monster_startup.cpp
+++ b/src/xrGame/ai/monsters/basemonster/base_monster_startup.cpp
@@ -534,9 +534,9 @@ void CBaseMonster::fill_bones_body_parts(LPCSTR body_part, CriticalWoundType wou
     IKinematics* kinematics = smart_cast<IKinematics*>(Visual());
     VERIFY(kinematics);
 
-    CInifile::Sect& body_part_section = pSettings->r_section(body_parts_section);
+    const CInifile::Sect& body_part_section = pSettings->r_section(body_parts_section);
     auto I = body_part_section.Data.cbegin();
     auto E = body_part_section.Data.cend();
     for (; I != E; ++I)
-        m_bones_body_parts.emplace(kinematics->LL_BoneID((*I).first), u32(wound_type));
+        m_bones_body_parts.emplace(kinematics->LL_BoneID((*I).name), u32(wound_type));
 }

--- a/src/xrGame/ai/stalker/ai_stalker.cpp
+++ b/src/xrGame/ai/stalker/ai_stalker.cpp
@@ -1240,11 +1240,11 @@ void CAI_Stalker::fill_bones_body_parts(LPCSTR bone_id, const ECriticalWoundType
     IKinematics* kinematics = smart_cast<IKinematics*>(Visual());
     VERIFY(kinematics);
 
-    CInifile::Sect& body_part_section = pSettings->r_section(body_part_section_id);
+    const CInifile::Sect& body_part_section = pSettings->r_section(body_part_section_id);
     auto I = body_part_section.Data.cbegin();
     auto E = body_part_section.Data.cend();
     for (; I != E; ++I)
-        m_bones_body_parts.emplace(kinematics->LL_BoneID((*I).first), u32(wound_type));
+        m_bones_body_parts.emplace(kinematics->LL_BoneID((*I).name), u32(wound_type));
 }
 
 void CAI_Stalker::on_before_change_team()

--- a/src/xrGame/configs_dump_verifyer.cpp
+++ b/src/xrGame/configs_dump_verifyer.cpp
@@ -89,17 +89,17 @@ LPCSTR configs_verifyer::get_section_diff(CInifile::Sect* sect_ptr, CInifile& ac
 
     for (auto cit = sect_ptr->Data.cbegin(), ciet = sect_ptr->Data.cend(); cit != ciet; ++cit)
     {
-        shared_str const& tmp_value = cit->second;
+        shared_str const& tmp_value = cit->value;
         shared_str real_value;
         if (tmp_active_param)
         {
-            if (active_params.line_exist(sect_ptr->Name.c_str(), cit->first))
+            if (active_params.line_exist(sect_ptr->Name.c_str(), cit->name))
             {
-                real_value = active_params.r_string(sect_ptr->Name.c_str(), cit->first.c_str());
+                real_value = active_params.r_string(sect_ptr->Name.c_str(), cit->name.c_str());
                 if (tmp_value != real_value)
                 {
                     pcstr tmp_key_str = nullptr;
-                    STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->first.c_str());
+                    STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->name.c_str());
                     STRCONCAT(diff_str, tmp_key_str, " = ", tmp_value.c_str(), ",right = ", real_value.c_str());
                     strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
                     dst_diff[sizeof(dst_diff) - 1] = 0;
@@ -108,18 +108,18 @@ LPCSTR configs_verifyer::get_section_diff(CInifile::Sect* sect_ptr, CInifile& ac
                 continue;
             }
         }
-        if (!pSettings->line_exist(sect_ptr->Name, cit->first))
+        if (!pSettings->line_exist(sect_ptr->Name, cit->name))
         {
-            STRCONCAT(diff_str, "line ", sect_ptr->Name.c_str(), "::", cit->first.c_str(), " not found");
+            STRCONCAT(diff_str, "line ", sect_ptr->Name.c_str(), "::", cit->name.c_str(), " not found");
             strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
             dst_diff[sizeof(dst_diff) - 1] = 0;
             return dst_diff;
         }
-        real_value = pSettings->r_string(sect_ptr->Name.c_str(), cit->first.c_str());
+        real_value = pSettings->r_string(sect_ptr->Name.c_str(), cit->name.c_str());
         if (tmp_value != real_value)
         {
             pcstr tmp_key_str = nullptr;
-            STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->first.c_str());
+            STRCONCAT(tmp_key_str, sect_ptr->Name.c_str(), "::", cit->name.c_str());
             STRCONCAT(diff_str, tmp_key_str, " = ", tmp_value.c_str(), ",right = ", real_value.c_str());
             strncpy_s(dst_diff, diff_str, sizeof(dst_diff) - 1);
             dst_diff[sizeof(dst_diff) - 1] = 0;

--- a/src/xrGame/damage_manager.cpp
+++ b/src/xrGame/damage_manager.cpp
@@ -74,25 +74,25 @@ void CDamageManager::load_section(LPCSTR section, CInifile const* ini)
 {
     string32 buffer;
     IKinematics* kinematics = smart_cast<IKinematics*>(m_object->Visual());
-    CInifile::Sect& damages = ini->r_section(section);
+    const CInifile::Sect& damages = ini->r_section(section);
     for (const auto & i : damages.Data)
     {
-        if (xr_strcmp(*i.first, "default"))
+        if (xr_strcmp(*i.name, "default"))
         { // read all except default line
             VERIFY(m_object);
-            int bone = kinematics->LL_BoneID(i.first);
-            R_ASSERT2(BI_NONE != bone, *i.first);
+            int bone = kinematics->LL_BoneID(i.name);
+            R_ASSERT2(BI_NONE != bone, *i.name);
             CBoneInstance& bone_instance = kinematics->LL_GetBoneInstance(u16(bone));
-            bone_instance.set_param(0, (float)atof(_GetItem(*i.second, 0, buffer)));
-            bone_instance.set_param(1, (float)atoi(_GetItem(*i.second, 1, buffer)));
-            bone_instance.set_param(2, (float)atof(_GetItem(*i.second, 2, buffer)));
-            if (_GetItemCount(*i.second) < 4)
+            bone_instance.set_param(0, (float)atof(_GetItem(*i.value, 0, buffer)));
+            bone_instance.set_param(1, (float)atoi(_GetItem(*i.value, 1, buffer)));
+            bone_instance.set_param(2, (float)atof(_GetItem(*i.value, 2, buffer)));
+            if (_GetItemCount(*i.value) < 4)
             {
-                bone_instance.set_param(3, (float)atof(_GetItem(*i.second, 0, buffer)));
+                bone_instance.set_param(3, (float)atof(_GetItem(*i.value, 0, buffer)));
             }
             else
             {
-                bone_instance.set_param(3, (float)atof(_GetItem(*i.second, 3, buffer)));
+                bone_instance.set_param(3, (float)atof(_GetItem(*i.value, 3, buffer)));
             }
             if (0 == bone && (fis_zero(bone_instance.get_param(0)) || fis_zero(bone_instance.get_param(2))))
             {

--- a/src/xrGame/ini_table_loader.h
+++ b/src/xrGame/ini_table_loader.h
@@ -96,22 +96,22 @@ typename CSIni_Table::ITEM_TABLE& CSIni_Table::table()
     m_pTable->resize(table_size);
 
     string64 buffer;
-    CInifile::Sect& table_ini = pSettings->r_section(table_sect);
+    const CInifile::Sect& table_ini = pSettings->r_section(table_sect);
 
     R_ASSERT3(table_ini.Data.size() == table_size, "wrong size for table in section", table_sect);
 
     for (auto i = table_ini.Data.cbegin(); table_ini.Data.cend() != i; ++i)
     {
         typename T_INI_LOADER::index_type cur_index =
-            T_INI_LOADER::IdToIndex((*i).first, type_max<typename T_INI_LOADER::index_type>);
+            T_INI_LOADER::IdToIndex((*i).name, type_max<typename T_INI_LOADER::index_type>);
 
         if (type_max<typename T_INI_LOADER::index_type> == cur_index)
-            xrDebug::Fatal(DEBUG_INFO, "wrong community %s in section [%s]", (*i).first.c_str(), table_sect);
+            xrDebug::Fatal(DEBUG_INFO, "wrong community %s in section [%s]", (*i).name.c_str(), table_sect);
 
         (*m_pTable)[cur_index].resize(cur_table_width);
         for (size_t j = 0; j < cur_table_width; j++)
         {
-            (*m_pTable)[cur_index][j] = convert(_GetItem(*(*i).second, (int)j, buffer));
+            (*m_pTable)[cur_index][j] = convert(_GetItem(*(*i).value, (int)j, buffer));
         }
     }
 

--- a/src/xrGame/inventory_upgrade_manager.cpp
+++ b/src/xrGame/inventory_upgrade_manager.cpp
@@ -177,7 +177,7 @@ public:
 
         const auto it = std::find_if(ib, ie, [&](const CInifile::Item& item)
         {
-            return item.first == item_id;
+            return item.name == item_id;
         });
 
         return it != ie;
@@ -226,12 +226,12 @@ void Manager::load_all_properties()
         pSettings->section_exist(properties_section), make_string("Section [%s] does not exist !", properties_section));
     VERIFY2(pSettings->line_count(properties_section), make_string("Section [%s] is empty !", properties_section));
 
-    CInifile::Sect& inv_section = pSettings->r_section(properties_section);
+    const CInifile::Sect& inv_section = pSettings->r_section(properties_section);
     auto ib = inv_section.Data.begin();
     auto ie = inv_section.Data.end();
     for (; ib != ie; ++ib)
     {
-        shared_str property_id((*ib).first);
+        shared_str property_id((*ib).name);
         add_property(property_id);
     }
 

--- a/src/xrGame/level_sounds.cpp
+++ b/src/xrGame/level_sounds.cpp
@@ -202,7 +202,7 @@ void CLevelSoundManager::Load()
                 for (; it != end; ++it)
                 {
                     m_MusicTracks.push_back(SMusicTrack());
-                    m_MusicTracks.back().Load(*it->first, *it->second);
+                    m_MusicTracks.back().Load(*it->name, *it->value);
                 }
             }
         }

--- a/src/xrGame/mp_config_sections.cpp
+++ b/src/xrGame/mp_config_sections.cpp
@@ -40,9 +40,9 @@ bool mp_config_sections::dump_one(CMemoryWriter& dest)
         return false;
 
     R_ASSERT(pSettings->section_exist(m_current_dump_sect->c_str()));
-    CInifile::Sect& tmp_sect = pSettings->r_section(m_current_dump_sect->c_str());
+    const CInifile::Sect& tmp_sect = pSettings->r_section(m_current_dump_sect->c_str());
 
-    m_tmp_dumper.sections().push_back(&tmp_sect);
+    m_tmp_dumper.sections().push_back(const_cast<CInifile::Sect*>(&tmp_sect));
     m_tmp_dumper.save_as(dest);
     m_tmp_dumper.sections().pop_back();
     ++m_current_dump_sect;

--- a/src/xrGame/purchase_list.cpp
+++ b/src/xrGame/purchase_list.cpp
@@ -27,12 +27,12 @@ void CPurchaseList::process(CInifile& ini_file, LPCSTR section, CInventoryOwner&
     auto E = S.Data.cend();
     for (; I != E; ++I)
     {
-        VERIFY3((*I).second.size(), "PurchaseList : cannot handle lines in section without values", section);
+        VERIFY3((*I).value.size(), "PurchaseList : cannot handle lines in section without values", section);
 
         string256 temp0, temp1;
-        THROW3(_GetItemCount(*(*I).second) == 2, "Invalid parameters in section", section);
-        process(game_object, (*I).first, atoi(_GetItem(*(*I).second, 0, temp0)),
-            (float)atof(_GetItem(*(*I).second, 1, temp1)));
+        THROW3(_GetItemCount(*(*I).value) == 2, "Invalid parameters in section", section);
+        process(game_object, (*I).name, atoi(_GetItem(*(*I).value, 0, temp0)),
+            (float)atof(_GetItem(*(*I).value, 1, temp1)));
     }
 }
 

--- a/src/xrGame/step_manager.cpp
+++ b/src/xrGame/step_manager.cpp
@@ -267,22 +267,22 @@ Fvector CStepManager::get_foot_position(ELegType leg_type)
     return global_transform.c;
 }
 
-void CStepManager::load_foot_bones(CInifile::Sect& data)
+void CStepManager::load_foot_bones(const CInifile::Sect& data)
 {
     for (auto I = data.Data.cbegin(); I != data.Data.cend(); ++I)
     {
         const CInifile::Item& item = *I;
 
-        u16 index = smart_cast<IKinematics*>(m_object->Visual())->LL_BoneID(*item.second);
-        VERIFY3(index != BI_NONE, "foot bone not found", *item.second);
+        u16 index = smart_cast<IKinematics*>(m_object->Visual())->LL_BoneID(*item.value);
+        VERIFY3(index != BI_NONE, "foot bone not found", *item.value);
 
-        if (xr_strcmp(*item.first, "front_left") == 0)
+        if (xr_strcmp(*item.name, "front_left") == 0)
             m_foot_bones[eFrontLeft] = index;
-        else if (xr_strcmp(*item.first, "front_right") == 0)
+        else if (xr_strcmp(*item.name, "front_right") == 0)
             m_foot_bones[eFrontRight] = index;
-        else if (xr_strcmp(*item.first, "back_right") == 0)
+        else if (xr_strcmp(*item.name, "back_right") == 0)
             m_foot_bones[eBackRight] = index;
-        else if (xr_strcmp(*item.first, "back_left") == 0)
+        else if (xr_strcmp(*item.name, "back_left") == 0)
             m_foot_bones[eBackLeft] = index;
     }
 }

--- a/src/xrGame/step_manager.h
+++ b/src/xrGame/step_manager.h
@@ -45,7 +45,7 @@ protected:
     virtual bool is_on_ground() { return true; }
 private:
     void reload_foot_bones();
-    void load_foot_bones(CInifile::Sect& data);
+    void load_foot_bones(const CInifile::Sect& data);
 
     float get_blend_time();
 };

--- a/src/xrGame/trade_parameters.cpp
+++ b/src/xrGame/trade_parameters.cpp
@@ -19,6 +19,6 @@ void CTradeParameters::process(action_show, CInifile& ini_file, const shared_str
     auto I = S.Data.cbegin();
     auto E = S.Data.cend();
     for (; I != E; ++I)
-        if (!(*I).second.size())
-            m_show.disable((*I).first);
+        if (!(*I).value.size())
+            m_show.disable((*I).name);
 }

--- a/src/xrGame/trade_parameters_inline.h
+++ b/src/xrGame/trade_parameters_inline.h
@@ -77,16 +77,16 @@ IC void CTradeParameters::process(_action_type type, CInifile& ini_file, const s
     auto E = S.Data.cend();
     for (; I != E; ++I)
     {
-        if (!(*I).second.size())
+        if (!(*I).value.size())
         {
-            _action.disable((*I).first);
+            _action.disable((*I).name);
             continue;
         }
 
         string256 temp0, temp1;
-        THROW3(_GetItemCount(*(*I).second) == 2, "Invalid parameters in section", *section);
-        _action.enable((*I).first, CTradeFactors((float)atof(_GetItem(*(*I).second, 0, temp0)),
-                                       (float)atof(_GetItem(*(*I).second, 1, temp1))));
+        THROW3(_GetItemCount(*(*I).value) == 2, "Invalid parameters in section", *section);
+        _action.enable((*I).name, CTradeFactors((float)atof(_GetItem(*(*I).value, 0, temp0)),
+                                       (float)atof(_GetItem(*(*I).value, 1, temp1))));
     }
 }
 

--- a/src/xrGame/ui/UIBuyWndShared.cpp
+++ b/src/xrGame/ui/UIBuyWndShared.cpp
@@ -6,15 +6,15 @@ extern pcstr _list_names[];
 
 void CItemMgr::Load(const shared_str& sect_cost)
 {
-    CInifile::Sect& sect = pSettings->r_section(sect_cost);
+    const CInifile::Sect& sect = pSettings->r_section(sect_cost);
 
     u32 idx = 0;
     for (auto it = sect.Data.cbegin(); it != sect.Data.cend(); ++it, ++idx)
     {
-        _i& val = m_items[it->first];
+        _i& val = m_items[it->name];
         val.slot_idx = 0xff;
         int c = sscanf(
-            it->second.c_str(), "%d,%d,%d,%d,%d", &val.cost[0], &val.cost[1], &val.cost[2], &val.cost[3], &val.cost[4]);
+            it->value.c_str(), "%d,%d,%d,%d,%d", &val.cost[0], &val.cost[1], &val.cost[2], &val.cost[3], &val.cost[4]);
         VERIFY(c > 0);
 
         while (c < _RANK_COUNT)

--- a/src/xrGame/ui/UICharacterInfo.cpp
+++ b/src/xrGame/ui/UICharacterInfo.cpp
@@ -385,12 +385,12 @@ bool CUICharacterInfo::ignore_community(shared_str const& check_community)
     if (!pSettings->section_exist(comm_section_str))
         return false;
 
-    CInifile::Sect& faction_section = pSettings->r_section(comm_section_str);
+    const CInifile::Sect& faction_section = pSettings->r_section(comm_section_str);
     auto ib = faction_section.Data.begin();
     auto ie = faction_section.Data.end();
     for (; ib != ie; ++ib)
     {
-        if (check_community == (*ib).first)
+        if (check_community == (*ib).name)
         {
             return true;
         }

--- a/src/xrGame/ui/UIInvUpgradeProperty.cpp
+++ b/src/xrGame/ui/UIInvUpgradeProperty.cpp
@@ -158,7 +158,7 @@ bool UIInvUpgPropertiesWnd::init_from_xml(LPCSTR xml_name)
     VERIFY2(pSettings->line_count(properties_section), make_string("Section [%s] is empty !", properties_section));
     shared_str property_id;
 
-    CInifile::Sect& inv_section = pSettings->r_section(properties_section);
+    const CInifile::Sect& inv_section = pSettings->r_section(properties_section);
     auto ib = inv_section.Data.begin();
     auto ie = inv_section.Data.end();
     for (; ib != ie; ++ib)
@@ -166,7 +166,7 @@ bool UIInvUpgPropertiesWnd::init_from_xml(LPCSTR xml_name)
         UIProperty* ui_property = xr_new<UIProperty>(); // load one time !!
         ui_property->init_from_xml(ui_xml);
 
-        property_id._set((*ib).first);
+        property_id._set((*ib).name);
         if (!ui_property->init_property(property_id))
         {
             Msg("! Invalid property <%s> in inventory upgrade manager!", property_id.c_str());

--- a/src/xrGame/ui/UIMapWnd.cpp
+++ b/src/xrGame/ui/UIMapWnd.cpp
@@ -182,7 +182,7 @@ bool CUIMapWnd::Init(cpcstr xml_name, cpcstr start_from, bool critical /*= true*
         auto it = S.Data.cbegin(), end = S.Data.cend();
         for (; it != end; ++it)
         {
-            shared_str map_name = it->first;
+            shared_str map_name = it->name;
             xr_strlwr(map_name);
             R_ASSERT2(m_GameMaps.end() == m_GameMaps.find(map_name), "Duplicate level name not allowed");
 

--- a/src/xrGame/ui/UIRankingWnd.cpp
+++ b/src/xrGame/ui/UIRankingWnd.cpp
@@ -1,8 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////
-//	Module 		: UIRankingWnd.cpp
-//	Created 	: 17.01.2008
-//	Author		: Evgeniy Sokolov
-//	Description : UI Ranking window class implementation
+//  Module      : UIRankingWnd.cpp
+//  Created     : 17.01.2008
+//  Author      : Evgeniy Sokolov
+//  Description : UI Ranking window class implementation
 ////////////////////////////////////////////////////////////////////////////
 
 #include "pch_script.h"
@@ -156,10 +156,10 @@ bool CUIRankingWnd::Init()
         {
             node = xml.NavigateToNode("fraction_list", 0);
             xml.SetLocalRoot(node);
-            CInifile::Sect& faction_section = pSettings->r_section(fract_section);
+            const CInifile::Sect& faction_section = pSettings->r_section(fract_section);
             for (const auto& item : faction_section.Data)
             {
-                add_faction(xml, item.first);
+                add_faction(xml, item.name);
             }
             node = xml.NavigateToNode("fraction_list", 0);
             xml.SetLocalRoot(stored_root);
@@ -188,7 +188,7 @@ bool CUIRankingWnd::Init()
         {
             const auto& achievs_section = pSettings->r_section(section);
             for (const auto& item : achievs_section.Data)
-                add_achievement(xml, item.first);
+                add_achievement(xml, item.name);
         }
     }
     xml.SetLocalRoot(stored_root);

--- a/src/xrServerEntities/xrServer_Objects_ALife_Monsters.cpp
+++ b/src/xrServerEntities/xrServer_Objects_ALife_Monsters.cpp
@@ -42,12 +42,12 @@ void setup_location_types_section(GameGraph::TERRAIN_VECTOR& m_vertex_types, CIn
     GameGraph::STerrainPlace terrain_mask;
     terrain_mask.tMask.resize(GameGraph::LOCATION_TYPE_COUNT);
 
-    CInifile::Sect& sect = ini->r_section(section);
+    const CInifile::Sect& sect = ini->r_section(section);
     auto I = sect.Data.cbegin();
     auto E = sect.Data.cend();
     for (; I != E; ++I)
     {
-        pcstr S = *(*I).first;
+        pcstr S = *(*I).name;
         string16 I2;
         u32 N = _GetItemCount(S);
 


### PR DESCRIPTION
- Completely handwritten parser which parses the entire ini file in one go including conversions to lowercase and without any string copies
- Fixed all sorts of crashes, infinite loops etc. I could find for invalid ini files. Instead of crashing we now report an (hopefully) helpful error message
- More lenient parsing for `#include` or inheritance thus
```
[a]
  #include "other_file"

[b] : a
```
will now be parsed just fine.
- Renamed Items members `first` and `second` to `name` and `value`
- Added and improved const-correctness for the entire `CInifile` class
- Moved all function definitions to the source files
- General cleanup of `xr_ini.h` and `xr_ini.cpp`