### PR TITLE
Fixes for Trader

### DIFF
--- a/src/xrGame/ai/trader/ai_trader.cpp
+++ b/src/xrGame/ai/trader/ai_trader.cpp
@@ -90,8 +90,14 @@ void CAI_Trader::BoneCallback(CBoneInstance* B)
 
 void CAI_Trader::LookAtActor(CBoneInstance* B)
 {
-    Fvector dir;
-    dir.sub(Level().CurrentEntity()->Position(), Position());
+    Fvector dir{};
+    Fvector actor_pos = Level().CurrentEntity()->Position();
+    Fvector this_pos = Position();
+
+    if (actor_pos.distance_to(this_pos) > 20.f)
+        return;
+
+    dir.sub(actor_pos, this_pos);
 
     float yaw, pitch;
     dir.getHP(yaw, pitch);
@@ -100,6 +106,7 @@ void CAI_Trader::LookAtActor(CBoneInstance* B)
     XFORM().getHPB(h, p, b);
     float cur_yaw = h;
     float dy = _abs(angle_normalize_signed(yaw - cur_yaw));
+    clamp(dy, 0.f, 1.f);
 
     if (angle_normalize_signed(yaw - cur_yaw) > 0)
         dy *= -1.f;

--- a/src/xrGame/ai/trader/ai_trader.h
+++ b/src/xrGame/ai/trader/ai_trader.h
@@ -119,6 +119,7 @@ public:
     virtual bool natural_weapon() const { return false; }
     virtual bool natural_detector() const { return false; }
     virtual bool AllowItemToTrade(CInventoryItem const* item, const SInvItemPlace& place) const;
+    virtual bool CanPutInSlot(PIItem item, u32 slot) { return (slot == PDA_SLOT); }
 
     void dialog_sound_start(LPCSTR phrase);
     void dialog_sound_stop();

--- a/src/xrGame/ai/trader/trader_animation.cpp
+++ b/src/xrGame/ai/trader/trader_animation.cpp
@@ -17,6 +17,8 @@ void CTraderAnimation::reinit()
 
     m_anim_global = 0;
     m_anim_head = 0;
+
+    m_head = smart_cast<IKinematics*>(m_trader->Visual())->LL_BoneID("bip01_head");
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -91,7 +93,7 @@ void CTraderAnimation::update_frame()
     if (m_sound)
     {
         if (m_sound->_feedback())
-            m_sound->set_position(m_trader->Position());
+            m_sound->set_position(sound_position());
         else
         {
             m_trader->callback(GameObject::eTraderSoundEnd)();
@@ -135,5 +137,13 @@ void CTraderAnimation::external_sound_stop()
 {
     if (m_sound)
         remove_sound();
+}
+
+Fvector CTraderAnimation::sound_position()
+{
+    IKinematics* kinematics = smart_cast<IKinematics*>(m_trader->Visual());
+    Fmatrix l_tMatrix;
+    l_tMatrix.mul_43(m_trader->XFORM(), kinematics->LL_GetBoneInstance(m_head).mTransform);
+    return l_tMatrix.c;
 }
 //////////////////////////////////////////////////////////////////////////

--- a/src/xrGame/ai/trader/trader_animation.h
+++ b/src/xrGame/ai/trader/trader_animation.h
@@ -15,6 +15,7 @@ class CTraderAnimation
 
     LPCSTR m_anim_global;
     LPCSTR m_anim_head;
+    u16 m_head;
 
     MotionID m_motion_head;
     MotionID m_motion_global;
@@ -42,4 +43,5 @@ public:
 
 private:
     void remove_sound();
+    Fvector sound_position();
 };


### PR DESCRIPTION
1) disabled Trader's head rotation when dist to actor is more than 20 meters
2) Trader's head rotation limited by 1 radian to left and right from center
3) sounds from Trader will be from his head instead of playing in "player's head"
4) disabled slots stuffing for Trader