### PR TITLE
Enable all map filters in ClearSky mode

### DIFF
--- a/src/xrGame/player_hud_tune.cpp
+++ b/src/xrGame/player_hud_tune.cpp
@@ -153,29 +153,29 @@ void CHudTuner::on_tool_frame()
                 {
                     ImGui::LogToClipboard();
                     xr_sprintf(selectable, "[%s]\n", m_sect_name.c_str());
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "hands_position%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_attach[0].x, new_measures.m_hands_attach[0].y, new_measures.m_hands_attach[0].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "hands_orientation%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_attach[1].x, new_measures.m_hands_attach[1].y, new_measures.m_hands_attach[1].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "aim_hud_offset_pos%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_offset[0][1].x, new_measures.m_hands_offset[0][1].y, new_measures.m_hands_offset[0][1].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "aim_hud_offset_rot%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_offset[1][1].x, new_measures.m_hands_offset[1][1].y, new_measures.m_hands_offset[1][1].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "gl_hud_offset_pos%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_offset[0][2].x, new_measures.m_hands_offset[0][2].y, new_measures.m_hands_offset[0][2].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "gl_hud_offset_rot%s = %f,%f,%f\n", (is_16x9) ? "_16x9" : "", new_measures.m_hands_offset[1][2].x, new_measures.m_hands_offset[1][2].y, new_measures.m_hands_offset[1][2].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "item_position = %f,%f,%f\n", new_measures.m_item_attach[0].x, new_measures.m_item_attach[0].y, new_measures.m_item_attach[0].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "item_orientation = %f,%f,%f\n", new_measures.m_item_attach[1].x, new_measures.m_item_attach[1].y, new_measures.m_item_attach[1].z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "fire_point = %f,%f,%f\n", new_measures.m_fire_point_offset.x, new_measures.m_fire_point_offset.y, new_measures.m_fire_point_offset.z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "fire_point = %f,%f,%f\n", new_measures.m_fire_point2_offset.x, new_measures.m_fire_point2_offset.y, new_measures.m_fire_point2_offset.z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     xr_sprintf(selectable, "shell_point = %f,%f,%f\n", new_measures.m_shell_point_offset.x, new_measures.m_shell_point_offset.y, new_measures.m_shell_point_offset.z);
-                    ImGui::LogText(selectable);
+                    ImGui::LogText("%s", selectable);
                     ImGui::LogFinish();
                 }
 

--- a/src/xrGame/ui/UIMapFilters.cpp
+++ b/src/xrGame/ui/UIMapFilters.cpp
@@ -177,7 +177,7 @@ CUICheckButton* CUIMapFilters::GetSelectedFilter() const
 
 bool CUIMapFilters::IsFilterEnabled(eSpotsFilter filter) const
 {
-    return m_filters[filter] && m_filters[filter]->GetCheck();
+    return !m_filters[filter] || m_filters[filter]->GetCheck();
 }
 
 void CUIMapFilters::SetFilterEnabled(eSpotsFilter filter, bool enable) const

--- a/src/xrGame/ui/UITaskWnd.cpp
+++ b/src/xrGame/ui/UITaskWnd.cpp
@@ -321,10 +321,10 @@ void CUITaskWnd::Show_TaskListWnd(bool status) const
     m_task_wnd->Show(status);
 }
 
-bool CUITaskWnd::IsTreasuresEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::Treasures)); }
-bool CUITaskWnd::IsQuestNpcsEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::QuestNpcs)); }
-bool CUITaskWnd::IsSecondaryTasksEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::SecondaryTasks)); }
-bool CUITaskWnd::IsPrimaryObjectsEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::PrimaryObjects)); }
+bool CUITaskWnd::IsTreasuresEnabled() const { return !m_filters || m_filters->IsFilterEnabled(CUIMapFilters::Treasures); }
+bool CUITaskWnd::IsQuestNpcsEnabled() const { return !m_filters || m_filters->IsFilterEnabled(CUIMapFilters::QuestNpcs); }
+bool CUITaskWnd::IsSecondaryTasksEnabled() const { return !m_filters || m_filters->IsFilterEnabled(CUIMapFilters::SecondaryTasks); }
+bool CUITaskWnd::IsPrimaryObjectsEnabled() const { return !m_filters || m_filters->IsFilterEnabled(CUIMapFilters::PrimaryObjects); }
 
 void CUITaskWnd::TreasuresEnabled(bool enable)
 {

--- a/src/xrGame/ui/UITaskWnd.cpp
+++ b/src/xrGame/ui/UITaskWnd.cpp
@@ -321,10 +321,10 @@ void CUITaskWnd::Show_TaskListWnd(bool status) const
     m_task_wnd->Show(status);
 }
 
-bool CUITaskWnd::IsTreasuresEnabled() const { return m_filters && m_filters->IsFilterEnabled(CUIMapFilters::Treasures); }
-bool CUITaskWnd::IsQuestNpcsEnabled() const { return m_filters && m_filters->IsFilterEnabled(CUIMapFilters::QuestNpcs); }
-bool CUITaskWnd::IsSecondaryTasksEnabled() const { return m_filters && m_filters->IsFilterEnabled(CUIMapFilters::SecondaryTasks); }
-bool CUITaskWnd::IsPrimaryObjectsEnabled() const { return m_filters && m_filters->IsFilterEnabled(CUIMapFilters::PrimaryObjects); }
+bool CUITaskWnd::IsTreasuresEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::Treasures)); }
+bool CUITaskWnd::IsQuestNpcsEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::QuestNpcs)); }
+bool CUITaskWnd::IsSecondaryTasksEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::SecondaryTasks)); }
+bool CUITaskWnd::IsPrimaryObjectsEnabled() const { return ClearSkyMode || (m_filters && m_filters->IsFilterEnabled(CUIMapFilters::PrimaryObjects)); }
 
 void CUITaskWnd::TreasuresEnabled(bool enable)
 {


### PR DESCRIPTION
Seems like Clear Sky doesn't have map filter functionality, thus all CUITaskWnd::Is... functions always return false, resulting in unusable task focus and hide/show buttons. 
Additional testing requested.
Should not affect Call of Pripyat mode.