### PR TITLE
Fix SDL2::SDL2 target was not found (fixes #1595)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,16 @@ add_compile_definitions(
 
 if (NOT WIN32)
     find_package(SDL2 REQUIRED)
+    # ref: issue-1595
+    # Fix to support older SDL2
+    if(NOT TARGET SDL2::SDL2 AND DEFINED SDL2_LIBRARIES)
+        add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+        set_target_properties(
+            SDL2::SDL2 PROPERTIES
+            IMPORTED_LOCATION "${SDL2_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+        )
+    endif()
     find_package(OpenGL REQUIRED)
     find_package(GLEW REQUIRED)
     find_package(OpenAL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,9 +239,9 @@ add_compile_definitions(
 
 if (NOT WIN32)
     find_package(SDL2 REQUIRED)
-    # ref: issue-1595
     # Fix to support older SDL2
-    if(NOT TARGET SDL2::SDL2 AND DEFINED SDL2_LIBRARIES)
+    # https://github.com/OpenXRay/xray-16/issues/1595
+    if (NOT TARGET SDL2::SDL2 AND DEFINED SDL2_LIBRARIES)
         add_library(SDL2::SDL2 UNKNOWN IMPORTED)
         set_target_properties(
             SDL2::SDL2 PROPERTIES


### PR DESCRIPTION
Fix to the issue reported in #1595 

* Update CMake files to supported older SDL2
* Tested on Ubuntu 20.04 with 3.28.1
* Now project can be build and runs as expected

```
$ cmake ..
-- CMAKE_VERSION: 3.28.1
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_VERBOSE_MAKEFILE: FALSE
-- git commit: be53de4e2217b7e52be76d7d371e9d34791a1789
-- git branch: dev-issue-1595
-- CMAKE_SYSTEM_PROCESSOR: x86_64
-- CMAKE_BUILD_TYPE: Release
-- MASTER_GOLD: ON
-- STATIC_BUILD: ON
-- CMAKE_UNITY_BUILD: OFF
-- USE_ADDRESS_SANITIZER: OFF
-- USE_LTO: ON
-- Performing Test GOLD_LINKER_AVAILABLE
-- Performing Test GOLD_LINKER_AVAILABLE - Success
-- Performing Test LLD_LINKER_AVAILABLE
-- Performing Test LLD_LINKER_AVAILABLE - Success
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libOpenGL.so   
-- Found GLEW: /usr/include (found version "2.1.0") 
-- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so  
-- Found JPEG: /usr/lib/x86_64-linux-gnu/libjpeg.so (found version "80") 
-- Found Ogg: /usr/lib/x86_64-linux-gnu/libogg.so  
-- Found Vorbis: /usr/lib/x86_64-linux-gnu/libvorbis.so   
-- Found Theora: /usr/lib/x86_64-linux-gnu/libtheora.so   
-- Found LZO: /usr/lib/x86_64-linux-gnu/liblzo2.so  
-- Could NOT find mimalloc (missing: mimalloc_DIR)
Using standard memory allocator
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
rm -f luajit libluajit.a libluajit.so host/minilua host/buildvm lj_vm.S lj_bcdef.h lj_ffdef.h lj_libdef.h lj_recdef.h lj_folddef.h host/buildvm_arch.h jit/vmdef.lua *.o host/*.o *.obj *.lib *.exp *.dll *.exe *.manifest *.pdb *.ilk
-- Configuring done (1.6s)
-- Generating done (0.4s)
-- Build files have been written to: /home/pavel/git/GitHub/xray-16/bin
```