### PR TITLE
xrCore: Fix gcc warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ add_compile_options(
     #-Wno-newline-eof
     $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>>
     $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-interference-size>>
+    $<$<CXX_COMPILER_ID:GNU>:$<$<COMPILE_LANGUAGE:CXX>:-Wno-overloaded-virtual>>
 )
 
 add_subdirectory(src)

--- a/src/xrCore/LocatorAPI.cpp
+++ b/src/xrCore/LocatorAPI.cpp
@@ -359,7 +359,7 @@ IReader* open_chunk(int fd, u32 ID, pcstr archiveName, size_t archiveSize, bool 
             u8* src_data = xr_alloc<u8>(dwSize);
             read_byte = _read(fd, src_data, dwSize);
 
-            VERIFY(read_byte == dwSize);
+            VERIFY(static_cast<size_t>(read_byte) == dwSize);
             if (dwType & CFS_CompressMark)
             {
                 u8* dest = nullptr;

--- a/src/xrCore/XML/XMLDocument.cpp
+++ b/src/xrCore/XML/XMLDocument.cpp
@@ -83,7 +83,14 @@ void ParseFile(pcstr path, CMemoryWriter& W, IReader* F, XMLDocument* xml, bool 
         if (includeName == strstr(includeName, comparePath))
         {
             pcstr fileName = strstr(includeName, comparePath);
-            fileName = fileName ? ++fileName : includeName;
+            if (fileName)
+            {
+                fileName++;
+            }
+            else
+            {
+                fileName = includeName;
+            }
 
             shared_str fn = xml->correct_file_name(uiPath, fileName);
             string_path buff;

--- a/src/xrCore/string_concatenations.cpp
+++ b/src/xrCore/string_concatenations.cpp
@@ -108,7 +108,7 @@ void string_tupples::error_process() const
             }
         }
     }
-    VERIFY(overrun_string_index != -1);
+    VERIFY(overrun_string_index != u32(-1));
 
     strconcat_error::process(overrun_string_index, m_count, strings);
 }

--- a/src/xrCore/xrDebug.cpp
+++ b/src/xrCore/xrDebug.cpp
@@ -107,7 +107,7 @@ AssertionResult xrDebug::ShowMessage(pcstr title, pcstr message, bool simpleMode
     {
         SDL_MESSAGEBOX_ERROR,
         windowHandler ? windowHandler->GetApplicationWindow() : nullptr,
-        title, message, SDL_arraysize(buttons), buttons
+        title, message, SDL_arraysize(buttons), buttons, nullptr
     };
 
     int button = -1;

--- a/src/xrCore/xr_ini.cpp
+++ b/src/xrCore/xr_ini.cpp
@@ -425,6 +425,7 @@ void CInifile::Load(IReader* F, pcstr path, allow_include_func_t allow_include_f
 
 #ifdef DEBUG
         pstr comment = 0;
+        (void)comment;
 #endif
         if (comm)
         {


### PR DESCRIPTION
With this commit xrCore should be warning free on gcc.

Work towards #713