### PR TITLE
fix: use-after-free in `CStateMonsterAttackOnRun::update_aim_side`

### DIFF
--- a/src/xrGame/ai/monsters/states/monster_state_attack_on_run.h
+++ b/src/xrGame/ai/monsters/states/monster_state_attack_on_run.h
@@ -17,7 +17,7 @@ public:
     virtual void execute();
     virtual void finalize();
     virtual void critical_finalize();
-    virtual void remove_links(IGameObject* object) { inherited::remove_links(object); }
+    virtual void remove_links(IGameObject* object);
     virtual bool check_completion();
     virtual bool check_start_conditions();
 

--- a/src/xrGame/ai/monsters/states/monster_state_attack_on_run_inline.h
+++ b/src/xrGame/ai/monsters/states/monster_state_attack_on_run_inline.h
@@ -54,6 +54,7 @@ void ATTACK_ON_RUN_STATE::initialize()
     m_is_jumping = this->object->is_jumping();
     m_reach_old_target = false;
     m_attack_side_chosen_time = 0;
+    m_enemy_to_attack = nullptr;
 
     choose_next_atack_animation();
 }
@@ -178,6 +179,9 @@ TEMPLATE_SIGNATURE
 void ATTACK_ON_RUN_STATE::update_aim_side()
 {
     CEntityAlive const* const enemy = m_attacking ? m_enemy_to_attack : this->object->EnemyMan.get_enemy();
+
+    if (!enemy)
+        return;
 
     Fvector const self_dir = this->object->Direction();
     Fvector const self_to_enemy = enemy->Position() - this->object->Position();
@@ -619,6 +623,15 @@ bool ATTACK_ON_RUN_STATE::check_completion()
     // if (!object->control().path_builder().is_moving_on_path() ||
     //	(object->m_time_last_attack_success != 0)) return true;
     return false;
+}
+
+TEMPLATE_SIGNATURE
+void ATTACK_ON_RUN_STATE::remove_links(IGameObject* object)
+{
+    inherited::remove_links(object);
+
+    if (m_enemy_to_attack == object)
+        m_enemy_to_attack = nullptr;
 }
 
 #undef DEBUG_STATE


### PR DESCRIPTION
It appears that the `CStateMonsterAttackOnRun` state does not properly cleanup it's `m_enemy_to_attack` pointer which leads to a use-after-free. Also made sure that we don't dereference a null pointer in `update_aim_side`

<details>
  <summary>ASAN report</summary>
  
```
AddressSanitizer: heap-use-after-free on address 0x7dba5e1f4080 at pc 0x7fba7772e471 bp 0x7ffc750e54e0 sp 0x7ffc750e54d0
READ of size 8 at 0x7dba5e1f4080 thread T0
    #0 0x7fba7772e470 in CStateMonsterAttackOnRun<CSnork>::update_aim_side() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/states/monster_state_attack_on_run_inline.h:183
    #1 0x7fba7773df5d in CStateMonsterAttackOnRun<CSnork>::execute() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/states/monster_state_attack_on_run_inline.h:544
    #2 0x7fba77735468 in CStateMonsterAttack<CSnork>::execute() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/states/monster_state_attack_inline.h:105
    #3 0x7fba776f7221 in CStateManagerSnork::execute() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/snork/snork_state_manager.cpp:89
    #4 0x7fba776fe50d in CMonsterStateManager<CSnork>::update() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/monster_state_manager_inline.h:37
    #5 0x7fba77151a73 in CBaseMonster::update_fsm() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/basemonster/base_monster_think.cpp:44
    #6 0x7fba7715128d in CBaseMonster::Think() /mnt/data/dev/xray-16/src/xrGame/ai/monsters/basemonster/base_monster_think.cpp:36
    #7 0x7fba74b7f84e in CCustomMonster::shedule_Update(unsigned int) /mnt/data/dev/xray-16/src/xrGame/CustomMonster.cpp:370
    #8 0x7fba770e52d6 in CBaseMonster::shedule_Update(unsigned int) /mnt/data/dev/xray-16/src/xrGame/ai/monsters/basemonster/base_monster.cpp:356
    #9 0x7fba654db3db in CSheduler::ProcessStep() /mnt/data/dev/xray-16/src/xrEngine/xrSheduler.cpp:371
    #10 0x7fba654dc47c in CSheduler::Update() /mnt/data/dev/xray-16/src/xrEngine/xrSheduler.cpp:467
    #11 0x7fba7518d3f8 in CGamePersistent::OnFrame() /mnt/data/dev/xray-16/src/xrGame/GamePersistent.cpp:616
    #12 0x7fba654fd08c in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #13 0x7fba654fd08c in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #14 0x7fba654ec3b7 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #15 0x7fba654eca4b in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #16 0x7fba654a1e0e in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #17 0x55e93d61b4d5 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #18 0x55e93d61b95b in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109
    #19 0x7fba62e27b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #20 0x7fba62e27c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #21 0x55e93d61b304 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x7304) (BuildId: 641967ad2a0d49a0875fb3a38754d6f887123692)

0x7dba5e1f4080 is located 0 bytes inside of 3952-byte region [0x7dba5e1f4080,0x7dba5e1f4ff0)
freed by thread T0 here:
    #0 0x7fba8b95103d in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x7fba6428aba5 in xrMemory::mem_free(void*) /mnt/data/dev/xray-16/src/xrCore/xrMemory.cpp:260
    #2 0x7fba89070b58 in void xr_free<void>(void*&) /mnt/data/dev/xray-16/src/xrCore/xrMemory.h:105
    #3 0x7fba65450f2b in xr_special_free<true, IGameObject>::operator()(IGameObject*&) /mnt/data/dev/xray-16/src/xrCore/xrMemory.h:117
    #4 0x7fba65451064 in void xr_delete<IGameObject>(IGameObject*&) /mnt/data/dev/xray-16/src/xrCore/xrMemory.h:143
    #5 0x7fba6544f12a in IGame_ObjectPool::destroy(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/IGame_ObjectPool.cpp:53
    #6 0x7fba65482d84 in CObjectList::Destroy(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:547
    #7 0x7fba65488b5a in CObjectList::Update(bool) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:342
    #8 0x7fba65402503 in IGame_Level::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/IGame_Level.cpp:196
    #9 0x7fba7572c1d4 in CLevel::OnFrame() /mnt/data/dev/xray-16/src/xrGame/Level.cpp:473
    #10 0x7fba654fd08c in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #11 0x7fba654fd08c in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #12 0x7fba654ec3b7 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #13 0x7fba654eca4b in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #14 0x7fba654a1e0e in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #15 0x55e93d61b4d5 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #16 0x55e93d61b95b in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109
    #17 0x7fba62e27b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)

previously allocated by thread T0 here:
    #0 0x7fba8b952345 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x7fba6428ab2d in xrMemory::mem_alloc(unsigned long) /mnt/data/dev/xray-16/src/xrCore/xrMemory.cpp:202
    #2 0x7fba6428ad2a in xr_malloc(unsigned long) /mnt/data/dev/xray-16/src/xrCore/xrMemory.cpp:365
    #3 0x7fba6298c6ce in luabind_allocator /mnt/data/dev/xray-16/src/xrScriptEngine/script_engine.cpp:79
    #4 0x7fba775a85dd in luabind::detail::call_allocator(void const*, unsigned long) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/memory.hpp:29
    #5 0x7fba775a85dd in CPsyDogPhantom* luabind::luabind_new<CPsyDogPhantom>() /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/memory.hpp:36
    #6 0x7fba775a9a18 in luabind::detail::construct_aux_helper<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::meta::type_list<>, luabind::meta::index_list<> >::operator()(luabind::adl::argument const&) const /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/constructor.hpp:37
    #7 0x7fba775a9ce7 in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> > >::call_struct<false, true, luabind::meta::index_list<0u> >::call(lua_State*, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >&, std::tuple<luabind::default_converter<luabind::adl::argument const&, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:244
    #8 0x7fba775aa4aa in int luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> > >::call_fun<std::tuple<luabind::default_converter<luabind::adl::argument const&, void> > >(lua_State*, luabind::detail::invoke_context&, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >&, int, std::tuple<luabind::default_converter<luabind::adl::argument const&, void> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:317
    #9 0x7fba775aa4aa in luabind::detail::invoke_struct<luabind::meta::type_list<>, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> > >::invoke(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:374
    #10 0x7fba775aa55a in int luabind::detail::invoke<luabind::meta::type_list<>, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> > >(lua_State*, luabind::detail::function_object const&, luabind::detail::invoke_context&, luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:392
    #11 0x7fba775aa55a in luabind::detail::function_object_impl<luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::meta::type_list<> >::invoke_defer(lua_State*, luabind::detail::function_object_impl<luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::meta::type_list<> >*, luabind::detail::invoke_context&, int&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:51
    #12 0x7fba775aa721 in luabind::detail::function_object_impl<luabind::detail::construct<CPsyDogPhantom, std::unique_ptr<CPsyDogPhantom, luabind::luabind_deleter<CPsyDogPhantom> >, luabind::meta::type_list<void, luabind::adl::argument const&> >, luabind::meta::type_list<void, luabind::adl::argument const&>, luabind::meta::type_list<> >::entry_point(lua_State*) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:73
    #13 0x7fba8b76ba14 in lj_BC_FUNCC /mnt/data/dev/xray-16/bin/buildvm_x86.dasc:849

SUMMARY: AddressSanitizer: heap-use-after-free /mnt/data/dev/xray-16/src/xrGame/ai/monsters/states/monster_state_attack_on_run_inline.h:183 in CStateMonsterAttackOnRun<CSnork>::update_aim_side()
Shadow bytes around the buggy address:
  0x7dba5e1f3e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7dba5e1f3e80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7dba5e1f3f00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7dba5e1f3f80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7dba5e1f4000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x7dba5e1f4080:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7dba5e1f4100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7dba5e1f4180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7dba5e1f4200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7dba5e1f4280: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7dba5e1f4300: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1090841==ABORTING
```

</details>