### PR TITLE
[LUA] Fix exporting of `cse_alife_inventory_item` upgrades methods.

### DIFF
--- a/src/xrServerEntities/xrServer_Objects_ALife_Items_script.cpp
+++ b/src/xrServerEntities/xrServer_Objects_ALife_Items_script.cpp
@@ -21,11 +21,11 @@ SCRIPT_EXPORT(CSE_ALifeInventoryItem, (),
             //.def(constructor<pcstr>())
             .def("has_upgrade", +[](CSE_ALifeInventoryItem* ta, pcstr str)
             {
-                ta->add_upgrade(str);
+                return ta->has_upgrade(str);
             })
             .def("add_upgrade", +[](CSE_ALifeInventoryItem* ta, pcstr str)
             {
-                return ta->has_upgrade(str);
+                ta->add_upgrade(str);
             })
     ];
 });


### PR DESCRIPTION
## Changes

Fixing reversed code implementation for cse_alife_inventory_item upgrades related methods.

Related to: #1751 and #1529