### PR TITLE
fix: `CSpaceRestrictionComposition::test_correctness` crashing when ignoring error

### DIFF
--- a/src/xrGame/space_restriction_composition.cpp
+++ b/src/xrGame/space_restriction_composition.cpp
@@ -133,11 +133,9 @@ void CSpaceRestrictionComposition::test_correctness()
     m_test_storage.clear();
 
     {
-        RESTRICTIONS::iterator I = m_restrictions.begin();
-        RESTRICTIONS::iterator E = m_restrictions.end();
-        for (; I != E; ++I)
-            m_test_storage.insert(
-                m_test_storage.end(), (*I)->object().m_test_storage.begin(), (*I)->object().m_test_storage.end());
+        for (const auto& restriction : m_restrictions)
+            m_test_storage.insert(m_test_storage.end(), restriction->object().m_test_storage.begin(),
+                restriction->object().m_test_storage.end());
     }
 
     {
@@ -153,15 +151,23 @@ void CSpaceRestrictionComposition::test_correctness()
 
     xr_vector<u32> nodes;
     {
-        RESTRICTIONS::iterator I = m_restrictions.begin();
-        RESTRICTIONS::iterator E = m_restrictions.end();
-        for (; I != E; ++I)
+        for (const auto& restriction : m_restrictions)
         {
-            VERIFY3(!(*I)->object().m_test_storage.empty(), "Restrictor has no border", *(*I)->object().name());
+            // Check if the restrictor has has a border
+            if (restriction->object().m_test_storage.empty())
+            {
+                static bool ignoreAlways = false;
+                if (!ignoreAlways)
+                    xrDebug::Fail(ignoreAlways, DEBUG_INFO, "!restriction->object().m_test_storage.empty()",
+                        "Restrictor has no border", *restriction->object().name());
+
+                continue;
+            }
+
             nodes.clear();
             ai().level_graph().set_mask(border());
-            ai().graph_engine().search(ai().level_graph(), (*I)->object().m_test_storage.back(),
-                (*I)->object().m_test_storage.back(), &nodes, GraphEngineSpace::CFlooder());
+            ai().graph_engine().search(ai().level_graph(), restriction->object().m_test_storage.back(),
+                restriction->object().m_test_storage.back(), &nodes, GraphEngineSpace::CFlooder());
             ai().level_graph().clear_mask(border());
 
             if (nodes.size() == 65535)

--- a/src/xrGame/space_restriction_composition.cpp
+++ b/src/xrGame/space_restriction_composition.cpp
@@ -153,17 +153,11 @@ void CSpaceRestrictionComposition::test_correctness()
     {
         for (const auto& restriction : m_restrictions)
         {
-            // Check if the restrictor has has a border
-            if (restriction->object().m_test_storage.empty())
+            R_ASSERT3_CURE(!restriction->object().m_test_storage.empty(), "Restrictor has no border", restriction->object().name().c_str(),
             {
-                static bool ignoreAlways = false;
-                if (!ignoreAlways)
-                    xrDebug::Fail(ignoreAlways, DEBUG_INFO, "!restriction->object().m_test_storage.empty()",
-                        "Restrictor has no border", *restriction->object().name());
-
-                continue;
-            }
-
+                m_correct = false;
+                break;
+            });
             nodes.clear();
             ai().level_graph().set_mask(border());
             ai().graph_engine().search(ai().level_graph(), restriction->object().m_test_storage.back(),


### PR DESCRIPTION
Sadly CoC (#1529) fails this correctness test and ignoring it causes a crash. Also did a bit of cleanup like using a ranged for loop instead of the iterator shenanigans.

Crashlog:
```
/usr/include/c++/14.2.1/bits/stl_iterator.h:1149:45: runtime error: applying non-zero offset 18446744073709551612 to null pointer
    #0 0x7fffe5a58892 in __gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, xalloc<unsigned int> > >::operator-(long) const /usr/include/c++/14.2.1/bits/stl_iterator.h:1149
    #1 0x7fffe5a58ace in std::vector<unsigned int, xalloc<unsigned int> >::back() /usr/include/c++/14.2.1/bits/stl_vector.h:1238
    #2 0x7fffe7a33228 in CSpaceRestrictionComposition::test_correctness() /mnt/data/dev/xray-16/src/xrGame/space_restriction_composition.cpp:164
    #3 0x7fffe7a372b4 in CSpaceRestrictionComposition::initialize() /mnt/data/dev/xray-16/src/xrGame/space_restriction_composition.cpp:125
    #4 0x7fffe79f382a in CSpaceRestrictionBridge::initialize() /mnt/data/dev/xray-16/src/xrGame/space_restriction_bridge.cpp:25
    #5 0x7fffe7a388e9 in CSpaceRestriction::initialize() /mnt/data/dev/xray-16/src/xrGame/space_restriction.cpp:232
    #6 0x7fffe7a0f8f6 in CSpaceRestriction::accessible(unsigned int, float) /mnt/data/dev/xray-16/src/xrGame/space_restriction.cpp:81
    #7 0x7fffe7a0fc9d in CSpaceRestrictionManager::accessible(unsigned short, unsigned int, float) /mnt/data/dev/xray-16/src/xrGame/space_restriction_manager.cpp:160
    #8 0x7fffe7227482 in CRestrictedObject::accessible(unsigned int, float) const /mnt/data/dev/xray-16/src/xrGame/restricted_object.cpp:145
    #9 0x7fffe6e90f60 in bool CMovementManager::accessible<unsigned int>(unsigned int, float) const /mnt/data/dev/xray-16/src/xrGame/movement_manager_inline.h:28
    #10 0x7fffe81076fe in CControlPathBuilder::valid_and_accessible(_vector3<float>&, unsigned int) /mnt/data/dev/xray-16/src/xrGame/ai/monsters/control_path_builder.cpp:212
    #11 0x7fffe8123353 in CControlPathBuilderBase::find_target_point_set() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/control_path_builder_base_path.cpp:72
    #12 0x7fffe8124958 in CControlPathBuilderBase::update_target_point() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/control_path_builder_base_update.cpp:43
    #13 0x7fffe8124aea in CControlPathBuilderBase::update_frame() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/control_path_builder_base_update.cpp:15
    #14 0x7fffe8055b47 in CControl_Manager::update_frame() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/control_manager.cpp:126
    #15 0x7fffe80fd559 in CBaseMonster::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/basemonster/base_monster.cpp:341
    #16 0x7fffe83e9f7f in CAI_Dog::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/dog/dog.cpp:186
    #17 0x7fffdc09b7f5 in CObjectList::SingleUpdate(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:144
    #18 0x7fffdc0aa201 in CObjectList::Update(bool) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:285
    #19 0x7fffdc03b064 in IGame_Level::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/IGame_Level.cpp:188
    #20 0x7fffe6b5b0a3 in CLevel::OnFrame() /mnt/data/dev/xray-16/src/xrGame/Level.cpp:474
    #21 0x7fffdc12686b in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #22 0x7fffdc12686b in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #23 0x7fffdc127521 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:483
    #24 0x7fffdc107301 in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:269
    #25 0x7fffdc0d741a in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:445
    #26 0x5555555575cc in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:38
    #27 0x555555557b23 in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:89
    #28 0x7fffda0278cd  (/usr/lib/libc.so.6+0x278cd) (BuildId: 6cb3848fe8b7e02ffe7b4d9db1cffb88b14b0659)
    #29 0x7fffda027989 in __libc_start_main (/usr/lib/libc.so.6+0x27989) (BuildId: 6cb3848fe8b7e02ffe7b4d9db1cffb88b14b0659)
    #30 0x555555557254 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x3254) (BuildId: 332c1f56345bdc10eb35ac3e8dd3c171f4e80839)

```