### PR TITLE
[CoC/Anomaly] Optional grenade launcher switch animation usage.

### DIFF
--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -378,11 +378,6 @@ bool CHudItem::TryPlayAnimIdle()
     return false;
 }
 
-bool CHudItem::isHUDAnimationExist(pcstr anim_name) const
-{
-    return isHUDAnimationExist(anim_name, false);
-}
-
 //AVO: check if animation exists
 bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool is_silent) const
 {
@@ -408,11 +403,6 @@ bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool is_silent) const
         Msg("~ [WARNING] ------ Animation [%s] does not exist in [%s]", anim_name, HudSection().c_str());
 #endif
     return false;
-}
-
-pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2) const
-{
-    return WhichHUDAnimationExist(anim_name, anim_name2, false);
 }
 
 pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool is_silent) const

--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -378,8 +378,13 @@ bool CHudItem::TryPlayAnimIdle()
     return false;
 }
 
-//AVO: check if animation exists
 bool CHudItem::isHUDAnimationExist(pcstr anim_name) const
+{
+    return isHUDAnimationExist(anim_name, false);
+}
+
+//AVO: check if animation exists
+bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool is_silent) const
 {
     if (const auto* data = HudItemData()) // First person
     {
@@ -399,16 +404,22 @@ bool CHudItem::isHUDAnimationExist(pcstr anim_name) const
     else
         return false; // No hud section, no warning
 #ifdef DEBUG
-    Msg("~ [WARNING] ------ Animation [%s] does not exist in [%s]", anim_name, HudSection().c_str());
+    if (!is_silent)
+        Msg("~ [WARNING] ------ Animation [%s] does not exist in [%s]", anim_name, HudSection().c_str());
 #endif
     return false;
 }
 
 pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2) const
 {
-    if (isHUDAnimationExist(anim_name))
+    return WhichHUDAnimationExist(anim_name, anim_name2, false);
+}
+
+pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool is_silent) const
+{
+    if (isHUDAnimationExist(anim_name, is_silent))
         return anim_name;
-    if (isHUDAnimationExist(anim_name2))
+    if (isHUDAnimationExist(anim_name2, is_silent))
         return anim_name2;
     return nullptr;
 }

--- a/src/xrGame/HudItem.cpp
+++ b/src/xrGame/HudItem.cpp
@@ -379,7 +379,7 @@ bool CHudItem::TryPlayAnimIdle()
 }
 
 //AVO: check if animation exists
-bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool is_silent) const
+bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool silent) const
 {
     if (const auto* data = HudItemData()) // First person
     {
@@ -399,17 +399,17 @@ bool CHudItem::isHUDAnimationExist(pcstr anim_name, bool is_silent) const
     else
         return false; // No hud section, no warning
 #ifdef DEBUG
-    if (!is_silent)
+    if (!silent)
         Msg("~ [WARNING] ------ Animation [%s] does not exist in [%s]", anim_name, HudSection().c_str());
 #endif
     return false;
 }
 
-pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool is_silent) const
+pcstr CHudItem::WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool silent) const
 {
-    if (isHUDAnimationExist(anim_name, is_silent))
+    if (isHUDAnimationExist(anim_name, silent))
         return anim_name;
-    if (isHUDAnimationExist(anim_name2, is_silent))
+    if (isHUDAnimationExist(anim_name2, silent))
         return anim_name2;
     return nullptr;
 }

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -185,5 +185,7 @@ public:
     virtual CHudItem* cast_hud_item() { return this; }
     void PlayAnimIdleMovingCrouch(); //AVO: new crouch idle animation
     bool isHUDAnimationExist(pcstr anim_name) const;
+    bool isHUDAnimationExist(pcstr anim_name, bool is_silent) const;
     pcstr WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2) const;
+    pcstr WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool is_silent) const;
 };

--- a/src/xrGame/HudItem.h
+++ b/src/xrGame/HudItem.h
@@ -184,8 +184,6 @@ public:
 
     virtual CHudItem* cast_hud_item() { return this; }
     void PlayAnimIdleMovingCrouch(); //AVO: new crouch idle animation
-    bool isHUDAnimationExist(pcstr anim_name) const;
-    bool isHUDAnimationExist(pcstr anim_name, bool is_silent) const;
-    pcstr WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2) const;
-    pcstr WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool is_silent) const;
+    bool isHUDAnimationExist(pcstr anim_name, bool silent = false) const;
+    pcstr WhichHUDAnimationExist(pcstr anim_name, pcstr anim_name2, bool silent = false) const;
 };

--- a/src/xrGame/WeaponMagazinedWGrenade.cpp
+++ b/src/xrGame/WeaponMagazinedWGrenade.cpp
@@ -736,10 +736,14 @@ void CWeaponMagazinedWGrenade::PlayAnimShoot()
 
 void CWeaponMagazinedWGrenade::PlayAnimModeSwitch()
 {
-    if (m_bGrenadeMode)
-        PlayHUDMotion("anm_switch_g", "anim_switch_grenade_on", /*FALSE*/ TRUE, this, eSwitch); //AVO: fix fast anim switch
+    // Respect SOC/CS/COP animations naming with two possible animation assignments and do not spam in logs on checks.
+    // Possible place to inject anm_switch_g_empty / anm_switch_empty logics later with CoC/anomaly-like implementation.
+    cpcstr animation = m_bGrenadeMode ? WhichHUDAnimationExist("anm_switch_g", "anim_switch_grenade_on", true) : WhichHUDAnimationExist("anm_switch", "anim_switch_grenade_off", true);
+
+    if (animation)
+        PlayHUDMotion(animation, TRUE, this, eSwitch);
     else
-        PlayHUDMotion("anm_switch", "anim_switch_grenade_off", /*FALSE*/ TRUE, this, eSwitch); //AVO: fix fast anim switch
+        SwitchState(eSwitch);
 }
 
 void CWeaponMagazinedWGrenade::PlayAnimBore()


### PR DESCRIPTION
Just changing how animation is handled for grenade launcher toggling.

In case of missing animation just toggle switch. It is normal for some weapons with GL where switching mode does not require adjusting weapon / placing hand on another position. Found this one when was playing with integration of anomaly weapons and noticed some missing `anm_switch_g` `anm_switch` animation fields.

Main question as for now is logging -> probably prettier variant without method overloading can be implemented?

## Changes

- Just changing how animation is handled for grenade launcher toggling, allow cases without animation
- Still respect variant with two animations (SoC support?) and add comment for it
- Add param to prevent not_found log messages when doing animation checks / playing SoC animation variant (currently it produces 2 messages if animation is not found, I believe it is always 1 message for SoC)

## Links
https://github.com/xrLil-Batya/xray-monolith/blob/d404b95d92947e83b283d912111fe0957fb5fbb6/src/xrGame/WeaponMagazinedWGrenade.cpp#L839

https://github.com/OpenXRay/xray-16/pull/1763

#1373