### PR TITLE
[POC] Restore 3rd party dependencies using NuGet for MSVC generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,13 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT XRAY_USE_DEFAULT_CXX_LIB)
     endif()
 endif()
 
-add_compile_options(-Wno-attributes)
-if (APPLE)
-    add_compile_options(-Wl,-undefined,error)
-else()
-    add_compile_options(-Wl,--no-undefined)
+if (NOT MSVC)
+    add_compile_options(-Wno-attributes)
+    if (APPLE)
+        add_compile_options(-Wl,-undefined,error)
+    else()
+        add_compile_options(-Wl,--no-undefined)
+    endif()
 endif()
 
 # TODO test
@@ -229,6 +231,10 @@ add_compile_definitions(
     _CPPUNWIND
 )
 
+include(restoreFromNuget)
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    restore_from_nuget()
+endif()
 if (NOT WIN32)
     find_package(SDL2 REQUIRED)
     find_package(OpenGL REQUIRED)
@@ -263,28 +269,36 @@ option(XRAY_USE_LUAJIT "Use LuaJIT" ON)
 
 add_subdirectory(Externals)
 
-add_compile_options(
-    -Wall
-    #-Werror
-    -Wextra
-    #-pedantic
-    -Wno-unknown-pragmas
-    -Wno-strict-aliasing
-    -Wno-parentheses
-    -Wno-unused-label
-    -Wno-unused-parameter
-    -Wno-switch
-    #-Wno-padded
-    #-Wno-c++98-compat
-    #-Wno-c++98-compat-pedantic
-    #-Wno-c++11-compat
-    #-Wno-c++11-compat-pedantic
-    #-Wno-c++14-compat
-    #-Wno-c++14-compat-pedantic
-    #-Wno-newline-eof
-    $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>>
-    $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-interference-size>>
-)
+if (MSVC)
+    add_compile_options(
+        /EHa-
+        /EHsc-
+        /EHs-
+        )
+else()
+    add_compile_options(
+        -Wall
+        #-Werror
+        -Wextra
+        #-pedantic
+        -Wno-unknown-pragmas
+        -Wno-strict-aliasing
+        -Wno-parentheses
+        -Wno-unused-label
+        -Wno-unused-parameter
+        -Wno-switch
+        #-Wno-padded
+        #-Wno-c++98-compat
+        #-Wno-c++98-compat-pedantic
+        #-Wno-c++11-compat
+        #-Wno-c++11-compat-pedantic
+        #-Wno-c++14-compat
+        #-Wno-c++14-compat-pedantic
+        #-Wno-newline-eof
+        $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>>
+        $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-interference-size>>
+    )
+endif()
 
 add_subdirectory(src)
 add_subdirectory(res)

--- a/Externals/CMakeLists.txt
+++ b/Externals/CMakeLists.txt
@@ -1,7 +1,8 @@
 if (XRAY_USE_LUAJIT)
     add_subdirectory(LuaJIT-proj)
 else()
-    find_package(Lua51 REQUIRED)
+    # TODO: Add Lua51 package
+    # find_package(Lua51 REQUIRED)
 endif()
 
 add_subdirectory(xrLuaFix)

--- a/cmake/restoreFromNuget.cmake
+++ b/cmake/restoreFromNuget.cmake
@@ -1,0 +1,40 @@
+function(restore_from_nuget)
+    message(STATUS "Generator is set to ${CMAKE_GENERATOR} - restoring NuGet dependencies...")
+    find_program(NUGET nuget)
+    if(NOT NUGET)
+        message(FATAL "Cannot find nuget. Please install it using: winget install -e --id Microsoft.NuGet")
+    endif()
+    FILE(GLOB_RECURSE NUGET_SOURCES "${CMAKE_SOURCE_DIR}/packages.config")
+    foreach(config_path IN LISTS NUGET_SOURCES )
+        message(STATUS "Restoring NuGet dependencies from ${config_path}")
+        execute_process(COMMAND
+            ${NUGET} restore ${config_path} -SolutionDirectory ${CMAKE_BINARY_DIR}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    endforeach()
+
+    SET(NUGET_PACKAGES_LOCATION "${CMAKE_BINARY_DIR}/packages")
+
+    SET(NUGET_SDL_PACKAGE_LOCATION "${NUGET_PACKAGES_LOCATION}/sdl2.nuget.2.28.5/build/native/")
+    add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+    set_target_properties(
+        SDL2::SDL2 PROPERTIES
+        IMPORTED_LOCATION "${NUGET_SDL_PACKAGE_LOCATION}/lib/${CMAKE_GENERATOR_PLATFORM}/"
+        INTERFACE_INCLUDE_DIRECTORIES "${NUGET_SDL_PACKAGE_LOCATION}/include/"
+    )
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(NUGET_D3DX_BUILD_TYPE "debug")
+    else()
+        set(NUGET_D3DX_BUILD_TYPE "release")
+    endif()
+    SET(NUGET_D3DX_PACKAGE_LOCATION "${NUGET_PACKAGES_LOCATION}/Microsoft.DXSDK.D3DX.9.29.952.8/build/native/")
+    add_library(Microsoft::DXSDK::D3DX UNKNOWN IMPORTED)
+    # TODO: Fix x86
+    set_target_properties(
+        Microsoft::DXSDK::D3DX PROPERTIES
+        IMPORTED_LOCATION "${NUGET_D3DX_PACKAGE_LOCATION}/${NUGET_D3DX_BUILD_TYPE}/bin/${CMAKE_GENERATOR_PLATFORM}/"
+        IMPORTED_IMPLIB "${NUGET_D3DX_PACKAGE_LOCATION}/${NUGET_D3DX_BUILD_TYPE}/lib/${CMAKE_GENERATOR_PLATFORM}/"
+        INTERFACE_INCLUDE_DIRECTORIES "${NUGET_D3DX_PACKAGE_LOCATION}/include/"
+    )
+endfunction()

--- a/src/Layers/CMakeLists.txt
+++ b/src/Layers/CMakeLists.txt
@@ -7,4 +7,7 @@ if (WIN32)
     add_subdirectory(xrRenderPC_R4)
 endif()
 
-add_subdirectory(xrRenderPC_GL)
+if (NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+# TODO: Add OpenGl library
+    add_subdirectory(xrRenderPC_GL)
+endif()

--- a/src/Layers/xrRenderPC_R1/CMakeLists.txt
+++ b/src/Layers/xrRenderPC_R1/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(xrRenderPC_R1 SHARED)
 target_sources(xrRenderPC_R1 PRIVATE
     FStaticRender_Blenders.cpp
     FStaticRender.cpp
-    FStaticRender_DetectSector.cpp
     FStaticRender.h
     FStaticRender_Loader.cpp
     FStaticRender_RenderTarget.cpp

--- a/src/utils/xrLC_Light/CMakeLists.txt
+++ b/src/utils/xrLC_Light/CMakeLists.txt
@@ -185,6 +185,7 @@ target_link_libraries(xrLC_Light
     xrCDB
     zlib
     xrLCUtil
+    Microsoft::DXSDK::D3DX
 )
 
 target_compile_definitions(xrLC_Light


### PR DESCRIPTION
Attempt to bring project closer to migration from hardcoded MSVS solutions to Cmake based generator. 

Verification:
* Install nuget cli `winget install -e --id Microsoft.NuGet`
* Run Cmake generator `cmake ..\xray-16 -G "Visual Studio 17 2022" -A x64 -DXRAY_USE_LUAJIT=OFF`
* Verify that packages listed as nuget dependencies are downloaded into `./packages`
* Open MSVC solution. Verify that target `xrLC_Light` does include `d3dx9` headers and they are included from expected location `..\..\..\packages\Microsoft.DXSDK.D3DX.9.29.952.8\build\native\include\d3dx9.h`