### PR TITLE
Ignore more variations of build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ cmake_install.cmake
 cmake-build-*
 install_manifest.txt
 bin/
-build/
+[bB]uild*/
 intermediate/
 intermediate_plugs/
 lib/


### PR DESCRIPTION
Background:
I usually create different build directories for different compiler like this
- build-gcc
- build-clang

with the current `.gitignore` file these are not included but with this patch they are :)