### PR TITLE
Fixup VSCode tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -103,10 +103,10 @@
       "options": [
         "Debug",
         "Release",
-        "MinSizeRel",
-        "RelWithDebInfo"
+        "Mixed",
+        "ReleaseMasterGold"
       ],
-      "default": "Debug"
+      "default": "ReleaseMasterGold"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -51,7 +51,7 @@
       "options": {
         "cwd": "${workspaceFolder}/bin"
       },
-      "command": "cmake --build . -j${CPU_COUNT}",
+      "command": "cmake --build . -j$(nproc --all)",
       "dependsOn": [
         "Configure"
       ]
@@ -101,10 +101,10 @@
       "options": [
         "Debug",
         "Release",
-        "MinSizeRel",
-        "RelWithDebInfo"
+        "Mixed",
+        "ReleaseMasterGold"
       ],
-      "default": "Debug"
+      "default": "ReleaseMasterGold"
     }
   ]
 }


### PR DESCRIPTION
This one replaces outdated build configurations in VSCode tasks. Also automatically fetches processor count for build. Works on Linux, and Windows CMake is not supported anyway.