### PR TITLE
Mark constants as `constexpr` to fix a linker error with GCC

### DIFF
--- a/src/xrScriptEngine/script_profiler.hpp
+++ b/src/xrScriptEngine/script_profiler.hpp
@@ -20,10 +20,10 @@ public:
     static constexpr cpcstr ARGUMENT_PROFILER_HOOK = "-lua_hook_profiler";
     static constexpr cpcstr ARGUMENT_PROFILER_SAMPLING = "-lua_sampling_profiler";
 
-    static const CScriptProfilerType PROFILE_TYPE_DEFAULT = CScriptProfilerType::Hook;
-    static const u32 PROFILE_ENTRIES_LOG_LIMIT_DEFAULT = 128;
-    static const u32 PROFILE_SAMPLING_INTERVAL_DEFAULT = 10;
-    static const u32 PROFILE_SAMPLING_INTERVAL_MAX = 1000;
+    static constexpr CScriptProfilerType PROFILE_TYPE_DEFAULT = CScriptProfilerType::Hook;
+    static constexpr u32 PROFILE_ENTRIES_LOG_LIMIT_DEFAULT = 128;
+    static constexpr u32 PROFILE_SAMPLING_INTERVAL_DEFAULT = 10;
+    static constexpr u32 PROFILE_SAMPLING_INTERVAL_MAX = 1000;
 
 private:
     CScriptEngine* m_engine;


### PR DESCRIPTION
Linker error:

```
FAILED: x86_64/Debug/xr_3da 
: && /usr/bin/sccache /usr/bin/c++ -g -flto=auto -fno-fat-lto-objects -fsanitize=address -fsanitize=leak -fsanitize=undefined -Wl,--dependency-file=src/xr_3da/CMakeFiles/xr_3da.dir/link.d src/xr_3da/CMakeFiles/xr_3da.dir/entry_point.cpp.o -o x86_64/Debug/xr_3da  -Wl,-rpath,"\$ORIGIN:"  x86_64/Debug/xrRender_GL.so  x86_64/Debug/xrGame.so  x86_64/Debug/xrEngine.so  x86_64/Debug/libxrMiscMath.a  x86_64/Debug/xrCore.so  -lpthread  /usr/lib/libSDL2-2.0.so.0.3200.52  x86_64/Debug/xrAPI.so  -Wl,-rpath-link,/mnt/data/dev/xray-16/bin/x86_64/Debug && :
/usr/bin/ld: /mnt/data/dev/xray-16/bin/x86_64/Debug/xrScriptEngine.so: undefined reference to `CScriptProfiler::PROFILE_SAMPLING_INTERVAL_MAX'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```