### PR TITLE
Support SOC PDA tab IDs (#392) 

### DIFF
--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -126,27 +126,24 @@ void CUIPdaWnd::Init()
     AttachChild(UITabControl);
     CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl);
 
-    if (ShadowOfChernobylMode)
+    const std::tuple<shared_str, shared_str> socIds[] = 
     {
-        const std::tuple<shared_str, shared_str> socIds[] = 
-        {
-            {"eptMap", "1"},
-            {"eptDiary", "2"},
-            {"eptContacts", "3"},
-            {"eptStatistics", "5"},
-            {"eptEncyclopedia", "6"}
-        };
+        {"eptMap", "1"},
+        {"eptDiary", "2"},
+        {"eptContacts", "3"},
+        {"eptStatistics", "5"},
+        {"eptEncyclopedia", "6"}
+    };
 
-        for (u32 i = 0, len = UITabControl->GetTabsCount(); i < len; i++)
-        {
-            CUITabButton* btn = UITabControl->GetButtonByIndex(i);
-            if (!btn) continue;
+    for (u32 i = 0, len = UITabControl->GetTabsCount(); i < len; i++)
+    {
+        CUITabButton* btn = UITabControl->GetButtonByIndex(i);
+        if (!btn) continue;
 
-            for (const auto& [replace, id] : socIds)
-            {
-                if (btn->m_btn_id != id) continue;
-                btn->m_btn_id = replace;
-            }
+        for (const auto& [replace, id] : socIds)
+        {
+            if (btn->m_btn_id != id) continue;
+            btn->m_btn_id = replace;
         }
     }
 

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -124,7 +124,8 @@ void CUIPdaWnd::Init()
     UITabControl = xr_new<CUITabControl>();
     UITabControl->SetAutoDelete(true);
     AttachChild(UITabControl);
-    CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl);
+    CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl, true, ShadowOfChernobylMode);
+    UITabControl->SetMessageTarget(this);
 
     constexpr std::tuple<pcstr, pcstr> socIds[] = 
     {
@@ -132,7 +133,7 @@ void CUIPdaWnd::Init()
         {"1", "eptMap"},
         {"2", "eptDiary"},
         {"3", "eptContacts"},
-        {"4", "eptRanking"},
+        {"4", "eptStalkersRanking"},
         {"5", "eptStatistics"},
         {"6", "eptEncyclopedia"},
     };
@@ -152,8 +153,6 @@ void CUIPdaWnd::Init()
             }
         }
     }
-
-    UITabControl->SetMessageTarget(this);
 
     UINoice = xr_new<CUIStatic>("Noise");
     UINoice->SetAutoDelete(true);

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -141,7 +141,7 @@ void CUIPdaWnd::Init()
     for (u32 i = 0; i < UITabControl->GetTabsCount(); i++)
     {
         CUITabButton* btn = UITabControl->GetButtonByIndex(i);
-        if (!btn || !btn->m_btn_id_default_assigned)
+        if (!btn || !btn->IsIdDefaultAssigned())
             continue;
 
         for (const auto& [id, replace] : known_soc_tab_ids)

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -125,6 +125,31 @@ void CUIPdaWnd::Init()
     UITabControl->SetAutoDelete(true);
     AttachChild(UITabControl);
     CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl);
+
+    if (ShadowOfChernobylMode)
+    {
+        const std::tuple<shared_str, shared_str> socIds[] = 
+        {
+            {"eptMap", "1"},
+            {"eptDiary", "2"},
+            {"eptContacts", "3"},
+            {"eptStatistics", "5"},
+            {"eptEncyclopedia", "6"}
+        };
+
+        for (u32 i = 0, len = UITabControl->GetTabsCount(); i < len; i++)
+        {
+            CUITabButton* btn = UITabControl->GetButtonByIndex(i);
+            if (!btn) continue;
+
+            for (const auto& [replace, id] : socIds)
+            {
+                if (btn->m_btn_id != id) continue;
+                btn->m_btn_id = replace;
+            }
+        }
+    }
+
     UITabControl->SetMessageTarget(this);
 
     UINoice = xr_new<CUIStatic>("Noise");

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -127,7 +127,7 @@ void CUIPdaWnd::Init()
     CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl, true, ShadowOfChernobylMode);
     UITabControl->SetMessageTarget(this);
 
-    constexpr std::tuple<pcstr, pcstr> known_soc_tab_ids[] = 
+    constexpr std::tuple<pcstr, pcstr> known_soc_tab_ids[] =
     {
         {"0", "eptTasks"},
         {"1", "eptMap"},

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -127,7 +127,7 @@ void CUIPdaWnd::Init()
     CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl, true, ShadowOfChernobylMode);
     UITabControl->SetMessageTarget(this);
 
-    constexpr std::tuple<pcstr, pcstr> socIds[] = 
+    constexpr std::tuple<pcstr, pcstr> known_soc_tab_ids[] = 
     {
         {"0", "eptTasks"},
         {"1", "eptMap"},
@@ -141,10 +141,10 @@ void CUIPdaWnd::Init()
     for (u32 i = 0; i < UITabControl->GetTabsCount(); i++)
     {
         CUITabButton* btn = UITabControl->GetButtonByIndex(i);
-        if (!btn) 
+        if (!btn || !btn->m_btn_id_default_assigned)
             continue;
 
-        for (const auto& [id, replace] : socIds)
+        for (const auto& [id, replace] : known_soc_tab_ids)
         {
             if (btn->m_btn_id == id)
             {

--- a/src/xrGame/ui/UIPdaWnd.cpp
+++ b/src/xrGame/ui/UIPdaWnd.cpp
@@ -126,24 +126,30 @@ void CUIPdaWnd::Init()
     AttachChild(UITabControl);
     CUIXmlInit::InitTabControl(uiXml, "tab", 0, UITabControl);
 
-    const std::tuple<shared_str, shared_str> socIds[] = 
+    constexpr std::tuple<pcstr, pcstr> socIds[] = 
     {
-        {"eptMap", "1"},
-        {"eptDiary", "2"},
-        {"eptContacts", "3"},
-        {"eptStatistics", "5"},
-        {"eptEncyclopedia", "6"}
+        {"0", "eptTasks"},
+        {"1", "eptMap"},
+        {"2", "eptDiary"},
+        {"3", "eptContacts"},
+        {"4", "eptRanking"},
+        {"5", "eptStatistics"},
+        {"6", "eptEncyclopedia"},
     };
 
-    for (u32 i = 0, len = UITabControl->GetTabsCount(); i < len; i++)
+    for (u32 i = 0; i < UITabControl->GetTabsCount(); i++)
     {
         CUITabButton* btn = UITabControl->GetButtonByIndex(i);
-        if (!btn) continue;
+        if (!btn) 
+            continue;
 
-        for (const auto& [replace, id] : socIds)
+        for (const auto& [id, replace] : socIds)
         {
-            if (btn->m_btn_id != id) continue;
-            btn->m_btn_id = replace;
+            if (btn->m_btn_id == id)
+            {
+                btn->m_btn_id = replace;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Adds patching of PDA windows IDs for SoC (since SoC doesn't have IDs at all - we need this to make PDA work on CoP system)