### PR TITLE
fix: `SMusicTrack::SetVolume` setting the final volume to either 0.0 or 1.0

### DIFF
--- a/src/xrGame/level_sounds.cpp
+++ b/src/xrGame/level_sounds.cpp
@@ -149,7 +149,8 @@ bool SMusicTrack::IsPlaying() const
 
 void SMusicTrack::SetVolume(float volume)
 {
-    const bool finalVolume = volume * m_Volume;
+    const float finalVolume = volume * m_Volume;
+
     m_SourceStereo.set_volume(finalVolume);
     m_SourceLeft.set_volume(finalVolume);
     m_SourceRight.set_volume(finalVolume);


### PR DESCRIPTION
This was caused by what probably is a typo as the final volume is calculated as `volume * m_Volume` but then assigned to a bool (which C++ just allows you todo).

This was introduced in commit fa7af012e08622961d1c8d3a5d2044757f3d2f56.

Looking at the diff this is not the behaviour we had before.