### PR TITLE
Make MP configs optional in single-player

### DIFF
--- a/src/xrGame/UIGameCustom.cpp
+++ b/src/xrGame/UIGameCustom.cpp
@@ -431,7 +431,18 @@ void CMapListHelper::Load()
 {
     string_path cfgFileName;
     FS.update_path(cfgFileName, "$game_config$", "mp" DELIMITER "map_list.ltx");
+    if (!FS.exist(cfgFileName))
+    {
+        Log("~ Can't open MP map list:", cfgFileName);
+        return;
+    }
+
     CInifile maplistCfg(cfgFileName);
+    if (!maplistCfg.section_exist("weather"))
+    {
+        Log("~ MP map list has no [weather] section:", cfgFileName);
+        return;
+    }
     // read weathers set
     CInifile::Sect weatherCfg = maplistCfg.r_section("weather");
     m_weathers.reserve(weatherCfg.Data.size());
@@ -468,9 +479,10 @@ void CMapListHelper::Load()
         FS.unload_archive(arch);
     }
     levelsPath->_set_root(prevRoot.c_str());
-    // XXX nitrocaster: is that really fatal?
-    R_ASSERT2(m_storage.size() > 0, "unable to fill map list");
-    R_ASSERT2(m_weathers.size() > 0, "unable to fill weathers list");
+    if (m_storage.empty())
+        Log("! Unable to fill MP map list (no maps discovered).");
+    if (m_weathers.empty())
+        Log("! Unable to fill MP weather list (no weather presets discovered).");
 }
 
 const SGameTypeMaps& CMapListHelper::GetMapListFor(const shared_str& gameType)
@@ -478,7 +490,16 @@ const SGameTypeMaps& CMapListHelper::GetMapListFor(const shared_str& gameType)
     if (m_storage.size() == 0)
         Load();
     // XXX nitrocaster: always use enum for game type representation
-    return *GetMapListInt(gameType);
+    if (auto* maps = GetMapListInt(gameType))
+        return *maps;
+
+    static SGameTypeMaps empty{};
+    if (!empty.m_game_type_name.size())
+    {
+        empty.m_game_type_name = "unknown";
+        empty.m_game_type_id = eGameIDNoGame;
+    }
+    return empty;
 }
 
 SGameTypeMaps* CMapListHelper::GetMapListInt(const shared_str& gameType)
@@ -496,8 +517,16 @@ const SGameTypeMaps& CMapListHelper::GetMapListFor(const EGameIDs gameId)
     if (m_storage.size() == 0)
     {
         Load();
-        // XXX nitrocaster: is that really fatal?
-        R_ASSERT2(m_storage.size() > 0, "unable to fill map list");
+    }
+    if (m_storage.empty())
+    {
+        static SGameTypeMaps empty{};
+        if (!empty.m_game_type_name.size())
+        {
+            empty.m_game_type_name = "unknown";
+            empty.m_game_type_id = eGameIDNoGame;
+        }
+        return empty;
     }
     for (SGameTypeMaps& maps : m_storage)
     {
@@ -509,7 +538,7 @@ const SGameTypeMaps& CMapListHelper::GetMapListFor(const EGameIDs gameId)
 
 const xr_vector<MPWeatherDesc>& CMapListHelper::GetGameWeathers()
 {
-    if (m_weathers.size() == 0)
+    if (m_weathers.empty())
         Load();
     return m_weathers;
 }


### PR DESCRIPTION
Single-player should not hard-require multiplayer configuration under `gamedata/configs/mp/`.

Previously, `CMapListHelper` always loaded `$game_config$/mp/map_list.ltx` and asserted that maps/weathers were present. For SP-only installs or story mods that remove MP configs, that made startup/save-load fail and also forced expensive archive scanning.

Changes:
- Treat `mp/map_list.ltx` (and its `[weather]` section) as optional: if missing, log and keep MP map/weather lists empty.
- Remove `R_ASSERT`s and avoid dereferencing null map list entries; return an empty "unknown" map list when queried.

Notes:
- The LTX/INI loader remains strict and generic (missing `#include` targets still fail).
- `mp_ranks.ltx` is still expected for NPC weapon ranking; it is not MP-only.


Resolves #1302.