### PR TITLE
fix: undefined behavior in `pvCompress`

### DIFF
--- a/src/xrCore/_compressed_normal.cpp
+++ b/src/xrCore/_compressed_normal.cpp
@@ -44,7 +44,7 @@ void pvInitializeStatics(void)
 
 u16 pvCompress(const Fvector& vec)
 {
-    if (vec.x == 0.f && vec.y == 0.f && vec.z == 0.f)
+    if (fis_zero(vec.x) && fis_zero(vec.y) && fis_zero(vec.z))
         return 0;
 
     // save copy

--- a/src/xrCore/_compressed_normal.cpp
+++ b/src/xrCore/_compressed_normal.cpp
@@ -44,6 +44,9 @@ void pvInitializeStatics(void)
 
 u16 pvCompress(const Fvector& vec)
 {
+    if (vec.x == 0.f && vec.y == 0.f && vec.z == 0.f)
+        return 0;
+
     // save copy
     Fvector tmp = vec;
 


### PR DESCRIPTION
1. Standing in a radioactive zone creates a hit with the direction (0, 0, 0) [code](https://github.com/OpenXRay/xray-16/blob/9f0475db683956d7e14432aa36c608c21459cb7f/src/xrGame/RadioactiveZone.cpp#L35-L49)
2. The direction value then get compressed for the `NET_Packet`
3. `float w = 126.0f / (dir.x + dir.y + dir.z);` since in that case all the values are 0, we get a divide by zero (which usually results in -nan) [code](https://github.com/OpenXRay/xray-16/blob/9f0475db683956d7e14432aa36c608c21459cb7f/src/xrCore/_compressed_normal.cpp#L77)
4. `w` is then used to calculate the `xbits` and `ybits` which are now screwed.

As a fix we simply check for that special case and return 0 in that case.

<details>
  <summary>UBSAN report</summary>
  
  ```
/mnt/data/dev/xray-16/src/xrCore/_compressed_normal.cpp:100:20: runtime error: left shift of negative value -2147483648
    #0 0x7f6728874d96 in pvCompress(_vector3<float> const&) /mnt/data/dev/xray-16/src/xrCore/_compressed_normal.cpp:100
    #1 0x7f6728846884 in NET_Packet::w_dir(_vector3<float> const&) /mnt/data/dev/xray-16/src/xrCore/NET_utils.cpp:37
    #2 0x7f6739aff196 in SHit::Write_Packet_Cont(NET_Packet&) /mnt/data/dev/xray-16/src/xrGame/Hit.cpp:108
    #3 0x7f6739aff5ea in SHit::Write_Packet(NET_Packet&) /mnt/data/dev/xray-16/src/xrGame/Hit.cpp:133
    #4 0x7f67391ee5c4 in CCustomZone::CreateHit(unsigned short, unsigned short, _vector3<float> const&, float, short, _vector3<float> const&, float, ALife::EHitType) /mnt/data/dev/xray-16/src/xrGame/CustomZone.cpp:1500
    #5 0x7f673a4421fa in CRadioactiveZone::Affect(SZoneObjectInfo*) /mnt/data/dev/xray-16/src/xrGame/RadioactiveZone.cpp:49
    #6 0x7f67391f5919 in CCustomZone::AffectObjects() /mnt/data/dev/xray-16/src/xrGame/CustomZone.cpp:1160
    #7 0x7f67391fdd2e in CCustomZone::UpdateBlowout() /mnt/data/dev/xray-16/src/xrGame/CustomZone.cpp:1183
    #8 0x7f673a43a956 in CRadioactiveZone::BlowoutState() /mnt/data/dev/xray-16/src/xrGame/RadioactiveZone.cpp:18
    #9 0x7f67391fc7e1 in CCustomZone::UpdateWorkload(unsigned int) /mnt/data/dev/xray-16/src/xrGame/CustomZone.cpp:555
    #10 0x7f673a44396b in CRadioactiveZone::UpdateWorkload(unsigned int) /mnt/data/dev/xray-16/src/xrGame/RadioactiveZone.cpp:128
    #11 0x7f67391eb204 in CCustomZone::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/CustomZone.cpp:588
    #12 0x7f6729a7d4a6 in CObjectList::SingleUpdate(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:144
    #13 0x7f6729a874f8 in CObjectList::Update(bool) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:287
    #14 0x7f6729a02503 in IGame_Level::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/IGame_Level.cpp:196
    #15 0x7f6739d2cf34 in CLevel::OnFrame() /mnt/data/dev/xray-16/src/xrGame/Level.cpp:473
    #16 0x7f6729afd08c in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #17 0x7f6729afd08c in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #18 0x7f6729aec3b7 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #19 0x7f6729aeca4b in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #20 0x7f6729aa1e0e in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #21 0x56027d06a4d5 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #22 0x56027d06a95b in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109
    #23 0x7f6727427b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #24 0x7f6727427c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #25 0x56027d06a304 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x7304) (BuildId: 641967ad2a0d49a0875fb3a38754d6f887123692)
```
  
</details>