### PR TITLE
CMake: Use CMAKE_SYSTEM_PROCESSOR instead of ARCH_TYPE variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,18 @@ project(OpenXRay
     HOMEPAGE_URL "https://github.com/OpenXRay/xray-16"
     LANGUAGES CXX C
 )
-message(STATUS "CMAKE_PROJECT_VERSION: ${}")
+
+# Detect arch type ( x86 or x64 )
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(ARCH_TYPE x64)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(ARCH_TYPE x86)
+else()
+    set(ARCH_TYPE unknown)
+endif()
+message(STATUS "Arch type: ${ARCH_TYPE}")
+
+message(STATUS "CMAKE_PROJECT_VERSION: ${CMAKE_PROJECT_VERSION}")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,6 @@ project(OpenXRay
     LANGUAGES CXX C
 )
 
-# Detect arch type ( x86 or x64 )
-if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(ARCH_TYPE x64)
-elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-    set(ARCH_TYPE x86)
-else()
-    set(ARCH_TYPE unknown)
-endif()
-message(STATUS "Arch type: ${ARCH_TYPE}")
-
 message(STATUS "CMAKE_PROJECT_VERSION: ${CMAKE_PROJECT_VERSION}")
 
 set(CMAKE_CXX_STANDARD 17)
@@ -55,7 +45,7 @@ include(packaging)
 set_git_info()
 
 # Output all libraries and executable to one folder
-set(COMPILE_OUTPUT_FOLDER "${CMAKE_SOURCE_DIR}/bin/${ARCH_TYPE}/${CMAKE_BUILD_TYPE}")
+set(COMPILE_OUTPUT_FOLDER "${CMAKE_SOURCE_DIR}/bin/${CMAKE_SYSTEM_PROCESSOR}/${CMAKE_BUILD_TYPE}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${COMPILE_OUTPUT_FOLDER}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${COMPILE_OUTPUT_FOLDER}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${COMPILE_OUTPUT_FOLDER}")

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -24,13 +24,6 @@ function(target_sources_grouped)
     source_group(${PARSED_ARGS_NAME} FILES ${PARSED_ARGS_FILES})
 endfunction()
 
-# Detect arch type ( x86 or x64 )
-if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(ARCH_TYPE x64)
-else (CMAKE_SIZEOF_VOID_P EQUAL 4)
-    set(ARCH_TYPE x86)
-endif()
-
 function(set_git_info)
     execute_process(COMMAND git rev-parse --verify HEAD
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
This was caused by using the `CMAKE_SIZEOF_VOID_P` variable before it is actually set by cmake (after a call to project).

https://cmake.org/cmake/help/latest/variable/CMAKE_SIZEOF_VOID_P.html

> This is set to the size of a pointer on the target machine, and is
> determined when a compiled language is enabled. (...)

Also the `else(...)` construct in CMake works a bit different than the original author expected since the expression is not evaluated and thus we always set `ARCH_TYPE` to `x86` which is not correct.

Also took the liberty to properly output the `CMAKE_PROJECT_VERSION` and the `ARCH_TYPE` variables.