### PR TITLE
cmake: fix sanitizer builds missing link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ if (USE_ADDRESS_SANITIZER)
 
     add_link_options(
         $<$<CXX_COMPILER_ID:Clang>:-shared-libasan>
+        -fsanitize=address
+        -fsanitize=leak
+        -fsanitize=undefined
     )
 endif()
 


### PR DESCRIPTION
Without adding the sanitizer linker flags you will get a linker error since the sanitizer runtime libraries are missing otherwise