### PR TITLE
[COC] Support usage of multiple `spawn_loadout` sections in character descriptions.

### DIFF
--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -34,6 +34,10 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     u8 loadout_index = 1;
     LPCSTR loadout_section = "spawn_loadout";
 
+    // Alundaio: This will spawn a single random section listed in [spawn_loadout].
+    // No need to spawn ammo, this will automatically spawn 1 box for weapon and if ammo_type is specified it will spawn that type.
+    // Count is used only for ammo boxes (ie wpn_pm = 3) will spawn 3 boxes, not 3 wpn_pm.
+    // Supports few loadout options, iterates over `spawn_loadout`, `spawn_loadout2` ... `spawn_loadoutN`.
     while (ini.section_exist(loadout_section))
     {
         pcstr itmSection, V;

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -125,6 +125,13 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                                     alife().spawn_item(ammoSec, o_Position, m_tNodeID, m_tGraphID, ID);
                         }
                     }
+                    // If not weapon item, handle count as literal count, not ammo (useful for grenades and consumables).
+                    else
+                    {
+                        for (u32 i = 1; i <= spawnCount - 1; ++i)
+                            alife().spawn_item(itmSection, o_Position, m_tNodeID, m_tGraphID, ID);
+                    }
+
                     if (const auto IItem = smart_cast<CSE_ALifeInventoryItem*>(E))
                         IItem->m_fCondition = fCond;
                 }

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -22,6 +22,13 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     if (!xr_strlen(ini_string))
         return;
 
+    luabind::functor<bool> funct;
+	if (GEnv.ScriptEngine->functor("ai_stalker.CSE_ALifeObject_spawn_supplies", funct))
+	{
+		if (funct(this, ID, ini_string))
+			return;
+	}
+
 #pragma warning(push)
 #pragma warning(disable : 4238)
     IReader reader((void*)ini_string, xr_strlen(ini_string));

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -126,7 +126,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         loadoutIndex += 1;
         xr_sprintf(loadoutSection, "spawn_loadout%d", loadoutIndex);
     }
-    // -Alundaio
+    //-Alundaio
 
     if (ini.section_exist("spawn"))
     {
@@ -136,7 +136,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         {
             VERIFY(xr_strlen(N));
 
-            if (pSettings->section_exist(N)) // Alundaio: verify item section exists!
+            if (pSettings->section_exist(N)) //Alundaio: verify item section exists!
             {
                 float f_cond = 1.0f;
                 bool bScope = false;
@@ -169,7 +169,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                     if (randF(1.f) < p)
                     {
                         CSE_Abstract* E = alife().spawn_item(N, o_Position, m_tNodeID, m_tGraphID, ID);
-                        // подсоединить аддоны к оружию, если включены соответствующие флажки
+                        //подсоединить аддоны к оружию, если включены соответствующие флажки
                         CSE_ALifeItemWeapon* W = smart_cast<CSE_ALifeItemWeapon*>(E);
                         if (W)
                         {

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -32,7 +32,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     // count is used only for ammo boxes (ie wpn_pm = 3) will spawn 3 boxes, not 3 wpn_pm
     // Usage: to create random weapon loadouts
     u8 loadout_index = 1;
-    LPCSTR loadout_section = "spawn_loadout";
+    string32 loadout_section = "spawn_loadout";
 
     // Alundaio: This will spawn a single random section listed in [spawn_loadout].
     // No need to spawn ammo, this will automatically spawn 1 box for weapon and if ammo_type is specified it will spawn that type.
@@ -128,7 +128,6 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         }
 
         loadout_index += 1;
-        string32 buf;
         xr_sprintf(loadout_section, "spawn_loadout%d", loadout_index);
     }
     // -Alundaio

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -27,42 +27,38 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     IReader reader((void*)ini_string, xr_strlen(ini_string));
     CInifile ini(&reader, FS.get_path("$game_config$")->m_Path);
 #pragma warning(pop)
-    // Alundaio: This will spawn a single random section listed in [spawn_loadout]
-    // No need to spawn ammo, this will automatically spawn 1 box for weapon and if ammo_type is specified it will spawn that type
-    // count is used only for ammo boxes (ie wpn_pm = 3) will spawn 3 boxes, not 3 wpn_pm
-    // Usage: to create random weapon loadouts
-    u8 loadout_index = 1;
-    string32 loadout_section = "spawn_loadout";
+    u8 loadoutIndex = 1;
+    string32 loadoutSection = "spawn_loadout";
 
     // Alundaio: This will spawn a single random section listed in [spawn_loadout].
     // No need to spawn ammo, this will automatically spawn 1 box for weapon and if ammo_type is specified it will spawn that type.
     // Count is used only for ammo boxes (ie wpn_pm = 3) will spawn 3 boxes, not 3 wpn_pm.
     // Supports few loadout options, iterates over `spawn_loadout`, `spawn_loadout2` ... `spawn_loadoutN`.
-    while (ini.section_exist(loadout_section))
+    while (ini.section_exist(loadoutSection))
     {
         pcstr itmSection, V;
-        xr_vector<u32> spawn_loadouts;
+        xr_vector<u32> spawnLoadouts;
 
         pcstr lname = ai().game_graph().header().level(ai().game_graph().vertex(m_tGraphID)->level_id()).name().c_str();
 
-        for (u32 k = 0; ini.r_line(loadout_section, k, &itmSection, &V); k++)
+        for (u32 k = 0; ini.r_line(loadoutSection, k, &itmSection, &V); k++)
         {
             // If level=<lname> then only spawn items if object on that level
             if (strstr(V, "level=") != nullptr)
             {
                 if (strstr(V, lname) != nullptr)
-                    spawn_loadouts.push_back(k);
+                    spawnLoadouts.push_back(k);
             }
             else
             {
-                spawn_loadouts.push_back(k);
+                spawnLoadouts.push_back(k);
             }
         }
 
-        if (!spawn_loadouts.empty())
+        if (!spawnLoadouts.empty())
         {
-            s32 sel = Random.randI(0, spawn_loadouts.size());
-            if (ini.r_line(loadout_section, spawn_loadouts.at(sel), &itmSection, &V))
+            s32 sel = Random.randI(0, spawnLoadouts.size());
+            if (ini.r_line(loadoutSection, spawnLoadouts.at(sel), &itmSection, &V))
             {
                 VERIFY(xr_strlen(itmSection));
                 if (pSettings->section_exist(itmSection))
@@ -127,8 +123,8 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
             }
         }
 
-        loadout_index += 1;
-        xr_sprintf(loadout_section, "spawn_loadout%d", loadout_index);
+        loadoutIndex += 1;
+        xr_sprintf(loadoutSection, "spawn_loadout%d", loadoutIndex);
     }
     // -Alundaio
 

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -27,37 +27,38 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     IReader reader((void*)ini_string, xr_strlen(ini_string));
     CInifile ini(&reader, FS.get_path("$game_config$")->m_Path);
 #pragma warning(pop)
-
     // Alundaio: This will spawn a single random section listed in [spawn_loadout]
     // No need to spawn ammo, this will automatically spawn 1 box for weapon and if ammo_type is specified it will spawn that type
     // count is used only for ammo boxes (ie wpn_pm = 3) will spawn 3 boxes, not 3 wpn_pm
     // Usage: to create random weapon loadouts
-    static constexpr cpcstr LOADOUT_SECTION = "spawn_loadout";
-    if (ini.section_exist(LOADOUT_SECTION))
+    u8 loadout_index = 1;
+    LPCSTR loadout_section = "spawn_loadout";
+
+    while (ini.section_exist(loadout_section))
     {
         pcstr itmSection, V;
-        xr_vector<u32> OnlyOne;
+        xr_vector<u32> spawn_loadouts;
 
         pcstr lname = ai().game_graph().header().level(ai().game_graph().vertex(m_tGraphID)->level_id()).name().c_str();
 
-        for (u32 k = 0; ini.r_line(LOADOUT_SECTION, k, &itmSection, &V); k++)
+        for (u32 k = 0; ini.r_line(loadout_section, k, &itmSection, &V); k++)
         {
             // If level=<lname> then only spawn items if object on that level
             if (strstr(V, "level=") != nullptr)
             {
                 if (strstr(V, lname) != nullptr)
-                    OnlyOne.push_back(k);
+                    spawn_loadouts.push_back(k);
             }
             else
             {
-                OnlyOne.push_back(k);
+                spawn_loadouts.push_back(k);
             }
         }
 
-        if (!OnlyOne.empty())
+        if (!spawn_loadouts.empty())
         {
-            s32 sel = Random.randI(0, OnlyOne.size());
-            if (ini.r_line(LOADOUT_SECTION, OnlyOne.at(sel), &itmSection, &V))
+            s32 sel = Random.randI(0, spawn_loadouts.size());
+            if (ini.r_line(loadout_section, spawn_loadouts.at(sel), &itmSection, &V))
             {
                 VERIFY(xr_strlen(itmSection));
                 if (pSettings->section_exist(itmSection))
@@ -87,7 +88,6 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                         if (nullptr != strstr(V, "ammo_type="))
                             i_ammo_type = atoi(strstr(V, "ammo_type=") + 10);
                     }
-
 
                     CSE_Abstract* E = alife().spawn_item(itmSection, o_Position, m_tNodeID, m_tGraphID, ID);
                     CSE_ALifeItemWeapon* W = smart_cast<CSE_ALifeItemWeapon*>(E);
@@ -122,8 +122,12 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                 }
             }
         }
+
+        loadout_index += 1;
+        string32 buf;
+        loadout_section = strconcat(sizeof(buf), buf, "spawn_loadout", std::to_string(loadout_index).c_str());
     }
-    //-Alundaio
+    // -Alundaio
 
     if (ini.section_exist("spawn"))
     {
@@ -133,7 +137,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         {
             VERIFY(xr_strlen(N));
 
-            if (pSettings->section_exist(N)) //Alundaio: verify item section exists!
+            if (pSettings->section_exist(N)) // Alundaio: verify item section exists!
             {
                 float f_cond = 1.0f;
                 bool bScope = false;
@@ -166,7 +170,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                     if (randF(1.f) < p)
                     {
                         CSE_Abstract* E = alife().spawn_item(N, o_Position, m_tNodeID, m_tGraphID, ID);
-                        //подсоединить аддоны к оружию, если включены соответствующие флажки
+                        // подсоединить аддоны к оружию, если включены соответствующие флажки
                         CSE_ALifeItemWeapon* W = smart_cast<CSE_ALifeItemWeapon*>(E);
                         if (W)
                         {

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -129,7 +129,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
 
         loadout_index += 1;
         string32 buf;
-        loadout_section = strconcat(sizeof(buf), buf, "spawn_loadout", std::to_string(loadout_index).c_str());
+        xr_sprintf(loadout_section, "spawn_loadout%d", loadout_index);
     }
     // -Alundaio
 

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -27,7 +27,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
     IReader reader((void*)ini_string, xr_strlen(ini_string));
     CInifile ini(&reader, FS.get_path("$game_config$")->m_Path);
 #pragma warning(pop)
-    u8 loadoutIndex = 1;
+    u8 loadoutIndex = 0;
     string32 loadoutSection = "spawn_loadout";
 
     // Alundaio: This will spawn a single random section listed in [spawn_loadout].

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -175,9 +175,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
 
                     // probability
                     if (strstr(V, "prob=") != nullptr)
-                        p = static_cast<float>(atof(strstr(V, "prob=") + 5));
-                    if (fis_zero(p))
-                        p = 1.0f;
+                        sscanf(strstr(V, "prob=") + 5, "%f", &p);
                     if (strstr(V, "cond=") != nullptr)
                         fCond = static_cast<float>(atof(strstr(V, "cond=") + 5));
                 }
@@ -227,10 +225,12 @@ bool CSE_ALifeObject::is_spawn_supplies_flag_set(pcstr value, pcstr flag)
                 return true;
             }
 
-            float probability = static_cast<float>(atof(flagSubstring + flagLength + 1));
+            float probability = 1.0;
 
-            // Assume 0 is 1 for cases like `flag=,flag=\n` and consistency with `prob` calculations.
-            return fis_zero(probability) ? true : randF(1.f) <= probability;
+            if (sscanf(flagSubstring + flagLength + 1, "%f", &probability) == 1)
+                return randF(1.f) <= probability;
+            else
+                return true;
         }
         // Short variant of flag without assigned value.
         else

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -1,9 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////
-//  Module      : alife_object.cpp
-//  Created     : 27.10.2005
-//  Modified    : 27.10.2005
-//  Author      : Dmitriy Iassenev
-//  Description : ALife object class
+//	Module 		: alife_object.cpp
+//	Created 	: 27.10.2005
+//  Modified 	: 27.10.2005
+//	Author		: Dmitriy Iassenev
+//	Description : ALife object class
 ////////////////////////////////////////////////////////////////////////////
 
 #include "StdAfx.h"
@@ -175,7 +175,7 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
 
                     // probability
                     if (strstr(V, "prob=") != nullptr)
-                        sscanf(strstr(V, "prob=") + 5, "%f", &p);
+                        p = static_cast<float>(atof(strstr(V, "prob=") + 5));
                     if (strstr(V, "cond=") != nullptr)
                         fCond = static_cast<float>(atof(strstr(V, "cond=") + 5));
                 }
@@ -225,12 +225,7 @@ bool CSE_ALifeObject::is_spawn_supplies_flag_set(pcstr value, pcstr flag)
                 return true;
             }
 
-            float probability = 1.0;
-
-            if (sscanf(flagSubstring + flagLength + 1, "%f", &probability) == 1)
-                return randF(1.f) <= probability;
-            else
-                return true;
+            return randF(1.f) <= static_cast<float>(atof(flagSubstring + flagLength + 1));
         }
         // Short variant of flag without assigned value.
         else

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -1,9 +1,9 @@
 ////////////////////////////////////////////////////////////////////////////
-//	Module 		: alife_object.cpp
-//	Created 	: 27.10.2005
-//  Modified 	: 27.10.2005
-//	Author		: Dmitriy Iassenev
-//	Description : ALife object class
+//  Module      : alife_object.cpp
+//  Created     : 27.10.2005
+//  Modified    : 27.10.2005
+//  Author      : Dmitriy Iassenev
+//  Description : ALife object class
 ////////////////////////////////////////////////////////////////////////////
 
 #include "StdAfx.h"
@@ -23,11 +23,11 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
         return;
 
     luabind::functor<bool> funct;
-	if (GEnv.ScriptEngine->functor("ai_stalker.CSE_ALifeObject_spawn_supplies", funct))
-	{
-		if (funct(this, ID, ini_string))
-			return;
-	}
+    if (GEnv.ScriptEngine->functor("ai_stalker.CSE_ALifeObject_spawn_supplies", funct))
+    {
+        if (funct(this, ID, ini_string))
+            return;
+    }
 
 #pragma warning(push)
 #pragma warning(disable : 4238)
@@ -90,7 +90,8 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                         bSilencer = is_spawn_supplies_flag_set(V, "silencer");
                         bLauncher = is_spawn_supplies_flag_set(V, "launcher");
 
-                        if (!spawnCount) spawnCount = 1;
+                        if (!spawnCount)
+                            spawnCount = 1;
                         if (strstr(V, "cond=") != nullptr)
                             fCond = static_cast<float>(atof(strstr(V, "cond=") + 5));
                         if (strstr(V, "ammo_type=") != nullptr)

--- a/src/xrServerEntities/xrServer_Objects_ALife.h
+++ b/src/xrServerEntities/xrServer_Objects_ALife.h
@@ -168,6 +168,7 @@ public:
     virtual u32 ef_weapon_type() const;
     virtual u32 ef_detector_type() const;
 #ifdef XRGAME_EXPORTS
+    virtual bool is_spawn_supplies_flag_set(LPCSTR, LPCSTR);
     virtual void spawn_supplies(LPCSTR);
     virtual void spawn_supplies();
     CALifeSimulator& alife() const;

--- a/src/xrServerEntities/xrServer_Objects_ALife.h
+++ b/src/xrServerEntities/xrServer_Objects_ALife.h
@@ -168,7 +168,7 @@ public:
     virtual u32 ef_weapon_type() const;
     virtual u32 ef_detector_type() const;
 #ifdef XRGAME_EXPORTS
-    virtual bool is_spawn_supplies_flag_set(LPCSTR, LPCSTR);
+    virtual bool is_spawn_supplies_flag_set(pcstr value, pcstr flag);
     virtual void spawn_supplies(LPCSTR);
     virtual void spawn_supplies();
     CALifeSimulator& alife() const;


### PR DESCRIPTION
Allows addition of sections `spawn_loadout`, `spawn_loadout2` ... `spawn_loadoutN` for stalkers items randomization.
Definition of rifle + pistol character description becomes simpler and more readable.

## Related

https://github.com/OpenXRay/xray-16/issues/1529

## Changes

- Similar to CoC support few loadouts in character description
- Support silencer/scope probability to spawn
- Add callback for script based handling of loadouts (https://github.com/revolucas/CoC-Xray/blob/master/src/xrGame/alife_object.cpp#L29)
- Respect count value in loadouts for non-weapon items

