### PR TITLE
Add basic unittests for `CInifile`

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -156,6 +156,10 @@ jobs:
       id: cmake-build
       run: cmake --build build --config ${{ matrix.configuration }} --parallel ${{ matrix.platform.threads || 4 }}
 
+    - name: Run CTest
+      working-directory: build
+      run: ctest -C ${{ matrix.configuration }} --parallel ${{ matrix.platform.threads || 4 }} --output-on-failure --schedule-random --no-tests=error
+
     - name: Make package
       if: ${{ steps.cmake-build.outcome == 'success' }}
       id: make-package
@@ -237,3 +241,16 @@ jobs:
         shutdown_vm: false
         sync_files: false
         run: cmake --build build --config ${{ matrix.Configuration }} --parallel 4
+
+    - name: Run CTest
+      uses: cross-platform-actions/action@v0.27.0
+      with:
+        operating_system: ${{ matrix.platform.os }}
+        architecture: ${{ matrix.platform.arch }}
+        version: ${{ matrix.platform.os-version }}
+        cpu_count: 4
+        memory: 13G
+        environment_variables: CFLAGS CXXFLAGS
+        shutdown_vm: false
+        sync_files: false
+        run: ctest --test-dir build -C ${{ matrix.configuration }} --parallel 4 --output-on-failure --schedule-random --no-tests=error

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,7 @@
 [submodule "Externals/sse2rvv"]
 	path = Externals/sse2rvv
 	url = https://github.com/pattonkan/sse2rvv.git
+[submodule "Externals/doctest"]
+	path = Externals/doctest
+	url = https://github.com/doctest/doctest.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,12 +139,16 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT XRAY_USE_DEFAULT_CXX_LIB)
 
     if (XRAY_CXX_LIB STREQUAL "libstdc++")
         add_compile_options(-stdlib=libstdc++)
+        add_link_options(-stdlib=libstdc++)
     elseif (XRAY_CXX_LIB STREQUAL "libc++")
         add_compile_options(-stdlib=libc++)
+        add_link_options(-stdlib=libc++)
         if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
             add_compile_options(-lcxxrt)
+            add_link_options(-lcxxrt)
         else()
             add_compile_options(-lc++abi)
+            add_link_options(-lc++abi)
         endif()
     endif()
 endif()
@@ -294,6 +298,15 @@ add_compile_options(
 add_subdirectory(src)
 add_subdirectory(res)
 add_subdirectory(misc)
+
+# Tests
+option(BUILD_TESTS "Build tests" ON)
+message(STATUS "BUILD_TESTS: ${BUILD_TESTS}")
+
+if (BUILD_TESTS)
+    include(CTest)
+    add_subdirectory(tests)
+endif()
 
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
 

--- a/Externals/CMakeLists.txt
+++ b/Externals/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(GameSpy)
 add_subdirectory(OPCODE)
 add_subdirectory(ode)
 add_subdirectory(imgui-proj)
+add_subdirectory(doctest EXCLUDE_FROM_ALL)
 
 if (NOT TARGET xrLuabind)
     message(FATAL_ERROR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(xrCore)

--- a/tests/xrCore/CMakeLists.txt
+++ b/tests/xrCore/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(
+    xrCoreTests
+    main.cpp
+    xr_ini_test.cpp)
+
+target_link_libraries(xrCoreTests xrCore doctest::doctest)
+target_include_directories(xrCoreTests PRIVATE "${CMAKE_SOURCE_DIR}/src")
+add_test(NAME xrCoreTests COMMAND xrCoreTests)
+# https://github.com/doctest/doctest/blob/master/doc/markdown/configuration.md
+target_compile_definitions(xrCoreTests PRIVATE
+    DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+    DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+)

--- a/tests/xrCore/main.cpp
+++ b/tests/xrCore/main.cpp
@@ -1,0 +1,15 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+#include <Common/Platform.hpp>
+#include <xrCore/xrCore.h>
+
+int main(int argc, char** argv)
+{
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+
+    Memory._initialize();
+
+    return context.run();
+}

--- a/tests/xrCore/xr_ini_test.cpp
+++ b/tests/xrCore/xr_ini_test.cpp
@@ -1,0 +1,94 @@
+#include <doctest/doctest.h>
+
+#include <Common/Platform.hpp>
+#include <xrCore/xrCore.h>
+#include <xrCore/xr_types.h>
+
+#include <xrCore/xr_ini.h>
+
+CInifile read_from_string(pcstr str, CInifile::allow_include_func_t allow_include = nullptr)
+{
+    IReader reader = IReader(const_cast<pstr>(str), xr_strlen(str));
+    return CInifile(&reader, "test.ini", allow_include);
+}
+
+TEST_CASE("parse empty file")
+{
+    CInifile ini = read_from_string("");
+
+    CHECK_EQ(ini.section_count(), 0);
+}
+
+TEST_CASE("parse empty section")
+{
+    CInifile ini = read_from_string("[a]");
+
+    CHECK_EQ(ini.section_count(), 1);
+    CHECK_UNARY(ini.section_exist("a"));
+}
+
+TEST_CASE("parse simple section")
+{
+    CInifile ini = read_from_string(
+        R"ini(
+[a]
+key = value
+)ini");
+
+    CHECK_UNARY(ini.section_exist("a"));
+    CHECK_UNARY(ini.line_exist("a", "key"));
+    CHECK_EQ(ini.read<pcstr>("a", "key"), "value");
+}
+
+TEST_CASE("parse integer value")
+{
+    CInifile ini = read_from_string(
+        R"ini(
+[a]
+key = 123
+)ini");
+
+    CHECK_UNARY(ini.section_exist("a"));
+    CHECK_UNARY(ini.line_exist("a", "key"));
+    CHECK_EQ(ini.read<u32>("a", "key"), 123);
+}
+
+TEST_CASE("Parse float value")
+{
+    CInifile ini = read_from_string(
+        R"ini(
+[a]
+key = 123.456
+)ini");
+
+    CHECK_UNARY(ini.section_exist("a"));
+    CHECK_UNARY(ini.line_exist("a", "key"));
+    CHECK_EQ(ini.read<f32>("a", "key"), 123.456f);
+}
+
+TEST_CASE("Parse quoted value")
+{
+    CInifile ini = read_from_string(
+        R"ini(
+[a]
+key = "value"
+)ini");
+
+    CHECK_UNARY(ini.section_exist("a"));
+    CHECK_UNARY(ini.line_exist("a", "key"));
+    CHECK_EQ(ini.read<pcstr>("a", "key"), "\"value\"");
+}
+
+TEST_CASE("Parse multiline value")
+{
+    CInifile ini = read_from_string(
+        R"ini(
+[a]
+key = "multiline
+value"
+)ini");
+
+    CHECK_UNARY(ini.section_exist("a"));
+    CHECK_UNARY(ini.line_exist("a", "key"));
+    CHECK_EQ(ini.read<pcstr>("a", "key"), "\"multiline\r\nvalue\"");
+}


### PR DESCRIPTION
As discussed in #1543 here is a very simple integration of unittests using the doctest library.

Note that the tests currently don't work with MSVC which could be fixed by adding support for MSVC in our CMake files.