### PR TITLE
fix: `CSpaceRestrictionBase::m_correct` not being initialized

### DIFF
--- a/src/xrGame/space_restriction_base.h
+++ b/src/xrGame/space_restriction_base.h
@@ -18,7 +18,7 @@ private:
 public:
 #ifdef DEBUG
     xr_vector<u32> m_test_storage;
-    bool m_correct;
+    bool m_correct{ false };
 #endif
 
 protected:


### PR DESCRIPTION
Another uninitialized read I found while playing CoC with UBSAN :)