### PR TITLE
fix: dynamic stack buffer overflow in `stalker_movement_manager_smart_cover::build_exit_path_to_cover`

### DIFF
--- a/src/xrGame/stalker_movement_manager_smart_cover_loopholes.cpp
+++ b/src/xrGame/stalker_movement_manager_smart_cover_loopholes.cpp
@@ -356,7 +356,7 @@ void stalker_movement_manager_smart_cover::build_exit_path_to_cover()
         smart_cover::transitions::action const& current_action = nearest_action(current_cover, exitable_loophole_id,
             smart_cover::transform_vertex("", false), target_position, exit_position, exit_vertex_id, &exit_body_state);
 
-        buffer_vector<shared_str> temp(xr_alloca(sizeof(u32) * m_temp_loophole_path.size()), m_temp_loophole_path.size(),
+        buffer_vector<shared_str> temp(xr_alloca(sizeof(shared_str) * m_temp_loophole_path.size()), m_temp_loophole_path.size(),
             m_temp_loophole_path.begin(), m_temp_loophole_path.end());
         new_value += enter_path(0, exit_position, exit_vertex_id, target_cover,
             (target_loophole.enterable() ? target_loophole : nearest_enterable_loophole()).id());


### PR DESCRIPTION
This code worked properly for 32-bit builds since `shared_str` just holds a pointer. But for 64-bit builds this allocates too little memory on the stack causing a dynamic-stack-buffer-overflow.

<details>
  <summary>ASAN report</summary>
  
```
AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7fffffff91a0 at pc 0x7ffff531bf99 bp 0x7fffffff9060 sp 0x7fffffff9050
WRITE of size 8 at 0x7fffffff91a0 thread T0
    #0 0x7ffff531bf98 in shared_str::shared_str(shared_str const&) /mnt/data/dev/xray-16/src/xrCore/xrstring.h:109
    #1 0x7fffe2ad6c75 in buffer_vector<shared_str>::construct(shared_str*, shared_str const&) /mnt/data/dev/xray-16/src/xrCore/buffer_vector_inline.h:326
    #2 0x7fffe2ad6c75 in void buffer_vector<shared_str>::assign<__gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > > >(__gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > >, __gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > > const&) /mnt/data/dev/xray-16/src/xrCore/buffer_vector_inline.h:64
    #3 0x7fffe2ad6e2c in buffer_vector<shared_str>::buffer_vector<__gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > > >(void*, unsigned long const&, __gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > > const&, __gnu_cxx::__normal_iterator<shared_str*, std::vector<shared_str, xalloc<shared_str> > > const&) /mnt/data/dev/xray-16/src/xrCore/buffer_vector_inline.h:42
    #4 0x7fffe2acf8a4 in stalker_movement_manager_smart_cover::build_exit_path_to_cover() /mnt/data/dev/xray-16/src/xrGame/stalker_movement_manager_smart_cover_loopholes.cpp:360
    #5 0x7fffe2ad0925 in stalker_movement_manager_smart_cover::actualize_path() /mnt/data/dev/xray-16/src/xrGame/stalker_movement_manager_smart_cover_loopholes.cpp:407
    #6 0x7fffe2ad129a in stalker_movement_manager_smart_cover::try_actualize_path() /mnt/data/dev/xray-16/src/xrGame/stalker_movement_manager_smart_cover_loopholes.cpp:449
    #7 0x7fffe2ab30e8 in stalker_movement_manager_smart_cover::current_transition() /mnt/data/dev/xray-16/src/xrGame/stalker_movement_manager_smart_cover.cpp:430
    #8 0x7fffe27eab99 in smart_cover::evaluators::can_exit_loophole_with_animation::evaluate() /mnt/data/dev/xray-16/src/xrGame/smart_cover_evaluators.cpp:200
    #9 0x7fffe039091c in CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::evaluate_condition(__gnu_cxx::__normal_iterator<COperatorConditionAbstract<unsigned int, bool> const*, std::vector<COperatorConditionAbstract<unsigned int, bool>, xalloc<COperatorConditionAbstract<unsigned int, bool> > > >&, __gnu_cxx::__normal_iterator<COperatorConditionAbstract<unsigned int, bool> const*, std::vector<COperatorConditionAbstract<unsigned int, bool>, xalloc<COperatorConditionAbstract<unsigned int, bool> > > >&, unsigned int const&) const /mnt/data/dev/xray-16/src/xrAICore/Components/problem_solver_inline.h:192
    #10 0x7fffe0392994 in bool COperatorAbstract<COperatorConditionAbstract<unsigned int, bool>, unsigned short>::applicable<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*> const>(CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*> const&) const /mnt/data/dev/xray-16/src/xrAICore/Components/operator_abstract_inline.h:260
    #11 0x7fffe0394607 in CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::value(CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, __gnu_cxx::__normal_iterator<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator const*, std::vector<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator, xalloc<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator> > >&, bool) const /mnt/data/dev/xray-16/src/xrAICore/Components/problem_solver_inline.h:225
    #12 0x7fffe0394946 in CPathManager<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>, PriorityQueueConstructor<CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> >, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > >, CDataStorageBinaryHeap::CDataStorage<CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > > > >, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>, unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>::get_value(__gnu_cxx::__normal_iterator<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator const*, std::vector<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator, xalloc<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::SOperator> > >&, bool) const /mnt/data/dev/xray-16/src/xrAICore/Navigation/PathManagers/path_manager_solver_inline.h:45
    #13 0x7fffe039503a in bool CAStar<unsigned short, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, true, CEdgePath<unsigned int, true>, unsigned int, EmptyVertexData>::step<CPathManager<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>, PriorityQueueConstructor<CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> >, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > >, CDataStorageBinaryHeap::CDataStorage<CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > > > >, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>, unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int> >(CPathManager<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>, PriorityQueueConstructor<CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> >, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > >, CDataStorageBinaryHeap::CDataStorage<CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > > > >, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>, unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>&) /mnt/data/dev/xray-16/src/xrAICore/Navigation/a_star_inline.h:71
    #14 0x7fffe0395530 in bool CAStar<unsigned short, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, true, CEdgePath<unsigned int, true>, unsigned int, EmptyVertexData>::find<CPathManager<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>, PriorityQueueConstructor<CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> >, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > >, CDataStorageBinaryHeap::CDataStorage<CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > > > >, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>, unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int> >(CPathManager<CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>, PriorityQueueConstructor<CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> >, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > >, CDataStorageBinaryHeap::CDataStorage<CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>::CDataStorage<CEdgePath<unsigned int, true>, CVertexAllocatorFixed<8192u>, CompoundVertex<DijkstraVertexData<unsigned short, AStarVertexData<unsigned short, EmptyVertexData> >, CDataStorageBinaryHeap, CVertexManagerHashFixed<unsigned int, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, 256u, 8192u>, CVertexAllocatorFixed<8192u>, CEdgePath<unsigned int, true> > > > >, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>, unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int>&) /mnt/data/dev/xray-16/src/xrAICore/Navigation/a_star_inline.h:187
    #15 0x7fffe03959c5 in bool CGraphEngine::search<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int> >(CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*> const&, CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, CConditionState<COperatorConditionAbstract<unsigned int, bool> > const&, std::vector<unsigned int, xalloc<unsigned int> >*, SBaseParameters<unsigned short, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, unsigned int> const&) /mnt/data/dev/xray-16/src/xrAICore/Navigation/graph_engine_inline.h:112
    #16 0x7fffe0395f11 in CProblemSolver<COperatorConditionAbstract<unsigned int, bool>, CConditionState<COperatorConditionAbstract<unsigned int, bool> >, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, unsigned int, false, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::solve() /mnt/data/dev/xray-16/src/xrAICore/Components/problem_solver_inline.h:370
    #17 0x7fffe03960f2 in CActionPlanner<CScriptGameObject, false, CActionBase<CScriptGameObject>, CPropertyEvaluator<CScriptGameObject>, CActionBase<CScriptGameObject>*, CPropertyEvaluator<CScriptGameObject>*>::update() /mnt/data/dev/xray-16/src/xrGame/action_planner_inline.h:54
    #18 0x7fffe276fff5 in smart_cover::animation_planner::update() /mnt/data/dev/xray-16/src/xrGame/smart_cover_animation_planner.cpp:59
    #19 0x7fffe277d135 in smart_cover::animation_selector::select_animation(bool&) /mnt/data/dev/xray-16/src/xrGame/smart_cover_animation_selector.cpp:89
    #20 0x7fffe295e2f0 in fastdelegate::FastDelegate<MotionID (bool&)>::operator()(bool&) const /mnt/data/dev/xray-16/src/xrCore/fastdelegate.h:766
    #21 0x7fffe295db41 in CStalkerAnimationManager::assign_global_animation(bool&) /mnt/data/dev/xray-16/src/xrGame/stalker_animation_global.cpp:70
    #22 0x7fffe298907c in CStalkerAnimationManager::play_global() /mnt/data/dev/xray-16/src/xrGame/stalker_animation_manager_update.cpp:147
    #23 0x7fffe29896b1 in CStalkerAnimationManager::update_impl() /mnt/data/dev/xray-16/src/xrGame/stalker_animation_manager_update.cpp:212
    #24 0x7fffe2989858 in CStalkerAnimationManager::update() /mnt/data/dev/xray-16/src/xrGame/stalker_animation_manager_update.cpp:227
    #25 0x7fffe3a03330 in CAI_Stalker::SelectAnimation(_vector3<float> const&, _vector3<float> const&, float) /mnt/data/dev/xray-16/src/xrGame/ai/stalker/ai_stalker.cpp:1131
    #26 0x7fffe0d5a817 in CCustomMonster::UpdatePositionAnimation() /mnt/data/dev/xray-16/src/xrGame/CustomMonster.cpp:580
    #27 0x7fffe0d69fa7 in CCustomMonster::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/CustomMonster.cpp:533
    #28 0x7fffe3a0cab1 in CAI_Stalker::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/ai/stalker/ai_stalker.cpp:862
    #29 0x7fffd165fdd0 in CObjectList::SingleUpdate(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:144
    #30 0x7fffd165fcab in CObjectList::SingleUpdate(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:138
    #31 0x7fffd1669e22 in CObjectList::Update(bool) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:287
    #32 0x7fffd15eb9c3 in IGame_Level::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/IGame_Level.cpp:196
    #33 0x7fffe191b094 in CLevel::OnFrame() /mnt/data/dev/xray-16/src/xrGame/Level.cpp:473
    #34 0x7fffd16df9ac in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #35 0x7fffd16df9ac in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #36 0x7fffd16cecd7 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #37 0x7fffd16cf36b in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #38 0x7fffd168472e in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #39 0x55555555b4d5 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #40 0x55555555b8ed in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:104
    #41 0x7fffcf027b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #42 0x7fffcf027c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #43 0x55555555b304 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x7304) (BuildId: a42307e2056b24dd7d40950015579916511720c5)

Address 0x7fffffff91a0 is located in stack of thread T0
SUMMARY: AddressSanitizer: dynamic-stack-buffer-overflow /mnt/data/dev/xray-16/src/xrCore/xrstring.h:109 in shared_str::shared_str(shared_str const&)
Shadow bytes around the buggy address:
  0x7fffffff8f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff8f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7fffffff9180: ca ca ca ca[04]cb cb cb cb cb cb cb 00 00 00 00
  0x7fffffff9200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffffff9400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```
</details>