### PR TITLE
Fix SOC weapon zooming and grenade launcher bones usage (#392)

### DIFF
--- a/src/xrGame/Weapon.cpp
+++ b/src/xrGame/Weapon.cpp
@@ -35,6 +35,7 @@
 constexpr pcstr WPN_SCOPE = "wpn_scope";
 constexpr pcstr WPN_SILENCER = "wpn_silencer";
 constexpr pcstr WPN_GRENADE_LAUNCHER = "wpn_launcher";
+constexpr pcstr WPN_GRENADE_LAUNCHER_SOC = "wpn_grenade_launcher";
 
 BOOL b_toggle_weapon_aim = FALSE;
 
@@ -1302,6 +1303,7 @@ void CWeapon::UpdateHUDAddonsVisibility()
     static shared_str wpn_scope = WPN_SCOPE;
     static shared_str wpn_silencer = WPN_SILENCER;
     static shared_str wpn_grenade_launcher = WPN_GRENADE_LAUNCHER;
+    static shared_str wpn_grenade_launcher_soc = WPN_GRENADE_LAUNCHER_SOC;
 
     // actor only
     if (!GetHUDmode())
@@ -1332,16 +1334,20 @@ void CWeapon::UpdateHUDAddonsVisibility()
     else if (m_eSilencerStatus == ALife::eAddonPermanent)
         HudItemData()->set_bone_visible(wpn_silencer, TRUE, TRUE);
 
+    bool use_soc_name{};
+    if (HudItemData()->m_model->LL_BoneID(wpn_grenade_launcher) == BI_NONE)
+        use_soc_name = HudItemData()->m_model->LL_BoneID(wpn_grenade_launcher_soc) != BI_NONE;
+
     if (GrenadeLauncherAttachable())
     {
-        HudItemData()->set_bone_visible(wpn_grenade_launcher, IsGrenadeLauncherAttached());
+        HudItemData()->set_bone_visible((use_soc_name ? wpn_grenade_launcher_soc : wpn_grenade_launcher), IsGrenadeLauncherAttached());
     }
     if (m_eGrenadeLauncherStatus == ALife::eAddonDisabled)
     {
-        HudItemData()->set_bone_visible(wpn_grenade_launcher, FALSE, TRUE);
+        HudItemData()->set_bone_visible((use_soc_name ? wpn_grenade_launcher_soc : wpn_grenade_launcher), FALSE, TRUE);
     }
     else if (m_eGrenadeLauncherStatus == ALife::eAddonPermanent)
-        HudItemData()->set_bone_visible(wpn_grenade_launcher, TRUE, TRUE);
+        HudItemData()->set_bone_visible((use_soc_name ? wpn_grenade_launcher_soc : wpn_grenade_launcher), TRUE, TRUE);
 }
 
 void CWeapon::UpdateAddonsVisibility()
@@ -1352,6 +1358,7 @@ void CWeapon::UpdateAddonsVisibility()
     static shared_str wpn_scope = WPN_SCOPE;
     static shared_str wpn_silencer = WPN_SILENCER;
     static shared_str wpn_grenade_launcher = WPN_GRENADE_LAUNCHER;
+    static shared_str wpn_grenade_launcher_soc = WPN_GRENADE_LAUNCHER_SOC;
 
     IKinematics* pWeaponVisual = smart_cast<IKinematics*>(Visual());
     R_ASSERT(pWeaponVisual);
@@ -1401,6 +1408,9 @@ void CWeapon::UpdateAddonsVisibility()
     }
 
     bone_id = pWeaponVisual->LL_BoneID(wpn_grenade_launcher);
+    if (bone_id == BI_NONE)
+        bone_id = pWeaponVisual->LL_BoneID(wpn_grenade_launcher_soc);
+
     if (GrenadeLauncherAttachable())
     {
         if (IsGrenadeLauncherAttached())

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -316,12 +316,12 @@ Fmatrix hud_item_measures::load_monolithic(const shared_str& sect_name, IKinemat
                 rotation.y = pSettings->r_float(sect_name, strconcat(full_name, prefix, "zoom_rotate_y"));
                 rotation.z = pSettings->read_if_exists<float>(sect_name, strconcat(full_name, prefix, "zoom_rotate_z"), 0.f);
             };
-            load_zoom_offsets("", m_hands_offset[0][0], m_hands_offset[1][0]);
+            load_zoom_offsets("", m_hands_offset[0][1], m_hands_offset[1][1]);
             if (smart_cast<CWeaponMagazinedWGrenade*>(wpn))
             {
-                load_zoom_offsets("grenade_", m_hands_offset[0][1], m_hands_offset[1][1]);
+                load_zoom_offsets("grenade_", m_hands_offset[0][2], m_hands_offset[1][2]);
                 if (wpn->GrenadeLauncherAttachable())
-                    load_zoom_offsets("grenade_normal_", m_hands_offset[0][2], m_hands_offset[1][2]);
+                    load_zoom_offsets("grenade_normal_", m_hands_offset[0][1], m_hands_offset[1][1]);
             }
         }
     }


### PR DESCRIPTION
This PR Fixes:
- Grenade Launcher bone detection with CoP name instead of SoC name (Causing engine to crash)
- Weapon zooming for SoC HUD models