### PR TITLE
[LUA] Use xr_new for script debug entities in stack

### DIFF
--- a/src/xrScriptEngine/script_stack_tracker.cpp
+++ b/src/xrScriptEngine/script_stack_tracker.cpp
@@ -15,7 +15,7 @@ CScriptStackTracker::CScriptStackTracker(CScriptEngine* scriptEngine)
     this->scriptEngine = scriptEngine;
     m_current_stack_level = 0;
     for (int i = 0; i < max_stack_size; i++)
-        m_stack[i] = new lua_Debug();
+        m_stack[i] = xr_new<lua_Debug>();
 }
 
 CScriptStackTracker::~CScriptStackTracker()


### PR DESCRIPTION
Fixing issue with segfault when executing scripts from game console.
Simple 'spawn_items' script execution throws exceptions from destructor and point to implementation of memory management methods. I suspect that overloaded deletion/allocation methods should be used in pair to prevent crashes --- need confirmation here.

## Changes

- Using xr_new instead of new for stack entities memory allocation