### PR TITLE
fix: compressing invalid direction vectors

### DIFF
--- a/src/xrCore/_compressed_normal.cpp
+++ b/src/xrCore/_compressed_normal.cpp
@@ -46,6 +46,8 @@ u16 pvCompress(const Fvector& vec)
 {
     if (fis_zero(vec.x) && fis_zero(vec.y) && fis_zero(vec.z))
         return 0;
+    if (!_valid(vec))
+        return 0;
 
     // save copy
     Fvector tmp = vec;


### PR DESCRIPTION
Similar to https://github.com/OpenXRay/xray-16/pull/1974 but apparently this time the direction to compress included NaN.

<details>
  <summary>UBSAN report</summary>
  
  ```
/mnt/data/dev/xray-16/src/xrCore/_compressed_normal.cpp:103:20: runtime error: left shift of negative value -2147483648
    #0 0x7f67e2874eaa in pvCompress(_vector3<float> const&) /mnt/data/dev/xray-16/src/xrCore/_compressed_normal.cpp:103
    #1 0x7f67e2846884 in NET_Packet::w_dir(_vector3<float> const&) /mnt/data/dev/xray-16/src/xrCore/NET_utils.cpp:37
    #2 0x7f67f3aed2f6 in SHit::Write_Packet_Cont(NET_Packet&) /mnt/data/dev/xray-16/src/xrGame/Hit.cpp:108
    #3 0x7f67f3aed74a in SHit::Write_Packet(NET_Packet&) /mnt/data/dev/xray-16/src/xrGame/Hit.cpp:133
    #4 0x7f67f3443b01 in CExplosive::ExplodeWaveProcessObject(collide::rq_results&, CPhysicsShellHolder*) /mnt/data/dev/xray-16/src/xrGame/Explosive.cpp:715
    #5 0x7f67f344a087 in CExplosive::ExplodeWaveProcess() /mnt/data/dev/xray-16/src/xrGame/Explosive.cpp:737
    #6 0x7f67f344a3e7 in CExplosive::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/Explosive.cpp:503
    #7 0x7f67f3a1b898 in CGrenade::UpdateCL() /mnt/data/dev/xray-16/src/xrGame/Grenade.cpp:272
    #8 0x7f67e3a5fdd0 in CObjectList::SingleUpdate(IGameObject*) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:144
    #9 0x7f67e3a69e22 in CObjectList::Update(bool) /mnt/data/dev/xray-16/src/xrEngine/xr_object_list.cpp:287
    #10 0x7f67e39eb9c3 in IGame_Level::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/IGame_Level.cpp:196
    #11 0x7f67f3d1b094 in CLevel::OnFrame() /mnt/data/dev/xray-16/src/xrGame/Level.cpp:473
    #12 0x7f67e3adf9ac in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #13 0x7f67e3adf9ac in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #14 0x7f67e3acecd7 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #15 0x7f67e3acf36b in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #16 0x7f67e3a8472e in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #17 0x565254d4c4d5 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #18 0x565254d4c8ed in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:104
    #19 0x7f67e1427b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #20 0x7f67e1427c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: 3fb5bf3586fec17ba65a16ec9a3132455897d306)
    #21 0x565254d4c304 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0x7304) (BuildId: a42307e2056b24dd7d40950015579916511720c5)
```
</details>