### PR TITLE
Details cache update optimization

### DIFF
--- a/src/Layers/xrRender/DetailManager.cpp
+++ b/src/Layers/xrRender/DetailManager.cpp
@@ -454,7 +454,7 @@ void CDetailManager::DispatchMTCalc()
         const int s_z = iFloor(EYE.z / dm_slot_size + .5f);
 
         RImplementation.BasicStats.DetailCache.Begin();
-        cache_Update(s_x, s_z, EYE, dm_max_decompress);
+        cache_Update(s_x, s_z, EYE);
         RImplementation.BasicStats.DetailCache.End();
 
         UpdateVisibleM();

--- a/src/Layers/xrRender/DetailManager.h
+++ b/src/Layers/xrRender/DetailManager.h
@@ -209,7 +209,7 @@ public:
     DetailSlot& QueryDB(int sx, int sz);
 
     void cache_Initialize();
-    void cache_Update(int sx, int sz, Fvector& view, int limit);
+    void cache_Update(int sx, int sz, Fvector& view);
     void cache_Task(int gx, int gz, Slot* D);
     Slot* cache_Query(int sx, int sz);
     void cache_Decompress(Slot* D);


### PR DESCRIPTION
Iteration in cache_task could be a bottleneck with high details quality settings. Original code iterates 7 times (dm_max_decompress) over cache_task memory to find slots with closest distance. New code iterates once to find 7 closest slots. Memory access is very expensive.

https://youtu.be/G_b9tzXWons