### PR TITLE
AppVeyor: disable x86 Windows builds (it's still supported on Actions)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ skip_tags: true
 skip_branch_with_pr: true
 
 image:
+- Visual Studio 2019
 - Visual Studio 2022
 
 configuration:
@@ -17,7 +18,6 @@ configuration:
 
 platform:
 - x64
-- x86
 
 branches:
   except:
@@ -28,10 +28,6 @@ cache:
 
 for:
 -
-  matrix:
-    only:
-      - image: Visual Studio 2022
-
   before_build:
     - git submodule update --init --recursive
     - nuget restore src\engine.sln


### PR DESCRIPTION
x86 is still supported, but it's failing on AppVeyor and we will stop using it soon, so let's just make builds green. I also added VS 2019 builds just in case.