### PR TITLE
refactor: Use `R_ASSERT1_CURE` to validate vectors in `_compressed_normal.cpp`

### DIFF
--- a/src/xrCore/_compressed_normal.cpp
+++ b/src/xrCore/_compressed_normal.cpp
@@ -44,9 +44,9 @@ void pvInitializeStatics(void)
 
 u16 pvCompress(const Fvector& vec)
 {
+    R_ASSERT1_CURE(_valid(vec), return 0);
+
     if (fis_zero(vec.x) && fis_zero(vec.y) && fis_zero(vec.z))
-        return 0;
-    if (!_valid(vec))
         return 0;
 
     // save copy


### PR DESCRIPTION
As discussed in https://github.com/OpenXRay/xray-16/pull/1980