### PR TITLE
Added a checking bad phrase structure

### DIFF
--- a/src/xrGame/PhraseDialog.cpp
+++ b/src/xrGame/PhraseDialog.cpp
@@ -254,8 +254,7 @@ CPhrase* CPhraseDialog::AddPhrase(
 {
     CPhrase* phrase = NULL;
     CPhraseGraph::CVertex* _vertex = data()->m_PhraseGraph.vertex(phrase_id);
-
-    VERIFY2(!_vertex, make_string("Dublicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()));
+    VERIFY2(!_vertex, make_string("Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()));
 
     if (!_vertex)
     {

--- a/src/xrGame/PhraseDialog.cpp
+++ b/src/xrGame/PhraseDialog.cpp
@@ -254,6 +254,9 @@ CPhrase* CPhraseDialog::AddPhrase(
 {
     CPhrase* phrase = NULL;
     CPhraseGraph::CVertex* _vertex = data()->m_PhraseGraph.vertex(phrase_id);
+
+    VERIFY2(!_vertex, make_string("Dublicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()));
+
     if (!_vertex)
     {
         phrase = xr_new<CPhrase>();

--- a/src/xrGame/PhraseDialog.cpp
+++ b/src/xrGame/PhraseDialog.cpp
@@ -254,7 +254,7 @@ CPhrase* CPhraseDialog::AddPhrase(
 {
     CPhrase* phrase = NULL;
     CPhraseGraph::CVertex* _vertex = data()->m_PhraseGraph.vertex(phrase_id);
-    VERIFY2(!_vertex, make_string("Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()));
+    VERIFY2(!_vertex, make_string("Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()).c_str());
 
     if (!_vertex)
     {


### PR DESCRIPTION
This verify checks for an already existing phrase added with the same ID, which is an incorrect dialog structure. Each new phrase must have a unique identifier. This check is simply more informative than just `m_edges.end() == std::find(m_edges.begin(), m_edges.end(), vertex->vertex_id())`. The following crash will immediately follow:

```
FATAL ERROR
 
[error] Expression    : m_edges.end() == std::find(m_edges.begin(), m_edges.end(), vertex->vertex_id())
[error] Function      : add_edge
[error] File          : /home/ruut/Documents/qemu_shared/xray-16/src/xrAICore/Navigation/graph_vertex_inline.h
[error] Line          : 68
[error] Description   : assertion failed
 

stack trace:

xrDebug::GatherInfo(char*, unsigned long, ErrorLocation const&, char const*, char const*, char const*, char const*)
xrDebug::Fail(bool&, ErrorLocation const&, char const*, char const*, char const*, char const*)
CGraphVertex<CPhrase*, shared_str, CGraphAbstract<CPhrase*, float, shared_str, Loki::EmptyType> >::add_edge(CGraphVertex<CPhrase*, shared_str, CGraphAbstract<CPhrase*, float, shared_str, Loki::EmptyType> >*, float const&)
CGraphAbstract<CPhrase*, float, shared_str, Loki::EmptyType>::add_edge(shared_str const&, shared_str const&, float const&)
CPhraseDialog::AddPhrase(char const*, shared_str const&, shared_str const&, int)
CPhraseDialog::AddPhrase_script(char const*, char const*, char const*, int)
luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int)>::call_struct<true, false, luabind::meta::index_list<0u, 1u, 2u, 3u, 4u> >::call(lua_State*, CPhrase* (CPhraseDialog::*&)(char const*, char const*, char const*, int), std::tuple<luabind::default_converter<CPhraseDialog&, void>, luabind::default_converter<char const*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<int, void> >&)
luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int)>::invoke(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CPhrase* (CPhraseDialog::*&)(char const*, char const*, char const*, int))
luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >::invoke_defer(lua_State*, luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >*, luabind::detail::invoke_context&, int&)
luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >::entry_point(lua_State*)
/home/ruut/Documents/qemu_shared/xray-16/bin/x64/Debug/xrLuaJIT.so(+0xa3d5) [0x7f51526a73d5]
/home/ruut/Documents/qemu_shared/xray-16/bin/x64/Debug/xrLuaJIT.so(lua_pcall+0xae) [0x7f51526bab5e]
luabind::detail::pcall(lua_State*, int, int)
void luabind::detail::call_function_struct<void, luabind::meta::type_list<>, luabind::meta::index_list<1u>, 1u, &luabind::detail::pcall, true>::call<CPhraseDialog*>(lua_State*, CPhraseDialog*&&)
void luabind::call_pushed_function<void, luabind::meta::type_list<>, CPhraseDialog*>(lua_State*, CPhraseDialog*&&)
void luabind::call_function<void, luabind::meta::type_list<>, CPhraseDialog*>(luabind::adl::object const&, CPhraseDialog*&&)
CPhraseDialog::load_shared(char const*)
CSharedClass<SPhraseDialogData, shared_str, false>::load_shared(shared_str, char const*)
CPhraseDialog::Load(shared_str)
CPhraseDialogManager::AddAvailableDialog(shared_str, CPhraseDialogManager*)
```

The new verify:
```
 
FATAL ERROR
 
[error] Expression    : !_vertex
[error] Function      : AddPhrase
[error] File          : /home/ruut/Documents/qemu_shared/xray-16/src/xrGame/PhraseDialog.cpp
[error] Line          : 259
[error] Description   : Dublicate phrase ID: [244] for phrase: [dm_do_not_know_10]. Existed phrase by this ID: [dm_no_more_8]
 

stack trace:

xrDebug::GatherInfo(char*, unsigned long, ErrorLocation const&, char const*, char const*, char const*, char const*)
xrDebug::Fail(bool&, ErrorLocation const&, char const*, char const*, char const*, char const*)
xrDebug::Fail(bool&, ErrorLocation const&, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, char const*)
CPhraseDialog::AddPhrase(char const*, shared_str const&, shared_str const&, int)
CPhraseDialog::AddPhrase_script(char const*, char const*, char const*, int)
luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int)>::call_struct<true, false, luabind::meta::index_list<0u, 1u, 2u, 3u, 4u> >::call(lua_State*, CPhrase* (CPhraseDialog::*&)(char const*, char const*, char const*, int), std::tuple<luabind::default_converter<CPhraseDialog&, void>, luabind::default_converter<char const*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<int, void> >&)
luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int)>::invoke(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CPhrase* (CPhraseDialog::*&)(char const*, char const*, char const*, int))
luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >::invoke_defer(lua_State*, luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >*, luabind::detail::invoke_context&, int&)
luabind::detail::function_object_impl<CPhrase* (CPhraseDialog::*)(char const*, char const*, char const*, int), luabind::meta::type_list<CPhrase*, CPhraseDialog&, char const*, char const*, char const*, int>, luabind::meta::type_list<> >::entry_point(lua_State*)
/home/ruut/Documents/qemu_shared/xray-16/bin/x64/Debug/xrLuaJIT.so(+0xa3d5) [0x7f51526a73d5]
/home/ruut/Documents/qemu_shared/xray-16/bin/x64/Debug/xrLuaJIT.so(lua_pcall+0xae) [0x7f51526bab5e]
luabind::detail::pcall(lua_State*, int, int)
void luabind::detail::call_function_struct<void, luabind::meta::type_list<>, luabind::meta::index_list<1u>, 1u, &luabind::detail::pcall, true>::call<CPhraseDialog*>(lua_State*, CPhraseDialog*&&)
void luabind::call_pushed_function<void, luabind::meta::type_list<>, CPhraseDialog*>(lua_State*, CPhraseDialog*&&)
void luabind::call_function<void, luabind::meta::type_list<>, CPhraseDialog*>(luabind::adl::object const&, CPhraseDialog*&&)
CPhraseDialog::load_shared(char const*)
CSharedClass<SPhraseDialogData, shared_str, false>::load_shared(shared_str, char const*)
CPhraseDialog::Load(shared_str)
CPhraseDialogManager::AddAvailableDialog(shared_str, CPhraseDialogManager*)
CActor::UpdateAvailableDialogs(CPhraseDialogManager*)
```