### PR TITLE
[xrCore] Several Level 3 warnings eliminated

### DIFF
--- a/src/Common/Compiler.inl
+++ b/src/Common/Compiler.inl
@@ -26,6 +26,8 @@
 #endif
 
 #elif defined(_MSC_VER)
+// XXX: Disables MSVC warnings on unsafe C library functions. Should be removed later.
+#define _CRT_SECURE_NO_WARNINGS
 #include <intrin.h> // for __debugbreak
 
 #define NO_INLINE               __declspec(noinline)

--- a/src/xrCore/Animation/Motion.cpp
+++ b/src/xrCore/Animation/Motion.cpp
@@ -156,7 +156,7 @@ void COMotion::DeleteKey(float t) const
     envs[ctRotationB]->DeleteKey(t);
 }
 
-int COMotion::KeyCount() const { return envs[ctPositionX]->keys.size(); }
+size_t COMotion::KeyCount() const { return envs[ctPositionX]->keys.size(); }
 
 void COMotion::FindNearestKey(float t, float& mn, float& mx, float eps) const
 {

--- a/src/xrCore/Animation/Motion.hpp
+++ b/src/xrCore/Animation/Motion.hpp
@@ -119,7 +119,7 @@ public:
     void CreateKey(float t, const Fvector& P, const Fvector& R) const;
     void DeleteKey(float t) const;
     void NormalizeKeys();
-    int KeyCount() const;
+    size_t KeyCount() const;
     CEnvelope* Envelope(EChannelType et = ctPositionX) { return envs[et]; }
     BOOL ScaleKeys(float from_time, float to_time, float scale_factor) const;
     BOOL NormalizeKeys(float from_time, float to_time, float speed);

--- a/src/xrCore/Animation/SkeletonMotions.hpp
+++ b/src/xrCore/Animation/SkeletonMotions.hpp
@@ -178,7 +178,7 @@ public:
     CPartDef() : Name(0){};
 
     [[nodiscard]]
-    u32 mem_usage() const { return sizeof(*this) + bones.size() * sizeof(u32) + sizeof(Name); }
+    u64 mem_usage() const { return sizeof(*this) + bones.size() * sizeof(bones[0]) + sizeof(Name); }
 };
 class XRCORE_API CPartition
 {
@@ -188,7 +188,7 @@ public:
     IC CPartDef& operator[](u16 id) { return P[id]; }
     IC const CPartDef& part(u16 id) const { return P[id]; }
     [[nodiscard]] u16 part_id(const shared_str& name) const;
-    [[nodiscard]] u32 mem_usage() const { return P[0].mem_usage() * MAX_PARTS; }
+    [[nodiscard]] u64 mem_usage() const { return P[0].mem_usage() * MAX_PARTS; }
     void load(IKinematics* V, pcstr model_name);
 
     [[nodiscard]] u8 count() const
@@ -217,9 +217,9 @@ struct XRCORE_API motions_value
     BOOL load(pcstr N, IReader* data, vecBones* bones);
     MotionVec* bone_motions(shared_str bone_name);
 
-    u32 mem_usage()
+    u64 mem_usage()
     {
-        u32 sz = sizeof(*this) + m_motion_map.size() * 6 + m_partition.mem_usage();
+        u64 sz = sizeof(*this) + m_motion_map.size() * 6 + m_partition.mem_usage();
         for (auto it = m_mdefs.begin(); it != m_mdefs.end(); ++it)
             sz += it->mem_usage();
         for (auto bm_it = m_motions.begin(); bm_it != m_motions.end(); ++bm_it)

--- a/src/xrCore/Animation/interp.cpp
+++ b/src/xrCore/Animation/interp.cpp
@@ -268,7 +268,7 @@ float evalEnvelope(CEnvelope* env, float time)
         return env->keys[0]->value;
 
     // find the first and last keys
-    int sz = env->keys.size();
+    size_t sz = env->keys.size();
     skey = env->keys[0];
     ekey = env->keys[sz - 1];
     skey_n = env->keys[1];

--- a/src/xrCore/Compression/rt_compressor9.cpp
+++ b/src/xrCore/Compression/rt_compressor9.cpp
@@ -10,7 +10,7 @@
 thread_local HEAP_ALLOC(rtc9_wrkmem, LZO1X_999_MEM_COMPRESS);
 
 static u8* _LZO_Dictionary = nullptr;
-static u32 _LZO_DictionarySize = 0;
+static lzo_uint _LZO_DictionarySize = 0;
 
 //------------------------------------------------------------------------------
 

--- a/src/xrCore/Crypto/trivial_encryptor.cpp
+++ b/src/xrCore/Crypto/trivial_encryptor.cpp
@@ -59,7 +59,7 @@ void trivial_encryptor::initialize(key_flag what)
         m_alphabet_back[m_alphabet[i]] = (type)i;
 }
 
-void trivial_encryptor::encode(pcvoid source, const u32& source_size, pvoid destination, key_flag what /*= key_flag::worldwide*/)
+void trivial_encryptor::encode(pcvoid source, const size_t& source_size, pvoid destination, key_flag what /*= key_flag::worldwide*/)
 {
     if (what != m_current_key)
     {
@@ -75,7 +75,7 @@ void trivial_encryptor::encode(pcvoid source, const u32& source_size, pvoid dest
         *J = m_alphabet[*I] ^ type(temp.random(alphabet_size) & 0xff);
 }
 
-void trivial_encryptor::decode(pcvoid source, const u32& source_size, pvoid destination, key_flag what /*= key_flag::worldwide*/)
+void trivial_encryptor::decode(pcvoid source, const size_t& source_size, pvoid destination, key_flag what /*= key_flag::worldwide*/)
 {
     if (what != m_current_key)
     {

--- a/src/xrCore/Crypto/trivial_encryptor.h
+++ b/src/xrCore/Crypto/trivial_encryptor.h
@@ -40,8 +40,8 @@ private:
 public:
     trivial_encryptor();
 
-    void encode(pcvoid source, const u32& source_size, pvoid destination, key_flag what = key_flag::worldwide);
-    void decode(pcvoid source, const u32& source_size, pvoid destination, key_flag what = key_flag::worldwide);
+    void encode(pcvoid source, const size_t& source_size, pvoid destination, key_flag what = key_flag::worldwide);
+    void decode(pcvoid source, const size_t& source_size, pvoid destination, key_flag what = key_flag::worldwide);
 };
 
 extern XRCORE_API trivial_encryptor g_trivial_encryptor;

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -271,7 +271,7 @@ const CLocatorAPI::file* CLocatorAPI::Register(
 IReader* open_chunk(void* ptr, u32 ID, pcstr archiveName, size_t archiveSize, bool shouldDecrypt = false)
 {
     u32 dwType = INVALID_SET_FILE_POINTER;
-    size_t dwSize = 0;
+    u32 dwSize = 0;
     DWORD read_byte;
     u32 pt = SetFilePointer(ptr, 0, nullptr, FILE_BEGIN);
     VERIFY(pt != INVALID_SET_FILE_POINTER);
@@ -1388,7 +1388,7 @@ void CLocatorAPI::file_from_archive(IReader*& R, pcstr fname, const file& desc)
         end = A.size;
     const size_t sz = end - start;
 #if defined(XR_PLATFORM_WINDOWS)
-    u8* ptr = (u8*)MapViewOfFile(A.hSrcMap, FILE_MAP_READ, 0, start, sz);
+    u8* ptr = (u8*)MapViewOfFile(A.hSrcMap, FILE_MAP_READ, 0, static_cast<DWORD>(start), sz);
     VERIFY3(ptr, "cannot create file mapping on file", fname);
 #elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_BSD) || defined(XR_PLATFORM_APPLE)
     u8* ptr = (u8*)::mmap(NULL, sz, PROT_READ, MAP_SHARED, A.hSrcFile, start);

--- a/src/xrCore/XML/XMLDocument.cpp
+++ b/src/xrCore/XML/XMLDocument.cpp
@@ -248,9 +248,9 @@ XML_NODE XMLDocument::NavigateToNode(pcstr path, const size_t node_index) const
 XML_NODE XMLDocument::NavigateToNodeWithAttribute(pcstr tag_name, pcstr attrib_name, pcstr attrib_value) const
 {
     CONST_XML_NODE root = GetLocalRoot() ? GetLocalRoot() : GetRoot();
-    int tabsCount = GetNodesNum(root, tag_name);
+    size_t tabsCount = GetNodesNum(root, tag_name);
 
-    for (int i = 0; i < tabsCount; ++i)
+    for (size_t i = 0; i < tabsCount; ++i)
     {
         pcstr result = ReadAttrib(root, tag_name, i, attrib_name, "");
         if (result && xr_strcmp(result, attrib_value) == 0)
@@ -523,9 +523,9 @@ pcstr XMLDocument::CheckUniqueAttrib(CONST_XML_NODE start_node, pcstr tag_name, 
 {
     m_AttribValues.clear();
 
-    int tags_num = GetNodesNum(start_node, tag_name);
+    size_t tags_num = GetNodesNum(start_node, tag_name);
 
-    for (int i = 0; i < tags_num; i++)
+    for (size_t i = 0; i < tags_num; i++)
     {
         pcstr attrib = ReadAttrib(start_node, tag_name, i, attrib_name, nullptr);
 

--- a/src/xrCore/_std_extensions.h
+++ b/src/xrCore/_std_extensions.h
@@ -245,8 +245,8 @@ constexpr u32 operator""_hash(char const* p, size_t size) { return strhash({ p, 
 
 XRCORE_API char* timestamp(string64& dest);
 
-extern XRCORE_API u32 crc32(const void* P, u32 len);
-extern XRCORE_API u32 crc32(const void* P, u32 len, u32 starting_crc);
-extern XRCORE_API u32 path_crc32(const char* path, u32 len); // ignores '/' and '\'
+extern XRCORE_API u32 crc32(const void* P, size_t len);
+extern XRCORE_API u32 crc32(const void* P, size_t len, u32 starting_crc);
+extern XRCORE_API u32 path_crc32(const char* path, size_t len); // ignores '/' and '\'
 
 #endif // _STD_EXT_internal

--- a/src/xrCore/crc32.cpp
+++ b/src/xrCore/crc32.cpp
@@ -44,7 +44,7 @@ constexpr std::array<u32, 256> generate_crc32_lookup_table() noexcept
 // Lookup table array
 static constexpr auto crc32_table = generate_crc32_lookup_table();
 
-u32 crc32(const void* P, u32 len)
+u32 crc32(const void* P, size_t len)
 {
     // Pass a text string to this function and it will return the CRC.
 
@@ -68,7 +68,7 @@ u32 crc32(const void* P, u32 len)
     return ulCRC ^ 0xffffffff;
 }
 
-u32 crc32(const void* P, u32 len, u32 starting_crc)
+u32 crc32(const void* P, size_t len, u32 starting_crc)
 {
     u32 ulCRC = 0xffffffff ^ starting_crc;
     u8* buffer = (u8*)P;
@@ -79,7 +79,7 @@ u32 crc32(const void* P, u32 len, u32 starting_crc)
     return ulCRC ^ 0xffffffff;
 }
 
-u32 path_crc32(const char* path, u32 len)
+u32 path_crc32(const char* path, size_t len)
 {
     u32 ulCRC = 0xffffffff;
     u8* buffer = (u8*)path;

--- a/src/xrCore/log.cpp
+++ b/src/xrCore/log.cpp
@@ -81,7 +81,7 @@ void Log(pcstr s)
 {
     int i, j;
 
-    const u32 length = xr_strlen(s);
+    const size_t length = xr_strlen(s);
     pstr split = static_cast<pstr>(xr_alloca((length + 1) * sizeof(char)));
     for (i = 0, j = 0; s[i] != 0; i++)
     {
@@ -125,7 +125,7 @@ void Log(pcstr msg, pcstr dop)
         return;
     }
 
-    const u32 buffer_size = (xr_strlen(msg) + 1 + xr_strlen(dop) + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + xr_strlen(dop) + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
     strconcat(buffer_size, buf, msg, " ", dop);
     Log(buf);
@@ -133,7 +133,7 @@ void Log(pcstr msg, pcstr dop)
 
 void Log(pcstr msg, int dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 11 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 11 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %i", msg, dop);
@@ -142,7 +142,7 @@ void Log(pcstr msg, int dop)
 
 void Log(pcstr msg, unsigned int dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 10 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 10 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %u", msg, dop);
@@ -151,7 +151,7 @@ void Log(pcstr msg, unsigned int dop)
 
 void Log(pcstr msg, long dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %li", msg, dop);
@@ -160,7 +160,7 @@ void Log(pcstr msg, long dop)
 
 void Log(pcstr msg, unsigned long dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %lu", msg, dop);
@@ -169,7 +169,7 @@ void Log(pcstr msg, unsigned long dop)
 
 void Log(pcstr msg, long long dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %lli", msg, dop);
@@ -178,7 +178,7 @@ void Log(pcstr msg, long long dop)
 
 void Log(pcstr msg, unsigned long long dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %llu", msg, dop);
@@ -189,7 +189,7 @@ void Log(pcstr msg, float dop)
 {
     // actually, float string representation should be no more, than 40 characters,
     // but we will count with slight overhead
-    const u32 buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 1 + 64 + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s %f", msg, dop);
@@ -198,7 +198,7 @@ void Log(pcstr msg, float dop)
 
 void Log(pcstr msg, const Fvector& dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 2 + 3 * (64 + 1) + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 2 + 3 * (64 + 1) + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s (%f,%f,%f)", msg, VPUSH(dop));
@@ -207,7 +207,7 @@ void Log(pcstr msg, const Fvector& dop)
 
 void Log(pcstr msg, const Fmatrix& dop)
 {
-    const u32 buffer_size = (xr_strlen(msg) + 2 + 4 * (4 * (64 + 1) + 1) + 1) * sizeof(char);
+    const size_t buffer_size = (xr_strlen(msg) + 2 + 4 * (4 * (64 + 1) + 1) + 1) * sizeof(char);
     pstr buf = static_cast<pstr>(xr_alloca(buffer_size));
 
     xr_sprintf(buf, buffer_size, "%s:\n%f,%f,%f,%f\n%f,%f,%f,%f\n%f,%f,%f,%f\n%f,%f,%f,%f\n", msg, dop.i.x, dop.i.y,

--- a/src/xrCore/stream_reader.cpp
+++ b/src/xrCore/stream_reader.cpp
@@ -58,7 +58,7 @@ void CStreamReader::map(const size_t& new_offset)
     m_current_window_size = end_offset - start_offset;
 #if defined(XR_PLATFORM_WINDOWS)
     m_current_map_view_of_file =
-        static_cast<u8*>(MapViewOfFile(m_file_mapping_handle, FILE_MAP_READ, 0, start_offset, m_current_window_size));
+        static_cast<u8*>(MapViewOfFile(m_file_mapping_handle, FILE_MAP_READ, 0, static_cast<DWORD>(start_offset), m_current_window_size));
 #elif defined(XR_PLATFORM_LINUX) || defined(XR_PLATFORM_BSD) || defined(XR_PLATFORM_APPLE)
     m_current_map_view_of_file =
         static_cast<u8*>(::mmap(NULL, m_current_window_size, PROT_READ, MAP_SHARED, m_file_mapping_handle, start_offset));

--- a/src/xrCore/stream_reader_inline.h
+++ b/src/xrCore/stream_reader_inline.h
@@ -33,7 +33,7 @@ IC intptr_t CStreamReader::elapsed() const
 }
 
 IC const size_t& CStreamReader::length() const { return m_file_size; }
-IC void CStreamReader::seek(const int& offset) { advance(offset - tell()); }
+IC void CStreamReader::seek(const int& offset) { advance(offset - static_cast<int>(tell())); }
 IC size_t CStreamReader::tell() const
 {
     VERIFY(m_current_pointer >= m_start_pointer);

--- a/src/xrCore/string_concatenations_inline.h
+++ b/src/xrCore/string_concatenations_inline.h
@@ -58,10 +58,10 @@ public:
     }
 
 private:
-    static const u32 MAX_CONCAT_RESULT_SIZE = static_cast<u32>(512 * 1024);
-    static const u32 MAX_ITEM_COUNT = static_cast<u32>(6);
+    static const size_t MAX_CONCAT_RESULT_SIZE = static_cast<size_t>(512 * 1024);
+    static const size_t MAX_ITEM_COUNT = static_cast<size_t>(6);
 
-    template <u32 index>
+    template <size_t index>
     struct helper
     {
         static size_t get_length(pcstr string) { return string ? xr_strlen(string) : 0; }
@@ -85,7 +85,7 @@ private:
     using StringPair = std::pair<pcstr, size_t>;
 
     StringPair m_strings[MAX_ITEM_COUNT];
-    u32 m_count;
+    size_t m_count;
 };
 
 void XRCORE_API check_stack_overflow(u32 stack_increment);

--- a/src/xrCore/xr_ini.cpp
+++ b/src/xrCore/xr_ini.cpp
@@ -492,7 +492,7 @@ void CInifile::Load(IReader* F, pcstr path, allow_include_func_t allow_include_f
                 VERIFY2(m_flags.test(eReadOnly), "Allow for readonly mode only.");
                 inherited_names += 2;
                 u32 cnt = _GetItemCount(inherited_names);
-                u32 total_count = 0;
+                size_t total_count = 0;
                 u32 k = 0;
                 for (k = 0; k < cnt; ++k)
                 {
@@ -691,21 +691,21 @@ bool CInifile::line_exist(pcstr S, pcstr L) const
     return A != I.Data.end() && xr_strcmp(*A->first, L) == 0;
 }
 
-u32 CInifile::line_count(pcstr Sname) const
+size_t CInifile::line_count(pcstr Sname) const
 {
     Sect& S = r_section(Sname);
-    u32 C = 0;
+    size_t C = 0;
     for (const auto& item : S.Data)
         if (*item.first)
             C++;
     return C;
 }
 
-u32 CInifile::section_count() const { return DATA.size(); }
+size_t CInifile::section_count() const { return DATA.size(); }
 //--------------------------------------------------------------------------------------
 CInifile::Sect& CInifile::r_section(const shared_str& S) const { return r_section(*S); }
 bool CInifile::line_exist(const shared_str& S, const shared_str& L)const { return line_exist(*S, *L); }
-u32 CInifile::line_count(const shared_str& S) const { return line_count(*S); }
+size_t CInifile::line_count(const shared_str& S) const { return line_count(*S); }
 bool CInifile::section_exist(const shared_str& S) const { return section_exist(*S); }
 //--------------------------------------------------------------------------------------
 // Read functions
@@ -757,7 +757,7 @@ shared_str CInifile::r_string_wb(pcstr S, pcstr L) const
 
     string4096 _original;
     xr_strcpy(_original, sizeof _original, _base);
-    u32 _len = xr_strlen(_original);
+    size_t _len = xr_strlen(_original);
     if (0 == _len)
         return shared_str("");
     if ('"' == _original[_len - 1])

--- a/src/xrCore/xr_ini.h
+++ b/src/xrCore/xr_ini.h
@@ -88,9 +88,9 @@ public:
     Sect& r_section(const shared_str& S) const;
     bool line_exist(pcstr S, pcstr L)const;
     bool line_exist(const shared_str& S, const shared_str& L)const;
-    u32 line_count(pcstr S) const;
-    u32 line_count(const shared_str& S) const;
-    u32 section_count() const;
+    size_t line_count(pcstr S) const;
+    size_t line_count(const shared_str& S) const;
+    size_t section_count() const;
     bool section_exist(pcstr S) const;
     bool section_exist(const shared_str& S) const;
     Root& sections() { return DATA; }


### PR DESCRIPTION
I have addressed several Level 3 warnings within the *xrCore* component of the Engine. 

It's important to note that there are still multiple warnings remaining unresolved. These may necessitate further discussion as I have focused on rectifying issues that were straightforward and did not demand significant code alterations or excessive use of explicit `static_cast`, except in instances where, in my opinion, a static cast was necessary.

I believe this PR could be linked with #116.