### PR TITLE
Add Flatpak manifest and workflow (#1403)

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -241,3 +241,30 @@ jobs:
         shutdown_vm: false
         sync_files: false
         run: cmake --build build --config ${{ matrix.Configuration }} --parallel 4
+
+  flatpak:
+    name: Flatpak ${{ matrix.platform.arch }}
+    runs-on: ${{ matrix.platform.os }}
+
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: x86_64
+            os: ubuntu-latest
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@main
+
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: io.github.OpenXRay.xray-16-${{ matrix.platform.arch }}-${{ github.run_number }}.flatpak
+          manifest-path: misc/flatpak/manifest.yml
+          arch: ${{ matrix.platform.arch }}
+          verbose: true

--- a/misc/flatpak/manifest.yml
+++ b/misc/flatpak/manifest.yml
@@ -1,0 +1,26 @@
+id: io.github.OpenXRay.xray-16
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: xr_3da
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+
+modules:
+  - name: OpenXRay
+    buildsystem: cmake
+    sources:
+      - type: git
+        url: https://github.com/OpenXRay/xray-16.git
+        branch: dev
+    config-opts:
+      - -D CMAKE_BUILD_TYPE=ReleaseMasterGold
+      - -D CMAKE_UNITY_BUILD=ON
+
+#rename-icon: openxray_cop.png
+rename-desktop-file: openxray_cop.desktop


### PR DESCRIPTION
With this patch we can build x64 and arm64 Flatpaks of OpenXRay. I've tested it locally and after copying the original game files I am able to successfully launch CoP.

There are however a few problems I have not been able to solve:
- Unlike the desktop file renaming I couldn't get the icon renaming to work so there is not icon. 
- I might be wrong but I don't think Flatpak supports having multiple different desktop files in the same package so if you want to launch Clear Sky for example you have to do it manually via the command line `flatpak run io.github.OpenXRay.xray-16 -cs` and can't use the provides desktop file like in a "normal" install

I've also looked at what would be required to add OpenXRay to [flathub](https://flathub.org). But I don't think that would be possible at the moment. [Flathub submission requirements](https://docs.flathub.org/docs/for-app-authors/requirements)
1.
> The Flathub stable repository is dedicated to hosting only stable software. (...) Nightly releases, development snapshots, or any software requiring daily updates must not be published to either repo.

We currently provide only a nightly release.

2.
> Graphical applications must provide, preferably a SVG icon or at least a 256x256 PNG icon, properly [named and installed](https://docs.flatpak.org/en/latest/conventions.html#application-icons).

Apart from me not getting the icon properly installed the maximum resolution for icons we have is 64x64 and not 256x256.

However in the [docs](https://docs.flatpak.org/en/latest/hosting-a-repository.html) they mention that it's possible to host a custom Flatpak repository on GitHub and GitHub Pages directly which would obviously not have any of the restrictions Flathub has.