### PR TITLE
fix: `CSE_ALifeObject::spawn_supplies` stack use after scope

### DIFF
--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -114,9 +114,9 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
                         {
                             pcstr ammo_class = pSettings->r_string(itmSection, "ammo_class");
                             pcstr ammoSec = "";
+                            string128 tmp;
                             for (int i = 0, n = _GetItemCount(ammo_class); i < n; ++i)
                             {
-                                string128 tmp;
                                 ammoSec = _GetItem(ammo_class, i, tmp);
                                 if (i == iAmmoType)
                                     break;


### PR DESCRIPTION
Should be fairly obvious that the `tmp` variable should life atleast as long as the potential pointer to it in `ammoSec` which gets used directly afterwards.

Altough to be fair the chances of this leading to a "real" crash a very low.

crash log:
```
=================================================================
==1123022==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fffd5788390 at pc 0x7ffff7885d79 bp 0x7fffffff52b0 sp 0x7fffffff4a58
READ of size 19 at 0x7fffd5788390 thread T0
    #0 0x7ffff7885d78 in strlen /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x7fffe571d6e3 in xr_strlen(char const*) /mnt/data/dev/xray-16/src/xrCore/_std_extensions.h:141
    #2 0x7fffe5b8bd6c in CSE_ALifeObject::spawn_supplies(char const*) /mnt/data/dev/xray-16/src/xrGame/alife_object.cpp:124
    #3 0x7fffe5d3d8af in CSE_ALifeTraderAbstract::spawn_supplies() /mnt/data/dev/xray-16/src/xrGame/alife_trader_abstract.cpp:64
    #4 0x7fffe5aaf881 in CSE_ALifeHumanAbstract::spawn_supplies() /mnt/data/dev/xray-16/src/xrGame/alife_human_abstract.cpp:53
    #5 0x7fffe5c04934 in CALifeSimulatorBase::spawn_item(char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool) /mnt/data/dev/xray-16/src/xrGame/alife_simulator_base.cpp:131
    #6 0x7fffe5c05120 in CALifeSimulator__spawn_item(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short) /mnt/data/dev/xray-16/src/xrGame/alife_simulator_script.cpp:156
    #7 0x7fffe5c96dd2 in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short>, CSE_Abstract* (* const)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short)>::call_struct<false, false, luabind::meta::index_list<0u, 1u, 2u, 3u, 4u> >::call(lua_State*, CSE_Abstract* (* const&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short), std::tuple<luabind::default_converter<CALifeSimulator*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<_vector3<float> const&, void>, luabind::default_converter<unsigned int, void>, luabind::default_converter<unsigned short, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:218
    #8 0x7fffe5c97985 in int luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short>, CSE_Abstract* (* const)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short)>::call_fun<std::tuple<luabind::default_converter<CALifeSimulator*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<_vector3<float> const&, void>, luabind::default_converter<unsigned int, void>, luabind::default_converter<unsigned short, void> > >(lua_State*, luabind::detail::invoke_context&, CSE_Abstract* (* const&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short), int, std::tuple<luabind::default_converter<CALifeSimulator*, void>, luabind::default_converter<char const*, void>, luabind::default_converter<_vector3<float> const&, void>, luabind::default_converter<unsigned int, void>, luabind::default_converter<unsigned short, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:317
    #9 0x7fffe5c97985 in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short>, CSE_Abstract* (* const)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short)>::call_best_match(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CSE_Abstract* (* const&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short), int) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:355
    #10 0x7fffe5c97a4b in int luabind::detail::call_best_match<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short>, CSE_Abstract* (* const)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short)>(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CSE_Abstract* (* const&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short), int) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:386
    #11 0x7fffe5c97a4b in luabind::detail::function_object_impl<CSE_Abstract* (*)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short), luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short>, luabind::meta::type_list<> >::call(lua_State*, luabind::detail::invoke_context&, int) const /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:38
    #12 0x7fffe5c92ad2 in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool>, CSE_Abstract* (*)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool)>::call_best_match(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CSE_Abstract* (*&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool), int) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:352
    #13 0x7fffe5c92fb2 in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool>, CSE_Abstract* (*)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool)>::invoke(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CSE_Abstract* (*&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool)) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:378
    #14 0x7fffe5c1ecd7 in int luabind::detail::invoke<luabind::meta::type_list<>, luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool>, CSE_Abstract* (*)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool)>(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, CSE_Abstract* (*&)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool)) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:392
    #15 0x7fffe5c1ecd7 in luabind::detail::function_object_impl<CSE_Abstract* (*)(CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool), luabind::meta::type_list<CSE_Abstract*, CALifeSimulator*, char const*, _vector3<float> const&, unsigned int, unsigned short, unsigned short, bool>, luabind::meta::type_list<> >::entry_point(lua_State*) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:76
    #16 0x7fffd96a5ea4 in lj_BC_FUNCC /mnt/data/dev/xray-16/bin/buildvm_x86.dasc:849
    #17 0x7fffd96d34da in lua_pcall /mnt/data/dev/xray-16/Externals/LuaJIT/src/lj_api.c:1218
    #18 0x7fffd9bc1732 in luabind::detail::pcall(lua_State*, int, int) /mnt/data/dev/xray-16/Externals/luabind/src/pcall.cpp:43
    #19 0x7fffe5d1c941 in void luabind::detail::call_function_struct<void, luabind::meta::type_list<>, luabind::meta::index_list<1u>, 1u, &luabind::detail::pcall, true>::call<char const*>(lua_State*, char const*&&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_function.hpp:111
    #20 0x7fffe5d1ca5c in void luabind::call_pushed_function<void, luabind::meta::type_list<>, char const*>(lua_State*, char const*&&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_function.hpp:111
    #21 0x7fffe5d1caca in void luabind::call_function<void, luabind::meta::type_list<>, char const*>(luabind::adl::object const&, char const*&&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/object.hpp:146
    #22 0x7fffe8f98577 in void luabind::functor<void>::operator()<char const*>(char const*&&) const /mnt/data/dev/xray-16/src/xrScriptEngine/Functor.hpp:31
    #23 0x7fffe8f98577 in operator() /mnt/data/dev/xray-16/src/xrServerEntities/script_ini_file_script.cpp:113
    #24 0x7fffe8f986ed in _FUN /mnt/data/dev/xray-16/src/xrServerEntities/script_ini_file_script.cpp:115
    #25 0x7fffe8f9ac4c in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, CScriptIniFile*, luabind::functor<void> const&>, void (*)(CScriptIniFile*, luabind::functor<void> const&)>::call_struct<false, true, luabind::meta::index_list<0u, 1u> >::call(lua_State*, void (*&)(CScriptIniFile*, luabind::functor<void> const&), std::tuple<luabind::default_converter<CScriptIniFile*, void>, luabind::default_converter<luabind::functor<void> const&, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:244
    #26 0x7fffe8f9b75d in int luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, CScriptIniFile*, luabind::functor<void> const&>, void (*)(CScriptIniFile*, luabind::functor<void> const&)>::call_fun<std::tuple<luabind::default_converter<CScriptIniFile*, void>, luabind::default_converter<luabind::functor<void> const&, void> > >(lua_State*, luabind::detail::invoke_context&, void (*&)(CScriptIniFile*, luabind::functor<void> const&), int, std::tuple<luabind::default_converter<CScriptIniFile*, void>, luabind::default_converter<luabind::functor<void> const&, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:317
    #27 0x7fffe8f9b75d in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, CScriptIniFile*, luabind::functor<void> const&>, void (*)(CScriptIniFile*, luabind::functor<void> const&)>::invoke(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, void (*&)(CScriptIniFile*, luabind::functor<void> const&)) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:374
    #28 0x7fffe8f9b91a in int luabind::detail::invoke<luabind::meta::type_list<>, luabind::meta::type_list<void, CScriptIniFile*, luabind::functor<void> const&>, void (*)(CScriptIniFile*, luabind::functor<void> const&)>(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, void (*&)(CScriptIniFile*, luabind::functor<void> const&)) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:392
    #29 0x7fffe8f9b91a in luabind::detail::function_object_impl<void (*)(CScriptIniFile*, luabind::functor<void> const&), luabind::meta::type_list<void, CScriptIniFile*, luabind::functor<void> const&>, luabind::meta::type_list<> >::entry_point(lua_State*) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:76
    #30 0x7fffd96a5ea4 in lj_BC_FUNCC /mnt/data/dev/xray-16/bin/buildvm_x86.dasc:849
    #31 0x7fffd96d34da in lua_pcall /mnt/data/dev/xray-16/Externals/LuaJIT/src/lj_api.c:1218
    #32 0x7fffd9bc1732 in luabind::detail::pcall(lua_State*, int, int) /mnt/data/dev/xray-16/Externals/luabind/src/pcall.cpp:43
    #33 0x7fffe6432882 in void luabind::detail::call_member_impl<void, luabind::meta::type_list<>>(lua_State*, std::integral_constant<bool, true>, luabind::meta::index_list<>) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_member.hpp:54
    #34 0x7fffe6432a9a in void luabind::wrap_base::call<void>(char const*) const /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/wrapper_base.hpp:92
    #35 0x7fffe6432b9d in void luabind::call_member<void>(luabind::wrap_base const*, char const*) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_member.hpp:123
    #36 0x7fffe962b4e5 in CWrapperAbstractCreature<CSE_ALifeCreatureActor>::on_register() /mnt/data/dev/xray-16/src/xrServerEntities/xrServer_script_macroses.h:191
    #37 0x7fffe5d2e51a in CALifeUpdateManager::new_game(char const*) /mnt/data/dev/xray-16/src/xrGame/alife_update_manager.cpp:239
    #38 0x7fffe5d2e999 in CALifeUpdateManager::load(char const*, bool, bool) /mnt/data/dev/xray-16/src/xrGame/alife_update_manager.cpp:262
    #39 0x7fffe5c0f968 in CALifeSimulator::CALifeSimulator(IPureServer*, shared_str*) /mnt/data/dev/xray-16/src/xrGame/alife_simulator.cpp:62
    #40 0x7fffe67f17aa in CALifeSimulator* xr_new<CALifeSimulator, xrServer*, shared_str*>(xrServer*&&, shared_str*&&) /mnt/data/dev/xray-16/src/xrCore/xrMemory.h:135
    #41 0x7fffe6802186 in game_sv_Single::Create(shared_str&) /mnt/data/dev/xray-16/src/xrGame/game_sv_single.cpp:23
    #42 0x7fffe7f79cf2 in xrServer::Connect(shared_str&, GameDescriptionData&) /mnt/data/dev/xray-16/src/xrGame/xrServer_Connect.cpp:84
    #43 0x7fffe6d2a14c in CLevel::net_start2() /mnt/data/dev/xray-16/src/xrGame/Level_start.cpp:151
    #44 0x7fffdc125d3f in fastdelegate::FastDelegate<bool ()>::operator()() const /mnt/data/dev/xray-16/src/xrCore/fastdelegate.h:766
    #45 0x7fffdc0f6fe5 in CRenderDevice::BeforeFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:176
    #46 0x7fffdc107064 in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:264
    #47 0x7fffdc0d71da in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:445
    #48 0x5555555575cc in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:38
    #49 0x555555557b23 in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:89
    #50 0x7fffda0278cd  (/usr/lib/libc.so.6+0x278cd) (BuildId: 6cb3848fe8b7e02ffe7b4d9db1cffb88b14b0659)
    #51 0x7fffda027989 in __libc_start_main (/usr/lib/libc.so.6+0x27989) (BuildId: 6cb3848fe8b7e02ffe7b4d9db1cffb88b14b0659)
    #52 0x555555557254 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x3254) (BuildId: f419deab458fd0f712c1424711f846b8ca15b993)

Address 0x7fffd5788390 is located in stack of thread T0 at offset 912 in frame
    #0 0x7fffe5b89f83 in CSE_ALifeObject::spawn_supplies(char const*) /mnt/data/dev/xray-16/src/xrGame/alife_object.cpp:18

  This frame has 19 object(s):
    [48, 49) '<unknown>'
    [64, 68) 'k' (line 51)
    [80, 88) 'V' (line 46)
    [112, 120) 'itmSection' (line 46)
    [144, 152) 'V' (line 149)
    [176, 184) 'N' (line 149)
    [208, 216) '<unknown>'
    [240, 248) 'ini_string' (line 17)
    [272, 288) 'funct' (line 25)
    [304, 328) 'spawnLoadouts' (line 47)
    [368, 392) '<unknown>'
    [432, 456) '<unknown>'
    [496, 520) '<unknown>'
    [560, 616) 'reader' (line 34)
    [656, 688) 'loadoutSection' (line 38)
    [720, 784) 'tmp' (line 85)
    [816, 880) 'buf' (line 167)
    [912, 1040) 'tmp' (line 119) <== Memory access at offset 912 is inside this variable
    [1072, 9304) 'ini' (line 35)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x7fffd5788100: f2 f2 00 00 f2 f2 00 00 00 f2 f2 f2 f2 f2 f8 f8
  0x7fffd5788180: f8 f2 f2 f2 f2 f2 00 00 00 f2 f2 f2 f2 f2 00 00
  0x7fffd5788200: 00 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 f2 f2 f2
  0x7fffd5788280: f2 f2 00 00 00 00 f2 f2 f2 f2 f8 f8 f8 f8 f8 f8
  0x7fffd5788300: f8 f8 f2 f2 f2 f2 00 00 00 00 00 00 00 00 f2 f2
=>0x7fffd5788380: f2 f2[f8]f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x7fffd5788400: f8 f8 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
  0x7fffd5788480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffd5788500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffd5788580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffd5788600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1123022==ABORTING
```