### PR TITLE
xrGame: Fix buffer overflow in `ParseControlString`

### DIFF
--- a/src/xrGame/console_commands_mp.cpp
+++ b/src/xrGame/console_commands_mp.cpp
@@ -598,12 +598,10 @@ protected:
     shared_str m_action_param;
     bool ParseControlString(LPCSTR args_string)
     {
-        char action_name[17];
-        action_name[0] = 0;
-        char param_name[33];
-        param_name[0] = 0;
+        string32 action_name{};
+        string64 param_name{};
 
-        sscanf(args_string, "%16s %32s", action_name, param_name);
+        sscanf(args_string, "%31s %63s", action_name, param_name); // 31/63 instead of 32/64 because we reserve space for null character
         m_action_param = param_name;
 
         if (!xr_strcmp(action_name, "roundstart"))

--- a/src/xrGame/console_commands_mp.cpp
+++ b/src/xrGame/console_commands_mp.cpp
@@ -598,9 +598,9 @@ protected:
     shared_str m_action_param;
     bool ParseControlString(LPCSTR args_string)
     {
-        string16 action_name;
+        char action_name[17];
         action_name[0] = 0;
-        string32 param_name;
+        char param_name[33];
         param_name[0] = 0;
 
         sscanf(args_string, "%16s %32s", action_name, param_name);


### PR DESCRIPTION
The given buffers are actually not big enough for the size specified in the `sscanf` argument.

To quote [cppreference](https://en.cppreference.com/w/c/io/fscanf)
> Always stores a null character in addition to the characters matched (so the argument array must have room for at least __width+1__ characters)

Full credit this was found by CodeQL

Original diagnostics:
>  src/xrGame/console_commands_mp.cpp:606: This 'sscanf string argument' operation requires 33 bytes but the destination is only 32 bytes. [cpp/very-likely-overrunning-write]
>  src/xrGame/console_commands_mp.cpp:606: This 'sscanf string argument' operation requires 17 bytes but the destination is only 16 bytes. [cpp/very-likely-overrunning-write]