### PR TITLE
xrUICore: Remove unused DEF_UILIST macro

### DIFF
--- a/src/xrUICore/Windows/UIWindow.h
+++ b/src/xrUICore/Windows/UIWindow.h
@@ -2,10 +2,6 @@
 
 #define ui_list xr_vector
 
-#define DEF_UILIST(N, T)  \
-    typedef ui_list<T> N; \
-    typedef N::iterator N##_it;
-
 //////////////////////////////////////////////////////////////////////////
 
 #include "xrUICore/UIMessages.h"


### PR DESCRIPTION
Was replaced back in 79121121c67a971f9e23b9859b9c4790fa1a25b5