### PR TITLE
Fix crash during TaskScheduler creation

### DIFF
--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -219,7 +219,7 @@ TaskManager::~TaskManager()
     }
 }
 
-void TaskManager::MakeThreads()
+void TaskManager::SpawnThreads()
 {
     workers.reserve(std::thread::hardware_concurrency());
 

--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -192,7 +192,22 @@ void CalcIterations()
 TaskManager::TaskManager()
 {
     ZoneScoped;
+    workers.reserve(std::thread::hardware_concurrency());
+    RegisterThisThreadAsWorker();
+}
+
+void TaskManager::SpawnThreads()
+{
+    ZoneScoped;
     CalcIterations();
+
+    const u32 threads = workers.capacity() - OTHER_THREADS_COUNT;
+    workerThreads.reserve(threads);
+
+    for (u32 i = 0; i < threads; ++i)
+    {
+        workerThreads.emplace_back(Threading::RunThread("Task Worker", &TaskManager::TaskWorkerStart, this));
+    }
 }
 
 TaskManager::~TaskManager()
@@ -216,20 +231,6 @@ TaskManager::~TaskManager()
     {
         if (thread.joinable())
             thread.join();
-    }
-}
-
-void TaskManager::SpawnThreads()
-{
-    workers.reserve(std::thread::hardware_concurrency());
-
-    RegisterThisThreadAsWorker();
-
-    const u32 threads = std::thread::hardware_concurrency() - OTHER_THREADS_COUNT;
-    workerThreads.reserve(threads);
-    for (u32 i = 0; i < threads; ++i)
-    {
-        workerThreads.emplace_back(Threading::RunThread("Task Worker", &TaskManager::TaskWorkerStart, this));
     }
 }
 

--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -193,17 +193,6 @@ TaskManager::TaskManager()
 {
     ZoneScoped;
     CalcIterations();
-
-    workers.reserve(std::thread::hardware_concurrency());
-
-    RegisterThisThreadAsWorker();
-
-    const u32 threads = std::thread::hardware_concurrency() - OTHER_THREADS_COUNT;
-    workerThreads.reserve(threads);
-    for (u32 i = 0; i < threads; ++i)
-    {
-        workerThreads.emplace_back(Threading::RunThread("Task Worker", &TaskManager::TaskWorkerStart, this));
-    }
 }
 
 TaskManager::~TaskManager()
@@ -227,6 +216,20 @@ TaskManager::~TaskManager()
     {
         if (thread.joinable())
             thread.join();
+    }
+}
+
+void TaskManager::MakeThreads()
+{
+    workers.reserve(std::thread::hardware_concurrency());
+
+    RegisterThisThreadAsWorker();
+
+    const u32 threads = std::thread::hardware_concurrency() - OTHER_THREADS_COUNT;
+    workerThreads.reserve(threads);
+    for (u32 i = 0; i < threads; ++i)
+    {
+        workerThreads.emplace_back(Threading::RunThread("Task Worker", &TaskManager::TaskWorkerStart, this));
     }
 }
 

--- a/src/xrCore/Threading/TaskManager.hpp
+++ b/src/xrCore/Threading/TaskManager.hpp
@@ -78,7 +78,7 @@ public:
 public:
     void RegisterThisThreadAsWorker();
     void UnregisterThisThreadAsWorker();
-    void MakeThreads();
+    void SpawnThreads();
 
     void Wait(const Task& task) const;
     void WaitForChildren(const Task& task) const;

--- a/src/xrCore/Threading/TaskManager.hpp
+++ b/src/xrCore/Threading/TaskManager.hpp
@@ -50,6 +50,7 @@ private:
 public:
     TaskManager();
     ~TaskManager();
+    void SpawnThreads();
 
 public:
     // TaskFunc is at the end for fancy in-place lambdas
@@ -78,7 +79,6 @@ public:
 public:
     void RegisterThisThreadAsWorker();
     void UnregisterThisThreadAsWorker();
-    void SpawnThreads();
 
     void Wait(const Task& task) const;
     void WaitForChildren(const Task& task) const;

--- a/src/xrCore/Threading/TaskManager.hpp
+++ b/src/xrCore/Threading/TaskManager.hpp
@@ -78,6 +78,7 @@ public:
 public:
     void RegisterThisThreadAsWorker();
     void UnregisterThisThreadAsWorker();
+    void MakeThreads();
 
     void Wait(const Task& task) const;
     void WaitForChildren(const Task& task) const;

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -274,6 +274,7 @@ void xrCore::Initialize(pcstr _ApplicationName, pcstr commandLine, bool init_fs,
         Msg("\ncommand line %s\n", Params);
         _initialize_cpu();
         TaskScheduler = xr_make_unique<TaskManager>();
+        TaskScheduler->MakeThreads();
         // xrDebug::Initialize ();
 
         rtc_initialize();

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -274,7 +274,7 @@ void xrCore::Initialize(pcstr _ApplicationName, pcstr commandLine, bool init_fs,
         Msg("\ncommand line %s\n", Params);
         _initialize_cpu();
         TaskScheduler = xr_make_unique<TaskManager>();
-        TaskScheduler->MakeThreads();
+        TaskScheduler->SpawnThreads();
         // xrDebug::Initialize ();
 
         rtc_initialize();


### PR DESCRIPTION
Fixes run when compiled with gcc higher than 10

Tested it on gcc-14 and binary worked.
But need more tests.