### PR TITLE
Fix anm_idle_aim_empty

### DIFF
--- a/src/xrGame/WeaponPistol.cpp
+++ b/src/xrGame/WeaponPistol.cpp
@@ -68,7 +68,14 @@ void CWeaponPistol::PlayAnimIdle()
 
     if (iAmmoElapsed == 0)
     {
-        PlayHUDMotion("anm_idle_empty", "anim_empty", TRUE, NULL, GetState());
+        if (IsZoomed())
+        {
+            PlayAnimAim();
+        }
+        else
+        {
+            PlayHUDMotion("anm_idle_empty", "anim_empty", TRUE, NULL, GetState());
+        }
     }
     else
     {


### PR DESCRIPTION
Fixed aiming animation not working when the pistol is empty