### PR TITLE
[LUA] Export FS_Path readonly class to lua.

### DIFF
--- a/src/xrGame/fs_registrator_script.cpp
+++ b/src/xrGame/fs_registrator_script.cpp
@@ -198,14 +198,13 @@ SCRIPT_EXPORT(fs_registrator, (),
             .def("GetAt", &FS_file_list::GetAt)
             .def("Free", &FS_file_list::Free),
 
-        // XXX: uncomment
-        /*		class_<FS_Path>("FS_Path")
-                    .def_readonly("m_Path",						&FS_Path::m_Path)
-                    .def_readonly("m_Root",						&FS_Path::m_Root)
-                    .def_readonly("m_Add",						&FS_Path::m_Add)
-                    .def_readonly("m_DefExt",					&FS_Path::m_DefExt)
-                    .def_readonly("m_FilterCaption",			&FS_Path::m_FilterCaption),
-        */
+        class_<FS_Path>("FS_Path")
+            .def_readonly("m_Path", &FS_Path::m_Path)
+            .def_readonly("m_Root", &FS_Path::m_Root)
+            .def_readonly("m_Add", &FS_Path::m_Add)
+            .def_readonly("m_DefExt", &FS_Path::m_DefExt)
+            .def_readonly("m_FilterCaption", &FS_Path::m_FilterCaption),
+
         class_<CLocatorAPI::file>("fs_file")
             .def_readonly("name", &CLocatorAPI::file::name)
             .def_readonly("vfs", &CLocatorAPI::file::vfs)


### PR DESCRIPTION
## Changes

- Just re-exporting readonly FS_Path class definition to lua, some exported methods use it and cause game crashes (get_path)