### PR TITLE
Fixed loading of fast (shadow) geometry

### DIFF
--- a/src/Layers/xrRender/FVisual.cpp
+++ b/src/Layers/xrRender/FVisual.cpp
@@ -81,7 +81,7 @@ void Fvisual::Load(const char* N, IReader* data, u32 dwFlags)
             ID = def().r_u32();
             m_fast->iBase = def().r_u32();
             m_fast->iCount = def().r_u32();
-            m_fast->dwPrimitives = iCount / 3;
+            m_fast->dwPrimitives = m_fast->iCount / 3;
 
             VERIFY(nullptr == m_fast->p_rm_Indices);
             m_fast->p_rm_Indices = RImplementation.getIB(ID, true);


### PR DESCRIPTION
This issue was the cause of bug with fake static shadows on some custom maps. Since the level compiler optimizes shadow geometry and may remove some invalid triangles, the game still required the same number of triangles as normal geometry.