### PR TITLE
fix: handling invalid boxes in `CHOM::visible`

### DIFF
--- a/src/Layers/xrRender/HOM.cpp
+++ b/src/Layers/xrRender/HOM.cpp
@@ -365,6 +365,8 @@ BOOL CHOM::visible(vis_data& vis) const
         return TRUE; // not at this time :)
     if (!bEnabled)
         return TRUE; // return - everything visible
+    if (!vis.box.is_valid() || !_valid(vis.box))
+        return TRUE; // invalid box
 
     ScopeStatTimer scopeStats(stats.Total, stats.TotalTimerLock);
 


### PR DESCRIPTION
Apparently CoC is doing some weird stuff with NaN's leading to undefined behavior.

<details>
  <summary>UBSAN report</summary>
  
```
/mnt/data/dev/xray-16/src/xrCore/_bitwise.h:97:38: runtime error: -nan is outside the range of representable values of type 'int'
    #0 0x7f16ca4a58d5 in iCeil(float) /mnt/data/dev/xray-16/src/xrCore/_bitwise.h:97
    #1 0x7f16ca7e5252 in xray::render::render_gl::occRasterizer::df_2_s32up(float) /mnt/data/dev/xray-16/src/Layers/xrRender/occRasterizer.h:43
    #2 0x7f16ca7e5252 in xray::render::render_gl::occRasterizer::test(float, float, float, float, float) /mnt/data/dev/xray-16/src/Layers/xrRender/occRasterizer.cpp:213
    #3 0x7f16ca76476b in xray::render::render_gl::_visible(Fbox3 const&, Fmatrix const&) /mnt/data/dev/xray-16/src/Layers/xrRender/HOM.cpp:343
    #4 0x7f16ca74ffea in xray::render::render_gl::CHOM::visible(vis_data&) const /mnt/data/dev/xray-16/src/Layers/xrRender/HOM.cpp:379
    #5 0x7f16ca8ee4ba in xray::render::render_gl::R_dsgraph_structure::build_subspace() /mnt/data/dev/xray-16/src/Layers/xrRender/r__dsgraph_build.cpp:888
    #6 0x7f16cab238b8 in xray::render::render_gl::render_main::calculate() /mnt/data/dev/xray-16/src/Layers/xrRender_R2/r2_R_calculate.cpp:56
    #7 0x7f16cab2891e in xray::render::render_gl::i_render_phase::run()::{lambda()#1}::operator()() const /mnt/data/dev/xray-16/src/Layers/xrRender_R2/r2.h:51
    #8 0x7f16cab28cf6 in Task::Dispatcher<xray::render::render_gl::i_render_phase::run()::{lambda()#1}, false, void>::Call(Task&) /mnt/data/dev/xray-16/src/xrCore/Threading/Task.hpp:94
    #9 0x7f16a56ae634 in Task::operator()() /mnt/data/dev/xray-16/src/xrCore/Threading/Task.hpp:200
    #10 0x7f16a56ac462 in TaskManager::ExecuteTask(Task&) /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:307
    #11 0x7f16a56acc95 in TaskManager::ExecuteOneTask() const /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:339
    #12 0x7f16a56adf7a in TaskManager::TaskWorkerStart() /mnt/data/dev/xray-16/src/xrCore/Threading/TaskManager.cpp:244
    #13 0x7f16a56b33a2 in void std::__invoke_impl<void, void (TaskManager::*)(), TaskManager*>(std::__invoke_memfun_deref, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:76
    #14 0x7f16a56b33ef in std::__invoke_result<void (TaskManager::*)(), TaskManager*>::type std::__invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:98
    #15 0x7f16a56b33ef in std::invoke_result<void (TaskManager::*)(), TaskManager*>::type std::invoke<void (TaskManager::*)(), TaskManager*>(void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/functional:122
    #16 0x7f16a56b33ef in Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}::operator()(void (TaskManager::*&&)(), TaskManager*&&) const /mnt/data/dev/xray-16/src/xrCore/Threading/ThreadUtil.h:45
    #17 0x7f16a56b34b4 in void std::__invoke_impl<void, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*>(std::__invoke_other, Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&&&)(), TaskManager*&&)#1}, void (TaskManager::*&&)(), TaskManager*&&) /usr/include/c++/15.2.1/bits/invoke.h:63
    #18 0x7f16a56b34b4 in _ZSt8__invokeIZN9Threading9RunThreadIM11TaskManagerFvvEJPS2_EEESt6threadPKcOT_DpOT0_EUlOS4_OS5_E_JS4_S5_EENSt15__invoke_resultIS9_JDpSB_EE4typeESA_SD_ /usr/include/c++/15.2.1/bits/invoke.h:98
    #19 0x7f16a56b34b4 in void std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/include/c++/15.2.1/bits/std_thread.h:303
    #20 0x7f16a56b34b4 in std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> >::operator()() /usr/include/c++/15.2.1/bits/std_thread.h:310
    #21 0x7f16a56b34b4 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<Threading::RunThread<void (TaskManager::*)(), TaskManager*>(char const*, void (TaskManager::*&&)(), TaskManager*&&)::{lambda(void (TaskManager::*&&)(), TaskManager*&&)#1}, void (TaskManager::*)(), TaskManager*> > >::_M_run() /usr/include/c++/15.2.1/bits/std_thread.h:255
    #22 0x7f16a4f002f3 in execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
    #23 0x7f16cca65ca1 in asan_thread_start /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_interceptors.cpp:239
    #24 0x7f16a42a80d5  (/usr/lib/libc.so.6+0xa80d5) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #25 0x7f16a433b01b  (/usr/lib/libc.so.6+0x13b01b) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
```
</details>