### PR TITLE
Initialize `m_bIsHorizontal` in `CUIScrollBar`

### DIFF
--- a/src/xrUICore/ScrollBar/UIScrollBar.h
+++ b/src/xrUICore/ScrollBar/UIScrollBar.h
@@ -28,7 +28,7 @@ protected:
 
     int m_ScrollWorkArea;
     bool m_b_enabled{ true };
-    bool m_bIsHorizontal;
+    bool m_bIsHorizontal{ false };
 
     int m_mouse_state{};
 


### PR DESCRIPTION
Otherwise we get an uninitialized read which is picked up by UBSAN.