### PR TITLE
fix: Data race in `TaskManager::RegisterThisThreadAsWorker`

### DIFF
--- a/src/xrCore/Threading/TaskManager.cpp
+++ b/src/xrCore/Threading/TaskManager.cpp
@@ -197,10 +197,11 @@ TaskManager::~TaskManager()
 void TaskManager::RegisterThisThreadAsWorker()
 {
     ZoneScoped;
+    std::lock_guard guard{ workersLock };
+
     R_ASSERT2(workers.size() < std::thread::hardware_concurrency(),
         "You must change OTHER_THREADS_COUNT if you want to register more custom threads.");
 
-    std::lock_guard guard{ workersLock };
     s_tl_worker.id = workers.size();
     workers.emplace_back(&s_tl_worker);
 }


### PR DESCRIPTION
There is a data race on the `workers` vector because it's size is read inside the assertion before acquiring the `workersLock` mutex.

To be fair the actual impact of this is probably very minimal but doesn't hurt to be correct.

<details>
  <summary>TSAN report</summary>
  
  ```
WARNING: ThreadSanitizer: data race (pid=74154)
  Write of size 8 at 0x7f0c144b0098 by thread T2 (mutexes: write M0):
    #0 TaskWorker*& std::vector<TaskWorker*, xalloc<TaskWorker*> >::emplace_back<TaskWorker*>(TaskWorker*&&) /usr/include/c++/15.2.1/bits/vector.tcc:119 (xrCore.so+0xbdfab) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #1 TaskManager::RegisterThisThreadAsWorker() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:205 (xrCore.so+0xbbd3c) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #2 TaskManager::TaskWorkerStart() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:236 (xrCore.so+0xbc26c) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #3 void std::__invoke_impl<void, void (TaskManager::*)(), TaskManager*>(std::__invoke_memfun_deref, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:76 (xrCore.so+0xbcb81) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #4 std::__invoke_result<void (TaskManager::*)(), TaskManager*>::type std::__invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:98 (xrCore.so+0xbcb81)
    #5 std::invoke_result<void (TaskManager::*)(), TaskManager*>::type std::invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/functional:122 (xrCore.so+0xbcb81)
    #6 Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}::operator()(void (TaskManager::*&&)(), TaskManager*&&) const /mnt/data/dev/xray-16/src/xrCore/Threading/ThreadUtil.h:45 (xrCore.so+0xbcb81)
    #7 void std::__invoke_impl<void, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*>(std::__invoke_other, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&&&)(), TaskManager*&&)#1}, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:63 (xrCore.so+0xbe750) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #8 _ZSt8__invokeIZN9Threading9RunThreadIM11TaskManagerFvvEJPS2_EEESt6threadPKcOT_DpOT0_EUlOS4_OS5_E_JS4_S5_EENSt15__invoke_resultIS9_JDpSB_EE4typeESA_SD_ /usr/include/c++/15.2.1/bits/invoke.h:98 (xrCore.so+0xbe750)
    #9 void std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/include/c++/15.2.1/bits/std_thread.h:303 (xrCore.so+0xbe750)
    #10 std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::operator()() /usr/include/c++/15.2.1/bits/std_thread.h:310 (xrCore.so+0xbe750)
    #11 std::thread::_State_impl<std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> > >::_M_run() /usr/include/c++/15.2.1/bits/std_thread.h:255 (xrCore.so+0xbe78c) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #12 execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104 (libstdc++.so.6+0x1002f3) (BuildId: 95ad6d3df4b05831be9c386f9ad67480fd8d4431)

  Previous read of size 8 at 0x7f0c144b0098 by thread T3:
    #0 std::vector<TaskWorker*, xalloc<TaskWorker*> >::size() const /usr/include/c++/15.2.1/bits/stl_vector.h:1119 (xrCore.so+0xbbc03) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #1 TaskManager::RegisterThisThreadAsWorker() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:200 (xrCore.so+0xbbc03)
    #2 TaskManager::TaskWorkerStart() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:236 (xrCore.so+0xbc26c) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #3 void std::__invoke_impl<void, void (TaskManager::*)(), TaskManager*>(std::__invoke_memfun_deref, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:76 (xrCore.so+0xbcb81) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #4 std::__invoke_result<void (TaskManager::*)(), TaskManager*>::type std::__invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:98 (xrCore.so+0xbcb81)
    #5 std::invoke_result<void (TaskManager::*)(), TaskManager*>::type std::invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/functional:122 (xrCore.so+0xbcb81)
    #6 Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}::operator()(void (TaskManager::*&&)(), TaskManager*&&) const /mnt/data/dev/xray-16/src/xrCore/Threading/ThreadUtil.h:45 (xrCore.so+0xbcb81)
    #7 void std::__invoke_impl<void, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*>(std::__invoke_other, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&&&)(), TaskManager*&&)#1}, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:63 (xrCore.so+0xbe750) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #8 _ZSt8__invokeIZN9Threading9RunThreadIM11TaskManagerFvvEJPS2_EEESt6threadPKcOT_DpOT0_EUlOS4_OS5_E_JS4_S5_EENSt15__invoke_resultIS9_JDpSB_EE4typeESA_SD_ /usr/include/c++/15.2.1/bits/invoke.h:98 (xrCore.so+0xbe750)
    #9 void std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/include/c++/15.2.1/bits/std_thread.h:303 (xrCore.so+0xbe750)
    #10 std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::operator()() /usr/include/c++/15.2.1/bits/std_thread.h:310 (xrCore.so+0xbe750)
    #11 std::thread::_State_impl<std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> > >::_M_run() /usr/include/c++/15.2.1/bits/std_thread.h:255 (xrCore.so+0xbe78c) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #12 execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104 (libstdc++.so.6+0x1002f3) (BuildId: 95ad6d3df4b05831be9c386f9ad67480fd8d4431)

  Location is global '<null>' at 0x000000000000 ([anon:mimalloc]+0x4b0098)

  Mutex M0 (0x7f0c144b00c0) created at:
    #0 pthread_mutex_lock /usr/src/debug/gcc/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:1371 (libtsan.so.2+0x5fb2a) (BuildId: 7164436963fbf189c0875193cceaff13711b01c6)
    #1 __gthread_mutex_lock(pthread_mutex_t*) /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:795 (xrEngine.so+0x1aa90c) (BuildId: e35dcc8684c39a7750e1c2be301223632a9b8a43)
    #2 std::mutex::lock() /usr/include/c++/15.2.1/bits/std_mutex.h:115 (xrEngine.so+0x1aa90c)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/15.2.1/bits/std_mutex.h:252 (xrCore.so+0xbbc32) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #4 TaskManager::RegisterThisThreadAsWorker() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:203 (xrCore.so+0xbbc32)
    #5 TaskManager::TaskManager() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:151 (xrCore.so+0xbbe76) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #6 TaskManager* xr_new<TaskManager>() /mnt/data/dev/xray-16/src/xrCore/xrMemory.h:135 (xrCore.so+0xa53df) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #7 std::unique_ptr<TaskManager, xr_custom_deleter<TaskManager> > xr_make_unique<TaskManager>() /mnt/data/dev/xray-16/src/xrCommon/xr_smart_pointers.h:25 (xrCore.so+0xa4a56) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #8 xrCore::Initialize(char const*, char const*, bool, char const*, bool) /mnt/data/dev/xray-16/src/xrCore/xrCore.cpp:277 (xrCore.so+0xa4a56)
    #9 CApplication::CApplication(char const*, GameModule*, std::array<RendererModule*, 2ul> const&) /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:256 (xrEngine.so+0x1ae3fc) (BuildId: e35dcc8684c39a7750e1c2be301223632a9b8a43)
    #10 entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:51 (xr_3da+0x23c1) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)
    #11 main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109 (xr_3da+0x257e) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)

  Thread T2 'Task Worker' (tid=74157, running) created by main thread at:
    #0 pthread_create /usr/src/debug/gcc/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5f2b5) (BuildId: 7164436963fbf189c0875193cceaff13711b01c6)
    #1 __gthread_create(unsigned long*, void* (*)(void*), void*) /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:709 (libstdc++.so.6+0x1003b9) (BuildId: 95ad6d3df4b05831be9c386f9ad67480fd8d4431)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:172 (libstdc++.so.6+0x1003b9)
    #3 std::thread Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&) /mnt/data/dev/xray-16/src/xrCore/Threading/ThreadUtil.h:39 (xrCore.so+0xbd1a0) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #4 TaskManager::SpawnThreads() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:163 (xrCore.so+0xbbf55) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #5 xrCore::Initialize(char const*, char const*, bool, char const*, bool) /mnt/data/dev/xray-16/src/xrCore/xrCore.cpp:278 (xrCore.so+0xa4aa3) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #6 CApplication::CApplication(char const*, GameModule*, std::array<RendererModule*, 2ul> const&) /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:256 (xrEngine.so+0x1ae3fc) (BuildId: e35dcc8684c39a7750e1c2be301223632a9b8a43)
    #7 entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:51 (xr_3da+0x23c1) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)
    #8 main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109 (xr_3da+0x257e) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)

  Thread T3 'Task Worker' (tid=74158, running) created by main thread at:
    #0 pthread_create /usr/src/debug/gcc/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5f2b5) (BuildId: 7164436963fbf189c0875193cceaff13711b01c6)
    #1 __gthread_create(unsigned long*, void* (*)(void*), void*) /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:709 (libstdc++.so.6+0x1003b9) (BuildId: 95ad6d3df4b05831be9c386f9ad67480fd8d4431)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:172 (libstdc++.so.6+0x1003b9)
    #3 std::thread Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&) /mnt/data/dev/xray-16/src/xrCore/Threading/ThreadUtil.h:39 (xrCore.so+0xbd1a0) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #4 TaskManager::SpawnThreads() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:163 (xrCore.so+0xbbf55) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #5 xrCore::Initialize(char const*, char const*, bool, char const*, bool) /mnt/data/dev/xray-16/src/xrCore/xrCore.cpp:278 (xrCore.so+0xa4aa3) (BuildId: d4ac64682ef2281ace7637dac75701dc7f2a68c4)
    #6 CApplication::CApplication(char const*, GameModule*, std::array<RendererModule*, 2ul> const&) /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:256 (xrEngine.so+0x1ae3fc) (BuildId: e35dcc8684c39a7750e1c2be301223632a9b8a43)
    #7 entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:51 (xr_3da+0x23c1) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)
    #8 main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109 (xr_3da+0x257e) (BuildId: d98fef0da1a5037393edf6203b792b2f9a77f3f9)

SUMMARY: ThreadSanitizer: data race /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:205 in TaskManager::RegisterThisThreadAsWorker()
  ```
  
</details>