### PR TITLE
CMake: silence all warnings for external libraries

### DIFF
--- a/Externals/CMakeLists.txt
+++ b/Externals/CMakeLists.txt
@@ -5,10 +5,14 @@ else()
 endif()
 
 add_subdirectory(xrLuaFix)
+add_subdirectory(ode)
+
+# Silence all warnings for external libraries
+add_compile_options("-w")
+
 add_subdirectory(luabind)
 add_subdirectory(GameSpy)
 add_subdirectory(OPCODE)
-add_subdirectory(ode)
 add_subdirectory(imgui-proj)
 
 if (NOT TARGET xrLuabind)


### PR DESCRIPTION
Noticed that during build the external libraries throw up a lot of warnings. Since we can't really fix them I think it would make sense to just silence them, so only the warnings from our actual code shows up