### PR TITLE
[LUA] Unlock usage of 'source' functionality with tracy profiler.

### DIFF
--- a/Externals/tracy/public/tracy/TracyLua.hpp
+++ b/Externals/tracy/public/tracy/TracyLua.hpp
@@ -190,8 +190,11 @@ static tracy_force_inline void SendLuaCallstack( lua_State* L, uint32_t depth )
 
 static inline void LuaShortenSrc( char* dst, const char* src )
 {
-    size_t l = std::min( (size_t)255, strlen( src ) );
-    memcpy( dst, src, l );
+    // OpenXray - remove '@' prefix from luaJIT to allow directly working with file source with tracy application.
+    const char* src_trimmed = src && *src == '@' ? src + 1 : src;
+
+    size_t l = std::min( (size_t)255, strlen( src_trimmed ) );
+    memcpy( dst, src_trimmed, l );
     dst[l] = 0;
 }
 

--- a/Externals/tracy/public/tracy/TracyLua.hpp
+++ b/Externals/tracy/public/tracy/TracyLua.hpp
@@ -190,7 +190,7 @@ static tracy_force_inline void SendLuaCallstack( lua_State* L, uint32_t depth )
 
 static inline void LuaShortenSrc( char* dst, const char* src )
 {
-    // OpenXray - remove '@' prefix from luaJIT to allow directly working with file source with tracy application.
+    // OpenXRay - remove '@' prefix from LuaJIT to allow directly working with file source with Tracy application.
     const char* src_trimmed = src && *src == '@' ? src + 1 : src;
 
     size_t l = std::min( (size_t)255, strlen( src_trimmed ) );


### PR DESCRIPTION
## Changes

Strip '@' prefix for file paths of lua files when sending tracy net packets.
Looks like it all src are prefixed by luaJIT.

Without prefix stripping (current):
![image](https://github.com/user-attachments/assets/ead55fe5-b3ff-406a-8b98-8b6b92713161)

Without @ prefix:
![image](https://github.com/user-attachments/assets/d19f1661-99c9-43ef-b374-7ebc8ebd96e5)
