### PR TITLE
Restored mirroring of texture feature for `CUIStatic`

### DIFF
--- a/src/xrUICore/Static/UIStaticItem.cpp
+++ b/src/xrUICore/Static/UIStaticItem.cpp
@@ -6,7 +6,6 @@ CUIStaticItem::CUIStaticItem()
     uFlags.zero();
     vSize.set(0, 0);
     TextureRect.set(0, 0, 0, 0);
-    eMirrorMode = tmNone;
     vHeadingPivot.set(0, 0);
     vHeadingOffset.set(0, 0);
     dwColor = 0xffffffff;

--- a/src/xrUICore/Static/UIStaticItem.cpp
+++ b/src/xrUICore/Static/UIStaticItem.cpp
@@ -138,9 +138,9 @@ void CUIStaticItem::RenderInternal(float angle)
     RBt.set(TextureRect.x2 / ts.x + hp.x, TextureRect.y2 / ts.y + hp.y);
 
     // Check mirror mode
-    if (tmMirrorHorisontal == eMirrorMode || tmMirrorBoth == eMirrorMode)
+    if (EUIMirroring::Horisontal == eMirrorMode || EUIMirroring::Both == eMirrorMode)
         std::swap(LTt.x, RBt.x);
-    if (tmMirrorVertical == eMirrorMode || tmMirrorBoth == eMirrorMode)
+    if (EUIMirroring::Vertical == eMirrorMode || EUIMirroring::Both == eMirrorMode)
         std::swap(LTt.y, RBt.y);
 
     float kx = UI().get_current_kx();

--- a/src/xrUICore/Static/UIStaticItem.cpp
+++ b/src/xrUICore/Static/UIStaticItem.cpp
@@ -57,9 +57,9 @@ void CUIStaticItem::RenderInternal(const Fvector2& in_pos)
     RBt.set(TextureRect.x2 / ts.x, TextureRect.y2 / ts.y);
 
     // Check mirror mode
-    if (tmMirrorHorisontal == eMirrorMode || tmMirrorBoth == eMirrorMode)
+    if (EUIMirroring::Horisontal == eMirrorMode || EUIMirroring::Both == eMirrorMode)
         std::swap(LTt.x, RBt.x);
-    if (tmMirrorVertical == eMirrorMode || tmMirrorBoth == eMirrorMode)
+    if (EUIMirroring::Vertical == eMirrorMode || EUIMirroring::Both == eMirrorMode)
         std::swap(LTt.y, RBt.y);
 
     float offset = -0.5f;

--- a/src/xrUICore/Static/UIStaticItem.cpp
+++ b/src/xrUICore/Static/UIStaticItem.cpp
@@ -6,6 +6,7 @@ CUIStaticItem::CUIStaticItem()
     uFlags.zero();
     vSize.set(0, 0);
     TextureRect.set(0, 0, 0, 0);
+    eMirrorMode = tmNone;
     vHeadingPivot.set(0, 0);
     vHeadingOffset.set(0, 0);
     dwColor = 0xffffffff;
@@ -55,6 +56,12 @@ void CUIStaticItem::RenderInternal(const Fvector2& in_pos)
     //текстурные координаты
     LTt.set(TextureRect.x1 / ts.x, TextureRect.y1 / ts.y);
     RBt.set(TextureRect.x2 / ts.x, TextureRect.y2 / ts.y);
+
+    // Check mirror mode
+    if (tmMirrorHorisontal == eMirrorMode || tmMirrorBoth == eMirrorMode)
+        std::swap(LTt.x, RBt.x);
+    if (tmMirrorVertical == eMirrorMode || tmMirrorBoth == eMirrorMode)
+        std::swap(LTt.y, RBt.y);
 
     float offset = -0.5f;
     if (UI().m_currentPointType == IUIRender::pttLIT)
@@ -130,6 +137,12 @@ void CUIStaticItem::RenderInternal(float angle)
     Fvector2 LTt, RBt;
     LTt.set(TextureRect.x1 / ts.x + hp.x, TextureRect.y1 / ts.y + hp.y);
     RBt.set(TextureRect.x2 / ts.x + hp.x, TextureRect.y2 / ts.y + hp.y);
+
+    // Check mirror mode
+    if (tmMirrorHorisontal == eMirrorMode || tmMirrorBoth == eMirrorMode)
+        std::swap(LTt.x, RBt.x);
+    if (tmMirrorVertical == eMirrorMode || tmMirrorBoth == eMirrorMode)
+        std::swap(LTt.y, RBt.y);
 
     float kx = UI().get_current_kx();
 

--- a/src/xrUICore/Static/UIStaticItem.h
+++ b/src/xrUICore/Static/UIStaticItem.h
@@ -6,6 +6,14 @@
 #include "xrCore/xrstring.h"
 #endif
 
+enum EUIMirroring
+{
+    tmNone,
+    tmMirrorHorisontal,
+    tmMirrorVertical,
+    tmMirrorBoth
+};
+
 class XRUICORE_API CUIStaticItem
 {
 protected:
@@ -22,6 +30,7 @@ public:
     Fvector2 vHeadingPivot;
     Fvector2 vHeadingOffset;
     Flags8 uFlags;
+    EUIMirroring eMirrorMode;
 
     ui_shader hShader;
     Fvector2 vPos;
@@ -65,6 +74,9 @@ public:
     void ResetHeadingPivot();
     IC bool GetFixedLTWhileHeading() const { return !!uFlags.test(flFixedLTWhileHeading); }
     Fvector2 GetHeadingPivot() { return vHeadingPivot; }
+    IC void SetMirrorMode(EUIMirroring m) { eMirrorMode = m; }
+    IC EUIMirroring GetMirrorMode() { return eMirrorMode; }
+
 private:
     void RenderInternal(const Fvector2& pos);
     void RenderInternal(float angle);

--- a/src/xrUICore/Static/UIStaticItem.h
+++ b/src/xrUICore/Static/UIStaticItem.h
@@ -6,12 +6,12 @@
 #include "xrCore/xrstring.h"
 #endif
 
-enum EUIMirroring
+enum cls EUIMirroring
 {
-    tmNone,
-    tmMirrorHorisontal,
-    tmMirrorVertical,
-    tmMirrorBoth
+    None,
+    Horisontal,
+    Vertical,
+    Both
 };
 
 class XRUICORE_API CUIStaticItem
@@ -30,7 +30,7 @@ public:
     Fvector2 vHeadingPivot;
     Fvector2 vHeadingOffset;
     Flags8 uFlags;
-    EUIMirroring eMirrorMode;
+    EUIMirroring eMirrorMode{};
 
     ui_shader hShader;
     Fvector2 vPos;

--- a/src/xrUICore/Static/UIStaticItem.h
+++ b/src/xrUICore/Static/UIStaticItem.h
@@ -6,7 +6,7 @@
 #include "xrCore/xrstring.h"
 #endif
 
-enum cls EUIMirroring
+enum class EUIMirroring
 {
     None,
     Horisontal,

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -143,13 +143,13 @@ bool CUIXmlInitBase::InitStatic(CUIXml& xml_doc, pcstr path, int index, CUIStati
     InitTexture(xml_doc, path, index, pWnd);
     InitTextureOffset(xml_doc, path, index, pWnd);
 
-    shared_str mirroring = xml_doc.ReadAttrib(path, index, "mirror", "");
+    cpcstr mirroring = xml_doc.ReadAttrib(path, index, "mirror", "");
     if (0 == xr_strcmp(mirroring, "h"))
-        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorHorisontal);
+        pWnd->GetStaticItem()->SetMirrorMode(EUIMirroring::Horisontal);
     else if (0 == xr_strcmp(mirroring, "v"))
-        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorVertical);
+        pWnd->GetStaticItem()->SetMirrorMode(EUIMirroring::Vertical);
     else if (0 == xr_strcmp(mirroring, "b"))
-        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorBoth);
+        pWnd->GetStaticItem()->SetMirrorMode(EUIMirroring::Both);
 
     const int flag = xml_doc.ReadAttribInt(path, index, "heading", 0);
     pWnd->EnableHeading((flag) ? true : false);

--- a/src/xrUICore/XML/UIXmlInitBase.cpp
+++ b/src/xrUICore/XML/UIXmlInitBase.cpp
@@ -143,6 +143,14 @@ bool CUIXmlInitBase::InitStatic(CUIXml& xml_doc, pcstr path, int index, CUIStati
     InitTexture(xml_doc, path, index, pWnd);
     InitTextureOffset(xml_doc, path, index, pWnd);
 
+    shared_str mirroring = xml_doc.ReadAttrib(path, index, "mirror", "");
+    if (0 == xr_strcmp(mirroring, "h"))
+        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorHorisontal);
+    else if (0 == xr_strcmp(mirroring, "v"))
+        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorVertical);
+    else if (0 == xr_strcmp(mirroring, "b"))
+        pWnd->GetStaticItem()->SetMirrorMode(tmMirrorBoth);
+
     const int flag = xml_doc.ReadAttribInt(path, index, "heading", 0);
     pWnd->EnableHeading((flag) ? true : false);
 


### PR DESCRIPTION
Using: in node of element based on `CUIStatic` class type `mirror="b"`, `b` is one of mirroring modes.

`b` - both, mirror by vertical and horizontal;
`v` - vertical, mirror by vertical;
`h` - horizontal, mirror by horizontal.
It was a removed feature from SHoC, because the developers could not agree on its using(example was in trade window XML, , but in the wrong place).

There are examples of using this:
![image](https://github.com/OpenXRay/xray-16/assets/47980896/7f94b65e-0bd8-4cf6-960a-e9a5160e9983)
![image](https://github.com/OpenXRay/xray-16/assets/47980896/c56be7cb-7ec7-40d2-a344-8fbcf87d1c59)
![image](https://github.com/OpenXRay/xray-16/assets/47980896/633a2aca-38c8-4ec2-9aee-bd1a66c87fec)

How the trade window looks without mirroring and with it:
![image](https://github.com/OpenXRay/xray-16/assets/47980896/6f9a5e20-9947-4c14-a02d-df60a8d3583a)
![image](https://github.com/OpenXRay/xray-16/assets/47980896/927b4e1d-b5bf-465e-8bb4-094f36505f7a)

