### PR TITLE
[CoC] Add HUD animation speed parameter support in ltx files.

### DIFF
--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -24,12 +24,14 @@ constexpr float TENDTO_SPEED_AIM  = 8.f;    // (Для прицеливания)
 // --#SM+# End--
 // clang-format on
 
-float CalcMotionSpeed(const shared_str& anim_name)
+float CalcMotionSpeed(const shared_str& anim_name, const float anim_speed)
 {
-    if (!IsGameTypeSingle() && (anim_name == "anm_show" || anim_name == "anm_hide"))
-        return 2.0f;
+    // Apply custom animation speeds / configuration only for singleplayer games.
+    // Fast reloading / showing / hiding animation does not seem fair.
+    if (IsGameTypeSingle())
+        return anim_speed;
     else
-        return 1.0f;
+        return (anim_name == "anm_show" || anim_name == "anm_hide") ? 2.0f : 1.0f;
 }
 
 const player_hud_motion* player_hud_motion_container::find_motion(const shared_str& name) const
@@ -428,7 +430,7 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
                                             m_visual_name.c_str(), anim_name_r)
                                             .c_str());
 
-    const float speed = anm->m_anim_speed;
+    const float speed = CalcMotionSpeed(anm->m_base_name, anm->m_anim_speed);
 
     rnd_idx = (u8)Random.randI(anm->m_animations.size());
     const motion_descr& M = anm->m_animations[rnd_idx];
@@ -628,7 +630,7 @@ void player_hud::render_hud(u32 context_id, IRenderable* root)
 
 u32 player_hud::motion_length(const shared_str& anim_name, const shared_str& hud_name, const CMotionDef*& md)
 {
-    const float speed = CalcMotionSpeed(anim_name);
+    const float speed = CalcMotionSpeed(anim_name, 1.0f);
     attachable_hud_item* pi = create_hud_item(hud_name);
     const player_hud_motion* pm = pi->m_hand_motions.find_motion(anim_name);
 

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -63,7 +63,7 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
                 pm.m_base_name = str_item;
 
                 _GetItem(anm.c_str(), 1, str_item);
-                pm.m_additional_name = str_item;
+                pm.m_additional_name = (strlen(str_item) > 0) ? pm.m_additional_name = str_item : pm.m_base_name;
 
                 _GetItem(anm.c_str(), 2, str_item);
                 pm.m_anim_speed = strlen(str_item) > 0 ? atof(str_item) : 1.f;

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -53,16 +53,20 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
             {
                 pm.m_base_name = anm;
                 pm.m_additional_name = anm;
+                pm.m_anim_speed = 1.f;
             }
             else
             {
-                R_ASSERT2(_GetItemCount(anm.c_str()) == 2, anm.c_str());
+                R_ASSERT2(_GetItemCount(anm.c_str()) <= 3, anm.c_str());
                 string512 str_item;
                 _GetItem(anm.c_str(), 0, str_item);
                 pm.m_base_name = str_item;
 
                 _GetItem(anm.c_str(), 1, str_item);
                 pm.m_additional_name = str_item;
+
+                _GetItem(anm.c_str(), 2, str_item);
+                pm.m_anim_speed = strlen(str_item) > 0 ? atof(str_item) : 1.f;
             }
 
             // and load all motions for it
@@ -414,8 +418,6 @@ void attachable_hud_item::reload_measures()
 
 u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, const CMotionDef*& md, u8& rnd_idx)
 {
-    const float speed = CalcMotionSpeed(anm_name_b);
-
     string256 anim_name_r;
     const bool is_16x9 = UICore::is_widescreen();
     xr_sprintf(anim_name_r, "%s%s", anm_name_b.c_str(), m_attach_place_idx == 1 && is_16x9 ? "_16x9" : "");
@@ -425,6 +427,8 @@ u32 attachable_hud_item::anim_play(const shared_str& anm_name_b, BOOL bMixIn, co
     R_ASSERT2(anm->m_animations.size(), make_string("model [%s] has no motion defined in motion_alias [%s]",
                                             m_visual_name.c_str(), anim_name_r)
                                             .c_str());
+
+    const float speed = anm->m_anim_speed;
 
     rnd_idx = (u8)Random.randI(anm->m_animations.size());
     const motion_descr& M = anm->m_animations[rnd_idx];

--- a/src/xrGame/player_hud.cpp
+++ b/src/xrGame/player_hud.cpp
@@ -63,10 +63,10 @@ void player_hud_motion_container::load(IKinematicsAnimated* model, const shared_
                 pm.m_base_name = str_item;
 
                 _GetItem(anm.c_str(), 1, str_item);
-                pm.m_additional_name = (strlen(str_item) > 0) ? pm.m_additional_name = str_item : pm.m_base_name;
+                pm.m_additional_name = xr_strlen(str_item) > 0 ? str_item : pm.m_base_name;
 
                 _GetItem(anm.c_str(), 2, str_item);
-                pm.m_anim_speed = strlen(str_item) > 0 ? atof(str_item) : 1.f;
+                pm.m_anim_speed = xr_strlen(str_item) > 0 ? atof(str_item) : 1.f;
             }
 
             // and load all motions for it

--- a/src/xrGame/player_hud.h
+++ b/src/xrGame/player_hud.h
@@ -20,6 +20,7 @@ struct player_hud_motion
     shared_str m_base_name;
     shared_str m_additional_name;
     xr_vector<motion_descr> m_animations;
+    float m_anim_speed;
 };
 
 struct player_hud_motion_container


### PR DESCRIPTION
Still testing it while integrating some weapons from CoC/anomaly. Without it game crashes on assertions / has de-synced sounds.

## Changes

- Adding support of third parameter in weapon hud sections, CoC and anomaly uses it everywhere

## Examples

```
anm_idle = protecta_idle
anm_idle_aim = protecta_aim
anm_idle_aim_moving = protecta_move, idle, 0.75
anm_idle_aim_moving_crouch = protecta_move, idle, 0.7
anm_idle_moving = protecta_move
anm_idle_sprint = protecta_sprint
```

```
anm_idle_moving_crouch_w_gl_aim = sg550_crouch_w_gl
anm_idle_moving_g = sg550_move_g
anm_idle_moving_g_aim = sg550_move_g, idle, 0.75
anm_idle_moving_w_gl = sg550_move_w_gl
anm_idle_moving_w_gl_aim = sg550_move_w_gl, idle, 0.75
```

## Links

https://github.com/revolucas/CoC-Xray/blob/551dfba681928b7a1292949cb2156c24174d96d6/src/xrGame/player_hud.cpp#L77
https://github.com/revolucas/CoC-Xray/blob/551dfba681928b7a1292949cb2156c24174d96d6/src/xrGame/player_hud.cpp#L352