### PR TITLE
Fix multithreaded translation loading

### DIFF
--- a/src/xrCore/XML/XMLDocument.cpp
+++ b/src/xrCore/XML/XMLDocument.cpp
@@ -217,11 +217,33 @@ XML_NODE XMLDocument::NavigateToNode(CONST_XML_NODE start_node, pcstr path, cons
     buf_str[0] = 0;
     xr_strcpy(buf_str, path);
 
-    const char seps[] = ":";
     size_t tmp = 0;
 
-    //разбить путь на отдельные подпути
-    char* token = strtok(buf_str, seps);
+    char* cursor = buf_str;
+
+    // Thread-safe tokenization over ':'
+    auto next_token = [](char*& cur) -> char*
+    {
+        if (!cur || *cur == '\0')
+            return nullptr;
+
+        char* start = cur;
+        char* sep = strchr(cur, ':');
+        if (sep)
+        {
+            *sep = '\0';
+            cur = sep + 1;
+        }
+        else
+        {
+            cur = nullptr;
+        }
+
+        return start;
+    };
+
+    // разбить путь на отдельные подпути
+    char* token = next_token(cursor);
 
     if (token != nullptr)
     {
@@ -234,7 +256,7 @@ XML_NODE XMLDocument::NavigateToNode(CONST_XML_NODE start_node, pcstr path, cons
     while (token)
     {
         // Get next token:
-        token = strtok(nullptr, seps);
+        token = next_token(cursor);
 
         if (token != nullptr)
             if (node)

--- a/src/xrEngine/StringTable/StringTable.cpp
+++ b/src/xrEngine/StringTable/StringTable.cpp
@@ -59,17 +59,14 @@ void CStringTable::Init()
     xr_sprintf(files_mask, "text" DELIMITER "%s" DELIMITER "*.xml", pData->m_sLanguage.c_str());
     FS.file_list(fset, "$game_config$", FS_ListFiles, files_mask);
 
-    auto fit = fset.begin();
-    auto fit_e = fset.end();
-
-    for (; fit != fit_e; ++fit)
+    xr_parallel_for_each(fset, [this](const FS_File& it)
     {
         string_path fn, ext;
-        _splitpath(fit->name.c_str(), nullptr, nullptr, fn, ext);
+        _splitpath(it.name.c_str(), nullptr, nullptr, fn, ext);
         xr_strcat(fn, ext);
 
         Load(fn);
-    }
+    });
 
     if (!translate("st_currency", pData->m_sCurrency) &&
         !translate("ui_st_money_descr", pData->m_sCurrency) && // OGSR
@@ -238,7 +235,7 @@ void CStringTable::Load(LPCSTR xml_file_full)
         [[maybe_unused]] bool duplicate{};
         const STRING_VALUE str_val = ParseLine(string_text); // NOLINT
         {
-            //std::lock_guard guard{ pDataMutex };
+            std::lock_guard guard{ pDataMutex };
 #ifndef MASTER_GOLD
             duplicate = pData->m_StringTable.find(string_name) != pData->m_StringTable.end();
 #endif


### PR DESCRIPTION
The problem was that we used the thread-unsafe function `strtok`.

To quote [CppReference](https://en.cppreference.com/w/c/string/byte/strtok):
> "Each call to strtok modifies a static variable: is not thread safe."

Interestingly this only manifested on Linux because on Windows `strtok`
is actually thread-safe.

Fixes #1836