### PR TITLE
xrGame: Bump duplicate phrase ids down to a warning instead of crashing

### DIFF
--- a/src/xrGame/PhraseDialog.cpp
+++ b/src/xrGame/PhraseDialog.cpp
@@ -255,13 +255,6 @@ CPhrase* CPhraseDialog::AddPhrase(
     CPhrase* phrase = NULL;
     CPhraseGraph::CVertex* _vertex = data()->m_PhraseGraph.vertex(phrase_id);
 
-#ifdef DEBUG
-    if (_vertex)
-    {
-        Msg("! Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText());
-    }
-#endif
-
     if (!_vertex)
     {
         phrase = xr_new<CPhrase>();
@@ -273,6 +266,14 @@ CPhrase* CPhraseDialog::AddPhrase(
 
         data()->m_PhraseGraph.add_vertex(phrase, phrase_id);
     }
+#ifndef MASTER_GOLD
+    // Duplicating phrases with same ID and text is quite frequent in vanilla.
+    // Emit warning only if text is different.
+    else if (xr_strcmp(text, _vertex->data()->GetText()) != 0)
+    {
+        Msg("~ Trying to add phrase[%s] with ID[%s], but the ID is already used by phrase[%s]", text, phrase_id.c_str(), _vertex->data()->GetText());
+    }
+#endif
 
     if (prev_phrase_id != "")
         data()->m_PhraseGraph.add_edge(prev_phrase_id, phrase_id, 0.f);

--- a/src/xrGame/PhraseDialog.cpp
+++ b/src/xrGame/PhraseDialog.cpp
@@ -254,7 +254,13 @@ CPhrase* CPhraseDialog::AddPhrase(
 {
     CPhrase* phrase = NULL;
     CPhraseGraph::CVertex* _vertex = data()->m_PhraseGraph.vertex(phrase_id);
-    VERIFY2(!_vertex, make_string("Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText()).c_str());
+
+#ifdef DEBUG
+    if (_vertex)
+    {
+        Msg("! Duplicate phrase ID: [%s] for phrase: [%s]. Existed phrase by this ID: [%s]", phrase_id.c_str(), text, _vertex->data()->GetText());
+    }
+#endif
 
     if (!_vertex)
     {


### PR DESCRIPTION
Apparently in Clear Sky this happens a lot even with the original game files.