### PR TITLE
psHUD_FOV refactors

### DIFF
--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -483,7 +483,7 @@ ICF void FillSprite(FVF::LIT*& pv, const Fvector& pos, const Fvector& dir, const
 #error Specify your platform explicitly
 #endif // defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K)
 
-extern ENGINE_API float psHUD_FOV;
+extern ENGINE_API float g_hud_fov;
 
 #if defined(XR_ARCHITECTURE_X86) || defined(XR_ARCHITECTURE_X64) || defined(XR_ARCHITECTURE_E2K) || defined(XR_ARCHITECTURE_PPC64)
 ICF void magnitude_sse(Fvector& vec, float& res) // XXX: move this to Fvector class
@@ -679,7 +679,7 @@ void CParticleEffect::Render(CBackend& cmd_list, float, bool use_fast_geo)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);
@@ -727,7 +727,7 @@ IC void FillSprite(FVF::LIT*& pv, const Fvector& pos, const Fvector& dir, const 
     FillSprite_fpu(pv, pos, dir, lt, rb, r1, r2, clr, _sin(angle), _cos(angle));
 }
 
-extern ENGINE_API float psHUD_FOV;
+extern ENGINE_API float g_hud_fov;
 void CParticleEffect::Render(float, bool)
 {
     u32 dwOffset, dwCount;
@@ -847,7 +847,7 @@ void CParticleEffect::Render(float, bool)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -679,7 +679,7 @@ void CParticleEffect::Render(CBackend& cmd_list, float, bool use_fast_geo)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, HUD_VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);
@@ -847,7 +847,7 @@ void CParticleEffect::Render(float, bool)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT, HUD_VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -679,7 +679,7 @@ void CParticleEffect::Render(CBackend& cmd_list, float, bool use_fast_geo)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(psHUD_FOV * Device.fFOV), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT, VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);
@@ -847,7 +847,7 @@ void CParticleEffect::Render(float, bool)
                 Fmatrix FTold = Device.mFullTransform;
                 if (GetHudMode())
                 {
-                    Device.mProject.build_projection(deg2rad(psHUD_FOV * Device.fFOV), Device.fASPECT, VIEWPORT_NEAR,
+                    Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT, VIEWPORT_NEAR,
                         g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
                     Device.mFullTransform.mul(Device.mProject, Device.mView);

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -164,7 +164,7 @@ public:
         // https://github.com/ShokerStlk/xray-16-SWM/commit/869de0b6e74ac05990f541e006894b6fe78bd2a5#diff-4199ef700b18ce4da0e2b45dee1924d0R83
 
         Fmatrix prj_new;
-        prj_new.build_projection(deg2rad(psHUD_FOV * Device.fFOV /* *Device.fASPECT*/), Device.fASPECT,
+        prj_new.build_projection(deg2rad(psHUD_FOV), Device.fASPECT,
             VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
         cmd_list.set_xform_project(prj_new);
 

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -142,7 +142,7 @@ public:
     explicit hud_transform_helper(CBackend& cmd_list_in)
         : cmd_list(cmd_list_in)
     {
-        extern ENGINE_API float psHUD_FOV;
+        extern ENGINE_API float g_hud_fov;
 
         // Change projection
         Pold  = Device.mProject;
@@ -153,7 +153,7 @@ public:
         // if (isCustomFOV)
         //     customFOV = V->getVisData().obj_data->m_hud_custom_fov;
         // else
-        //     customFOV = psHUD_FOV * Device.fFOV;
+        //     customFOV = g_hud_fov * Device.fFOV;
         //
         // Device.mProject.build_projection(deg2rad(customFOV), Device.fASPECT,
         //    VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
@@ -164,7 +164,7 @@ public:
         // https://github.com/ShokerStlk/xray-16-SWM/commit/869de0b6e74ac05990f541e006894b6fe78bd2a5#diff-4199ef700b18ce4da0e2b45dee1924d0R83
 
         Fmatrix prj_new;
-        prj_new.build_projection(deg2rad(psHUD_FOV), Device.fASPECT,
+        prj_new.build_projection(deg2rad(g_hud_fov), Device.fASPECT,
             VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
         cmd_list.set_xform_project(prj_new);
 

--- a/src/Layers/xrRender/r__dsgraph_render.cpp
+++ b/src/Layers/xrRender/r__dsgraph_render.cpp
@@ -165,7 +165,7 @@ public:
 
         Fmatrix prj_new;
         prj_new.build_projection(deg2rad(g_hud_fov), Device.fASPECT,
-            VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
+            HUD_VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
         cmd_list.set_xform_project(prj_new);
 
         RImplementation.rmNear(cmd_list);

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
@@ -18,7 +18,7 @@ void CRenderTarget::accum_point(CBackend& cmd_list, light* L)
         Pold = Device.mProject;
         FTold = Device.mFullTransform;
         Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT,
-            VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
+            HUD_VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
         Device.mFullTransform.mul(Device.mProject, Device.mView);
         RCache.set_xform_project(Device.mProject);

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
@@ -14,10 +14,10 @@ void CRenderTarget::accum_point(CBackend& cmd_list, light* L)
 
     if (L->flags.bHudMode)
     {
-        extern ENGINE_API float psHUD_FOV;
+        extern ENGINE_API float g_hud_fov;
         Pold = Device.mProject;
         FTold = Device.mFullTransform;
-        Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT,
+        Device.mProject.build_projection(deg2rad(g_hud_fov), Device.fASPECT,
             VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
         Device.mFullTransform.mul(Device.mProject, Device.mView);

--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_accum_point.cpp
@@ -17,7 +17,7 @@ void CRenderTarget::accum_point(CBackend& cmd_list, light* L)
         extern ENGINE_API float psHUD_FOV;
         Pold = Device.mProject;
         FTold = Device.mFullTransform;
-        Device.mProject.build_projection(deg2rad(psHUD_FOV * Device.fFOV /* *Device.fASPECT*/), Device.fASPECT,
+        Device.mProject.build_projection(deg2rad(psHUD_FOV), Device.fASPECT,
             VIEWPORT_NEAR, g_pGamePersistent->Environment().CurrentEnv.far_plane);
 
         Device.mFullTransform.mul(Device.mProject, Device.mView);

--- a/src/xrEngine/device.h
+++ b/src/xrEngine/device.h
@@ -16,6 +16,7 @@
 #include "xrCore/ModuleLookup.hpp"
 
 #define VIEWPORT_NEAR 0.2f
+#define HUD_VIEWPORT_NEAR 0.05f
 
 #define DEVICE_RESET_PRECACHE_FRAME_COUNT 10
 

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -791,7 +791,7 @@ public:
 };
 
 ENGINE_API float g_fov = 67.5f;
-ENGINE_API float g_hud_fov = 67.5f;
+ENGINE_API float g_hud_fov = 25.7831f;
 
 // extern int psSkeletonUpdate;
 extern int rsDVB_Size;

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -791,7 +791,7 @@ public:
 };
 
 ENGINE_API float g_fov = 67.5f;
-ENGINE_API float psHUD_FOV = 67.5f;
+ENGINE_API float g_hud_fov = 67.5f;
 
 // extern int psSkeletonUpdate;
 extern int rsDVB_Size;

--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -791,7 +791,7 @@ public:
 };
 
 ENGINE_API float g_fov = 67.5f;
-ENGINE_API float psHUD_FOV = 0.45f;
+ENGINE_API float psHUD_FOV = 67.5f;
 
 // extern int psSkeletonUpdate;
 extern int rsDVB_Size;

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1770,14 +1770,14 @@ void CActor::ForceTransformAndDirection(const Fmatrix& m)
     cam_Active()->Set(-xyz.x, -xyz.y, -xyz.z);
 }
 
-//ENGINE_API extern float psHUD_FOV;
+//ENGINE_API extern float g_hud_fov;
 float CActor::Radius() const
 {
     float R = inherited::Radius();
     CWeapon* W = smart_cast<CWeapon*>(inventory().ActiveItem());
     if (W)
         R += W->Radius();
-    //if (HUDview()) R *= 1.f/psHUD_FOV;
+    //if (HUDview()) R *= 1.f/g_hud_fov;
     return R;
 }
 

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -73,7 +73,7 @@ extern u64 g_qwStartGameTime;
 extern u64 g_qwEStartGameTime;
 
 ENGINE_API
-extern float psHUD_FOV;
+extern float g_hud_fov;
 extern float psSqueezeVelocity;
 extern int psLUA_GCSTEP;
 extern int g_auto_ammo_unload;
@@ -2060,7 +2060,7 @@ void CCC_RegisterCommands()
     CMD3(CCC_Mask, "hud_crosshair_dist", &psHUD_Flags, HUD_CROSSHAIR_DIST);
     CMD3(CCC_Mask, "hud_left_handed", &psHUD_Flags, HUD_LEFT_HANDED);
 
-    CMD4(CCC_Float, "hud_fov", &psHUD_FOV, 5.0f, 180.f);
+    CMD4(CCC_Float, "hud_fov", &g_hud_fov, 5.0f, 180.f);
     CMD4(CCC_Float, "fov", &g_fov, 5.0f, 180.0f);
 
     // Demo

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2060,7 +2060,7 @@ void CCC_RegisterCommands()
     CMD3(CCC_Mask, "hud_crosshair_dist", &psHUD_Flags, HUD_CROSSHAIR_DIST);
     CMD3(CCC_Mask, "hud_left_handed", &psHUD_Flags, HUD_LEFT_HANDED);
 
-    CMD4(CCC_Float, "hud_fov", &psHUD_FOV, 0.1f, 1.0f);
+    CMD4(CCC_Float, "hud_fov", &psHUD_FOV, 5.0f, 180.f);
     CMD4(CCC_Float, "fov", &g_fov, 5.0f, 180.0f);
 
     // Demo


### PR DESCRIPTION
- Expose psHUD_FOV to users as degree value instead of radians
- renamed psHUD_FOV to g_hud_fov
- Add HUD_VIEWPORT_NEAR define, to fix camera clipping with high hud fov values