### PR TITLE
[CoC] Fixed crash after closing PDA when navigated to 'statistics' (fixes #1766)

### DIFF
--- a/src/xrGame/ui/UIRankingWnd.cpp
+++ b/src/xrGame/ui/UIRankingWnd.cpp
@@ -69,12 +69,13 @@ void CUIRankingWnd::Show(bool status)
 
 void CUIRankingWnd::Update()
 {
-    inherited::Update();
     if (Device.dwTimeGlobal - m_previous_time > m_delay)
     {
         m_previous_time = Device.dwTimeGlobal;
         update_info();
     }
+    if (IsShown())
+        inherited::Update();
 }
 
 bool CUIRankingWnd::Init()


### PR DESCRIPTION
Fixes a crash after closing the PDA when you navigated to the 'Statistics' page.

Thank you @Xottab-DUTY for the suggestion