### PR TITLE
Update read window title from configs/openxray.ltx

### DIFF
--- a/src/xrEngine/Device_Initialize.cpp
+++ b/src/xrEngine/Device_Initialize.cpp
@@ -40,8 +40,8 @@ void CRenderDevice::Initialize()
             title = "S.T.A.L.K.E.R.: Clear Sky";
         }
 
-        title = READ_IF_EXISTS(pSettingsOpenXRay, r_string,
-            "window", "title", title);
+        title = READ_IF_EXISTS(pSettingsOpenXRay, r_string_wb,
+            "window", "title", title).c_str();
 
         xr_strcpy(Core.ApplicationTitle, title);
 


### PR DESCRIPTION
Reads and removes quotes from the window title. With the `r_string` function the window title will be without spaces or with quotes. With the `r_string_wb` function the window title will be with spaces but without quotes. And then the the window title will look normal.