### PR TITLE
[FIX] Fix r5 hbao variable re-declaration.

### DIFF
--- a/res/gamedata/shaders/r5/ssao_hbao.ps
+++ b/res/gamedata/shaders/r5/ssao_hbao.ps
@@ -10,10 +10,8 @@ float4 calc_hbao(float z, float3 N, float2 tc0, float4 pos2d)
 //cbuffer PixelGlobalShaderData_s : register(b0)
 //{
 
-uniform	float4		screen_res_r5;
-
-#define g_Resolution screen_res_r5.xy
-#define g_InvResolution screen_res_r5.zw
+#define g_Resolution screen_res.xy
+#define g_InvResolution screen_res.zw
 
 static const float g_MaxFootprintUV=0.01f;
 

--- a/res/gamedata/shaders/r5/ssao_hbao.ps
+++ b/res/gamedata/shaders/r5/ssao_hbao.ps
@@ -10,10 +10,10 @@ float4 calc_hbao(float z, float3 N, float2 tc0, float4 pos2d)
 //cbuffer PixelGlobalShaderData_s : register(b0)
 //{
 
-uniform	float4		screen_res;
+uniform	float4		screen_res_r5;
 
-#define g_Resolution screen_res.xy
-#define g_InvResolution screen_res.zw
+#define g_Resolution screen_res_r5.xy
+#define g_InvResolution screen_res_r5.zw
 
 static const float g_MaxFootprintUV=0.01f;
 


### PR DESCRIPTION
## Changes

- Fixing variable re-declaration and error with r5 HBAO

```
Index: res/gamedata/shaders/r5/ssao_hbao.ps
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/res/gamedata/shaders/r5/ssao_hbao.ps b/res/gamedata/shaders/r5/ssao_hbao.ps
--- a/res/gamedata/shaders/r5/ssao_hbao.ps	(revision f3ce61e5b52321f7a9fbcfa9e725cb9e8a88bec9)
+++ b/res/gamedata/shaders/r5/ssao_hbao.ps	(revision 5cfbd42cbfb4d6139337156146e18d7a808ea0a7)
@@ -10,10 +10,10 @@
 //cbuffer PixelGlobalShaderData_s : register(b0)
 //{
 
-uniform	float4		screen_res;
+uniform	float4		screen_res_r5;
 
-#define g_Resolution screen_res.xy
-#define g_InvResolution screen_res.zw
+#define g_Resolution screen_res_r5.xy
+#define g_InvResolution screen_res_r5.zw
 
 static const float g_MaxFootprintUV=0.01f;
 
```

## Log

```
!  f:\applications\steam\steamapps\common\stalker call of pripyat\_appdata_\shaders_cache_oxr\r4\ssao_calc_nomsaa.ps\204811110011000000001010000011133211011113281000000
! error:  common_functions.h(101,2-37): warning X3206: implicit truncation of vector type
common_functions.h(106,9-59): warning X3206: implicit truncation of vector type
common_functions.h(138,2-37): warning X3206: implicit truncation of vector type
ssao.ps(156,9-55): warning X3206: implicit truncation of vector type
ssao.ps(197,9-57): warning X3206: implicit truncation of vector type
ssao_hbao.ps(13,17-26): error X3003: redefinition of 'screen_res'
```

## Screenshots

![image](https://github.com/OpenXRay/xray-16/assets/18573775/979bb6be-a1b9-4bbf-8ab3-39007381193f)


## Links

- Related to https://github.com/OpenXRay/xray-16/pull/1407#issuecomment-1732444642