### PR TITLE
Support running SSE intrinsics on RISCV platform

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "Externals/xrLuaFix"]
 	path = Externals/xrLuaFix
 	url = https://github.com/OpenXRay/xrLuaFix.git
+[submodule "Externals/sse2rvv"]
+	path = Externals/sse2rvv
+	url = https://github.com/pattonkan/sse2rvv.git

--- a/src/Common/Platform.hpp
+++ b/src/Common/Platform.hpp
@@ -42,7 +42,7 @@
 #elif defined (_M_ARM64) || defined(__aarch64__)
 #   define XR_ARCHITECTURE_ARM64
 #   define _XRAY_ARCHITECTURE_MARKER "ARM 64-bit"
-#elif (defined(__riscv) || defined(__riscv__))
+#elif defined(__riscv) || defined(__riscv__)
 #   define XR_ARCHITECTURE_RISCV
 #   define _XRAY_ARCHITECTURE_MARKER "RISC-V"
 #elif defined(__powerpc64__) || defined(__ppc64__)

--- a/src/Common/Platform.hpp
+++ b/src/Common/Platform.hpp
@@ -42,6 +42,9 @@
 #elif defined (_M_ARM64) || defined(__aarch64__)
 #   define XR_ARCHITECTURE_ARM64
 #   define _XRAY_ARCHITECTURE_MARKER "ARM 64-bit"
+#elif (defined(__riscv) || defined(__riscv__))
+#   define XR_ARCHITECTURE_RISCV
+#   define _XRAY_ARCHITECTURE_MARKER "RISC-V"
 #elif defined(__powerpc64__) || defined(__ppc64__)
 #   define XR_ARCHITECTURE_PPC64
 #   define _XRAY_ARCHITECTURE_MARKER "PowerPC 64-bit"

--- a/src/Layers/xrRender/DetailManager.cpp
+++ b/src/Layers/xrRender/DetailManager.cpp
@@ -24,6 +24,8 @@
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif

--- a/src/Layers/xrRender/ParticleEffect.cpp
+++ b/src/Layers/xrRender/ParticleEffect.cpp
@@ -9,6 +9,8 @@
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif

--- a/src/xrCDB/ISpatial_q_ray.cpp
+++ b/src/xrCDB/ISpatial_q_ray.cpp
@@ -8,6 +8,8 @@
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif

--- a/src/xrCDB/xrCDB_ray.cpp
+++ b/src/xrCDB/xrCDB_ray.cpp
@@ -10,6 +10,8 @@
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif

--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -31,6 +31,8 @@
 #include <immintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #elif defined(XR_ARCHITECTURE_PPC64)
 #include <xmmintrin.h>
 #else

--- a/src/xrParticles/noise.cpp
+++ b/src/xrParticles/noise.cpp
@@ -6,6 +6,8 @@
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif

--- a/src/xrParticles/particle_actions_collection.cpp
+++ b/src/xrParticles/particle_actions_collection.cpp
@@ -1620,6 +1620,8 @@ extern void noise3Init();
 #include <xmmintrin.h>
 #elif defined(XR_ARCHITECTURE_ARM) || defined(XR_ARCHITECTURE_ARM64)
 #include "sse2neon/sse2neon.h"
+#elif defined(XR_ARCHITECTURE_RISCV)
+#include "sse2rvv/sse2rvv.h"
 #else
 #error Add your platform here
 #endif


### PR DESCRIPTION
sse2rvv is a header file only translator which allows to run SSE on RSICV machines