### PR TITLE
Mark rsqrt function as noexcept

### DIFF
--- a/src/utils/xrMiscMath/vector.cpp
+++ b/src/utils/xrMiscMath/vector.cpp
@@ -140,7 +140,7 @@ float angle_inertion_var(float src, float tgt, float min_speed, float max_speed,
 	return src;
 }
 
-double rsqrt(double v) { return 1.0 / _sqrt(v); }
+double rsqrt(double v) noexcept { return 1.0 / _sqrt(v); }
 
 //////////////////////////////////////////////////////////////////
 

--- a/src/xrCore/_vector3d.h
+++ b/src/xrCore/_vector3d.h
@@ -356,7 +356,7 @@ bool _valid(const _vector3<T>& v)
 //////////////////////////////////////////////////////////////////////////
 #pragma warning(push)
 #pragma warning(disable : 4244)
-double rsqrt(double v);
+double rsqrt(double v) noexcept;
 bool exact_normalize(float* a);
 bool exact_normalize(Fvector3& a);
 #pragma warning(pop)


### PR DESCRIPTION
Apparently `clang-21` will not compile unless we mark `rsqrt` as `noexcept`.

Since it just calls `_sqrt` which is already marked `noexcept` this should be fine.