### PR TITLE
fix: Off by 1 buffer overflow in `commandLine` allocation

### DIFF
--- a/src/xr_3da/entry_point.cpp
+++ b/src/xr_3da/entry_point.cpp
@@ -88,9 +88,9 @@ int main(int argc, char *argv[])
         int i;
         if(argc > 1)
         {
-            size_t sum = 0;
+            size_t sum = 1;
             for(i = 1; i < argc; ++i)
-                sum += strlen(argv[i]) + strlen(" \0");
+                sum += strlen(argv[i]) + 1;
 
             commandLine = (char*)xr_malloc(sum);
             ZeroMemory(commandLine, sum);


### PR DESCRIPTION
The logic was off by one because it didn't account for the final null terminator.

As an example if we run with "-cs" the we get:
`strlen("-cs")` is 3
`strlen(" \0")` is always 1
so we allocate 4 bytes but then copy "-cs" which is 3 bytes and a space followed by a null terminator which is 2 bytes. 

I also took the liberty of replacing the strange `strlen(" \0")` with just 1 as they are equivalent.

<details>
  <summary>ASAN report</summary>
  
```
AddressSanitizer: heap-buffer-overflow on address 0x7b3909fe0374 at pc 0x7f1937f4f6c7 bp 0x7ffdf5f08890 sp 0x7ffdf5f08038
WRITE of size 2 at 0x7b3909fe0374 thread T0
    #0 0x7f1937f4f6c6 in memcpy /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x5563ae16389e in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:101
    #2 0x7f190f627b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #3 0x7f190f627c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #4 0x5563ae163304 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x7304) (BuildId: 641967ad2a0d49a0875fb3a38754d6f887123692)

0x7b3909fe0374 is located 0 bytes after 4-byte region [0x7b3909fe0370,0x7b3909fe0374)
allocated by thread T0 here:
    #0 0x7f1937f52345 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x7f1910a8ac4b in xrMemory::mem_alloc(unsigned long) /mnt/data/dev/xray-16/src/xrCore/xrMemory.cpp:202
    #2 0x7f1910a8ae48 in xr_malloc(unsigned long) /mnt/data/dev/xray-16/src/xrCore/xrMemory.cpp:365
    #3 0x5563ae163778 in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:95
    #4 0x7f190f627b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #5 0x7ffdf5f0a4fd  ([stack]+0x204fd)
    #6 0x34365f3638782f6d  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:101 in main
Shadow bytes around the buggy address:
  0x7b3909fe0080: fa fa 00 00 fa fa 00 07 fa fa 00 fa fa fa 00 02
  0x7b3909fe0100: fa fa 00 04 fa fa 00 07 fa fa 00 06 fa fa 00 07
  0x7b3909fe0180: fa fa 00 05 fa fa 00 00 fa fa 00 03 fa fa 00 07
  0x7b3909fe0200: fa fa 00 03 fa fa 00 fa fa fa 00 03 fa fa 00 03
  0x7b3909fe0280: fa fa 00 00 fa fa 00 07 fa fa 00 02 fa fa 00 00
=>0x7b3909fe0300: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa[04]fa
  0x7b3909fe0380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7b3909fe0400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7b3909fe0480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7b3909fe0500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7b3909fe0580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```
</details>