### PR TITLE
[LUA] Add `CALifeStorageManager_after_load` callback for consistency.

### DIFF
--- a/src/xrGame/alife_storage_manager.cpp
+++ b/src/xrGame/alife_storage_manager.cpp
@@ -143,6 +143,12 @@ void CALifeStorageManager::load(void* buffer, const u32& buffer_size, LPCSTR fil
         return;
 
     Level().autosave_manager().on_game_loaded();
+
+	//Alundaio: For consistency with before/after save callbacks.
+    luabind::functor<void> funct2;
+    if (GEnv.ScriptEngine->functor("alife_storage_manager.CALifeStorageManager_after_load", funct2))
+        funct2(file_name);
+	//-Alundaio
 }
 
 bool CALifeStorageManager::load(LPCSTR save_name_no_check)

--- a/src/xrGame/alife_storage_manager.cpp
+++ b/src/xrGame/alife_storage_manager.cpp
@@ -144,11 +144,11 @@ void CALifeStorageManager::load(void* buffer, const u32& buffer_size, LPCSTR fil
 
     Level().autosave_manager().on_game_loaded();
 
-	//Alundaio: For consistency with before/after save callbacks.
+	//Neloreck: For consistency with before/after save callbacks.
     luabind::functor<void> funct2;
     if (GEnv.ScriptEngine->functor("alife_storage_manager.CALifeStorageManager_after_load", funct2))
         funct2(file_name);
-	//-Alundaio
+	//-Neloreck
 }
 
 bool CALifeStorageManager::load(LPCSTR save_name_no_check)


### PR DESCRIPTION
## Changes

Just adding `CALifeStorageManager_after_load` callback for consistency.
Left comment in style of Alundaio to mark it as non-standard change.

Right now 3 callbacks exist after merge with CoC (https://github.com/OpenXRay/xray-16/pull/1751)
- `CALifeStorageManager_load`
- `CALifeStorageManager_before_save`
- `CALifeStorageManager_save`

Related to: https://github.com/OpenXRay/xray-16/pull/1395