### PR TITLE
xrEngine/defines.cpp: use designated init

### DIFF
--- a/src/xrEngine/defines.cpp
+++ b/src/xrEngine/defines.cpp
@@ -8,12 +8,12 @@ ECORE_API bool bDebug = false;
 // Video
 DeviceMode psDeviceMode =
 {
-    /* .Monitor        = */ 0,
-    /* .WindowStyle    = */ rsFullscreen,
-    /* .Width          = */ 0,
-    /* .Height         = */ 0,
-    /* .RefreshRate    = */ 0,
-    /* .BitsPerPixel   = */ 32
+    .Monitor      = 0,
+    .WindowStyle  = rsFullscreen,
+    .Width        = 0,
+    .Height       = 0,
+    .RefreshRate  = 0,
+    .BitsPerPixel = 32
 };
 
 // release version always has "mt_*" enabled


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-designated-initializers.html

> C++20 supports the designated initializer syntax for aggregate types. By applying it, we can always be sure that aggregates are constructed correctly, because every variable being initialized is referenced by its name.
