### PR TITLE
SDL: Remove redundant SDL_VERSION_ATLEAST for versions <= 2.0.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ add_compile_definitions(
 )
 
 if (NOT WIN32)
-    find_package(SDL2 REQUIRED)
+    find_package(SDL2 2.0.18 REQUIRED)
     # Fix to support older SDL2
     # https://github.com/OpenXRay/xray-16/issues/1595
     if (NOT TARGET SDL2::SDL2 AND DEFINED SDL2_LIBRARIES)

--- a/src/xrCore/_math.cpp
+++ b/src/xrCore/_math.cpp
@@ -13,23 +13,11 @@ XRCORE_API bool HasSSE     = SDL_HasSSE();
 XRCORE_API bool HasSSE2    = SDL_HasSSE2();
 XRCORE_API bool HasSSE42   = SDL_HasSSE42();
 
-#if SDL_VERSION_ATLEAST(2, 0, 6)
 XRCORE_API bool HasAVX     = SDL_HasAVX();
-#else
-XRCORE_API bool HasAVX     = false();
-#endif
 
-#if SDL_VERSION_ATLEAST(2, 0, 9)
 XRCORE_API bool HasAVX2    = SDL_HasAVX2();
-#else
-XRCORE_API bool HasAVX2    = false;
-#endif
 
-#if SDL_VERSION_ATLEAST(2, 0, 9)
 XRCORE_API bool HasAVX512F = SDL_HasAVX512F();
-#else
-XRCORE_API bool HasAVX512F = false;
-#endif
 
 XRCORE_API u64 qpc_freq = SDL_GetPerformanceFrequency();
 
@@ -85,12 +73,8 @@ void _initialize_cpu()
 
     // Other architectures
     listFeature("AltiVec", SDL_HasAltiVec());
-#if SDL_VERSION_ATLEAST(2, 0, 12)
     listFeature("ARMSIMD", SDL_HasARMSIMD());
-#endif
-#if SDL_VERSION_ATLEAST(2, 0, 6)
     listFeature("NEON",    SDL_HasNEON());
-#endif
 #if SDL_VERSION_ATLEAST(2, 24, 0)
     listFeature("LSX",     SDL_HasLSX());
     listFeature("LASX",    SDL_HasLASX());

--- a/src/xrEngine/Device_imgui.cpp
+++ b/src/xrEngine/Device_imgui.cpp
@@ -72,9 +72,7 @@ void CRenderDevice::InitializeImGui()
         // See SDL hack in ImGui_ImplSDL2_ShowWindow().
         sdl_flags |= (viewport->Flags & ImGuiViewportFlags_NoTaskBarIcon) ? SDL_WINDOW_SKIP_TASKBAR : 0;
 #endif
-#if SDL_VERSION_ATLEAST(2, 0, 5)
         sdl_flags |= (viewport->Flags & ImGuiViewportFlags_TopMost) ? SDL_WINDOW_ALWAYS_ON_TOP : 0;
-#endif
 
         const auto vd = IM_NEW(ImGuiViewportData)
         {
@@ -192,13 +190,11 @@ void CRenderDevice::InitializeImGui()
         SDL_SetWindowTitle(vd->Window, title);
     };
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     platform_io.Platform_SetWindowAlpha = [](ImGuiViewport* viewport, float alpha)
     {
         const auto vd = static_cast<ImGuiViewportData*>(viewport->PlatformUserData);
         SDL_SetWindowOpacity(vd->Window, alpha);
     };
-#endif
 #endif // IMGUI_ENABLE_VIEWPORTS
 
     editor().InitBackend();

--- a/src/xrEngine/Device_mode.cpp
+++ b/src/xrEngine/Device_mode.cpp
@@ -38,19 +38,15 @@ void FillImGuiMonitorData(const int monitorID)
     monitor.MainPos = monitor.WorkPos = ImVec2((float)r.x, (float)r.y);
     monitor.MainSize = monitor.WorkSize = ImVec2((float)r.w, (float)r.h);
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     SDL_GetDisplayUsableBounds(monitorID, &r);
     monitor.WorkPos = ImVec2((float)r.x, (float)r.y);
     monitor.WorkSize = ImVec2((float)r.w, (float)r.h);
-#endif
 
-#if SDL_VERSION_ATLEAST(2, 0, 4)
     // FIXME-VIEWPORT: On MacOS SDL reports actual monitor DPI scale, ignoring OS configuration. We may want to set
     //  DpiScale to cocoa_window.backingScaleFactor here.
     float dpi = 0.0f;
     if (!SDL_GetDisplayDPI(monitorID, &dpi, nullptr, nullptr))
         monitor.DpiScale = dpi / 96.0f;
-#endif
 
     monitor.PlatformHandle = (void*)(intptr_t)monitorID;
     platform_io.Monitors.push_back(monitor);
@@ -107,9 +103,7 @@ void CRenderDevice::SetWindowDraggable(bool draggable)
     const bool resizable = SDL_GetWindowFlags(Device.m_sdlWnd) & SDL_WINDOW_RESIZABLE;
     m_allowWindowDrag = draggable && windowed && resizable;
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     SDL_SetWindowOpacity(Device.m_sdlWnd, m_allowWindowDrag ? 0.95f : 1.0f);
-#endif
 }
 
 void CRenderDevice::UpdateWindowProps()
@@ -180,14 +174,12 @@ void CRenderDevice::UpdateWindowRects()
     SDL_GetWindowPosition(m_sdlWnd, &m_rcWindowBounds.x, &m_rcWindowBounds.y);
     SDL_GetWindowSize(m_sdlWnd, &m_rcWindowBounds.w, &m_rcWindowBounds.h);
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
     int top, left, bottom, right;
     SDL_GetWindowBordersSize(m_sdlWnd, &top, &left, &bottom, &right);
     m_rcWindowBounds.x -= left;
     m_rcWindowBounds.y -= top;
     m_rcWindowBounds.w += right;
     m_rcWindowBounds.h += bottom;
-#endif
 }
 
 void CRenderDevice::SelectResolution(const bool windowed)
@@ -268,9 +260,7 @@ void CRenderDevice::OnFatalError()
 {
     // make it sure window will hide in any way
     SDL_SetWindowFullscreen(m_sdlWnd, SDL_FALSE);
-#if SDL_VERSION_ATLEAST(2, 0, 16)
     SDL_SetWindowAlwaysOnTop(m_sdlWnd, SDL_FALSE);
-#endif
     SDL_ShowWindow(m_sdlWnd);
     SDL_MinimizeWindow(m_sdlWnd);
     SDL_HideWindow(m_sdlWnd);

--- a/src/xrEngine/device.cpp
+++ b/src/xrEngine/device.cpp
@@ -307,23 +307,16 @@ void CRenderDevice::ProcessEvent(const SDL_Event& event)
 
     switch (event.type)
     {
-#if SDL_VERSION_ATLEAST(2, 0, 9)
     case SDL_DISPLAYEVENT:
     {
         switch (event.display.type)
         {
         case SDL_DISPLAYEVENT_ORIENTATION:
-#if SDL_VERSION_ATLEAST(2, 0, 14)
         case SDL_DISPLAYEVENT_CONNECTED:
         case SDL_DISPLAYEVENT_DISCONNECTED:
-#endif
             CleanupVideoModes();
             FillVideoModes();
-#if SDL_VERSION_ATLEAST(2, 0, 14)
             if (event.display.display == psDeviceMode.Monitor && event.display.type != SDL_DISPLAYEVENT_CONNECTED)
-#else
-            if (event.display.display == psDeviceMode.Monitor)
-#endif
                 Reset();
             else
                 UpdateWindowProps();
@@ -331,7 +324,6 @@ void CRenderDevice::ProcessEvent(const SDL_Event& event)
         } // switch (event.display.type)
         break;
     }
-#endif
     case SDL_WINDOWEVENT:
     {
         const auto window = SDL_GetWindowFromID(event.window.windowID);
@@ -348,22 +340,15 @@ void CRenderDevice::ProcessEvent(const SDL_Event& event)
             if (window == m_sdlWnd)
             {
                 UpdateWindowRects();
-#if !SDL_VERSION_ATLEAST(2, 0, 18) // without SDL_WINDOWEVENT_DISPLAY_CHANGED, let's detect monitor change ourselves
-                const int display = SDL_GetWindowDisplayIndex(window);
-                if (display != -1)
-                    psDeviceMode.Monitor = display;
-#endif
             }
             if (viewport)
                 viewport->PlatformRequestMove = true;
             break;
         }
 
-#if SDL_VERSION_ATLEAST(2, 0, 18)
         case SDL_WINDOWEVENT_DISPLAY_CHANGED:
             psDeviceMode.Monitor = event.window.data1;
             break;
-#endif
 
         case SDL_WINDOWEVENT_RESIZED:
             if (window == m_sdlWnd)

--- a/src/xrEngine/x_ray.cpp
+++ b/src/xrEngine/x_ray.cpp
@@ -459,10 +459,8 @@ void CApplication::ShowSplash(bool topmost)
 
     Uint32 flags = SDL_WINDOW_BORDERLESS | SDL_WINDOW_HIDDEN;
 
-#if SDL_VERSION_ATLEAST(2,0,5)
     if (topmost)
         flags |= SDL_WINDOW_ALWAYS_ON_TOP;
-#endif
 
     m_window = SDL_CreateWindow("OpenXRay", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, m_surface->w, m_surface->h, flags);
     SDL_ShowWindow(m_window);

--- a/src/xrEngine/xr_input.cpp
+++ b/src/xrEngine/xr_input.cpp
@@ -95,6 +95,7 @@ void CInput::OpenController(int idx)
     if (psControllerEnableSensors.test(1))
         SDL_GameControllerSetSensorEnabled(controller, SDL_SENSOR_GYRO, SDL_TRUE);
     controllers.emplace_back(controller);
+
 }
 
 void CInput::EnableControllerSensors(bool enable)

--- a/src/xrEngine/xr_input.cpp
+++ b/src/xrEngine/xr_input.cpp
@@ -94,8 +94,8 @@ void CInput::OpenController(int idx)
 
     if (psControllerEnableSensors.test(1))
         SDL_GameControllerSetSensorEnabled(controller, SDL_SENSOR_GYRO, SDL_TRUE);
-    controllers.emplace_back(controller);
 
+    controllers.emplace_back(controller);
 }
 
 void CInput::EnableControllerSensors(bool enable)

--- a/src/xrEngine/xr_input.h
+++ b/src/xrEngine/xr_input.h
@@ -4,7 +4,7 @@
 
 #include <SDL.h>
 
-#if SDL_VERSION_ATLEAST(2,0,4) && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !(defined(__APPLE__) && TARGET_OS_IOS) && !defined(__amigaos4__)
+#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !(defined(__APPLE__) && TARGET_OS_IOS) && !defined(__amigaos4__)
 #   define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE 1
 #else
 #   define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE 0


### PR DESCRIPTION
Bump required version of SDL ro 2.0.18