### PR TITLE
fix: `m_opt_backup_value` not being initialized in `CUICheckButton`

### DIFF
--- a/src/xrUICore/Buttons/UICheckButton.cpp
+++ b/src/xrUICore/Buttons/UICheckButton.cpp
@@ -12,6 +12,7 @@ CUICheckButton::CUICheckButton()
     TextItemControl()->SetTextAlignment(CGameFont::alLeft);
     SetButtonAsSwitch(true);
     m_pDependControl = NULL;
+    m_opt_backup_value = false;
 }
 
 void CUICheckButton::SetDependControl(CUIWindow* pWnd) { m_pDependControl = pWnd; }

--- a/src/xrUICore/Buttons/UICheckButton.cpp
+++ b/src/xrUICore/Buttons/UICheckButton.cpp
@@ -12,7 +12,6 @@ CUICheckButton::CUICheckButton()
     TextItemControl()->SetTextAlignment(CGameFont::alLeft);
     SetButtonAsSwitch(true);
     m_pDependControl = NULL;
-    m_opt_backup_value = false;
 }
 
 void CUICheckButton::SetDependControl(CUIWindow* pWnd) { m_pDependControl = pWnd; }

--- a/src/xrUICore/Buttons/UICheckButton.h
+++ b/src/xrUICore/Buttons/UICheckButton.h
@@ -34,7 +34,7 @@ public:
     pcstr GetDebugType() override { return "CUICheckButton"; }
 
 private:
-    bool m_opt_backup_value;
+    bool m_opt_backup_value{};
     void InitTexture2(LPCSTR texture_name);
     CUIWindow* m_pDependControl;
 };


### PR DESCRIPTION
This can lead to an uninitialized read when changing stuff in the options menu.

UBSAN report:
```
/mnt/data/dev/xray-16/src/xrUICore/Buttons/UICheckButton.cpp:41:57: runtime error: load of value 190, which is not a valid value for type 'bool'
    #0 0x55a834613f85 in CUICheckButton::IsChangedOptValue() const /mnt/data/dev/xray-16/src/xrUICore/Buttons/UICheckButton.cpp:41
    #1 0x55a834655f1a in CUIOptionsManager::SaveValues(shared_str const&) /mnt/data/dev/xray-16/src/xrUICore/Options/UIOptionsManager.cpp:80
    #2 0x55a8343ff50c in SaveValues /mnt/data/dev/xray-16/src/xrUICore/ui_export_script.cpp:916
    #3 0x55a8343fe183 in call /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:295
    #4 0x55a83441ab14 in call_fun<std::tuple<luabind::default_converter<CUIOptionsManager::script_register(lua_State*)::CUIOptionsManagerScript&, void>, luabind::default_converter<char const*, void> > > /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:317
    #5 0x55a83441ab14 in invoke /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:374
    #6 0x55a83441abc4 in invoke<luabind::meta::type_list<>, luabind::meta::type_list<void, CUIOptionsManager::script_register(lua_State*)::CUIOptionsManagerScript&, char const*>, void (CUIOptionsManager::script_register(lua_State*)::CUIOptionsManagerScript::*)(char const*)> /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call.hpp:392
    #7 0x55a83441abc4 in invoke_defer /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:51
    #8 0x55a83441ad88 in entry_point /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/make_function.hpp:73
    #9 0x55a83503f084 in lj_BC_FUNCC /mnt/data/dev/xray-16/bin/buildvm_x86.dasc:849
    #10 0x55a835003e45 in lua_pcall /mnt/data/dev/xray-16/Externals/LuaJIT/src/lj_api.c:1218
    #11 0x55a834f516de in luabind::detail::pcall(lua_State*, int, int) /mnt/data/dev/xray-16/Externals/luabind/src/pcall.cpp:43
    #12 0x55a82fac4470 in void luabind::detail::call_function_struct<void, luabind::meta::type_list<>, luabind::meta::index_list<1u>, 1u, &luabind::detail::pcall, true>::call<luabind::adl::object&>(lua_State*, luabind::adl::object&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_function.hpp:111
    #13 0x55a82fac456f in void luabind::call_pushed_function<void, luabind::meta::type_list<>, luabind::adl::object&>(lua_State*, luabind::adl::object&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/call_function.hpp:111
    #14 0x55a82fac45b8 in void luabind::call_function<void, luabind::meta::type_list<>, luabind::adl::object&>(luabind::adl::object const&, luabind::adl::object&) /mnt/data/dev/xray-16/Externals/luabind/src/../luabind/detail/object.hpp:146
    #15 0x55a82fac4888 in void CScriptCallbackEx<void>::operator()<>() /mnt/data/dev/xray-16/src/xrScriptEngine/script_callback_ex.h:197
    #16 0x55a82fac236b in CUIDialogWndEx::SendMessage(CUIWindow*, short, void*) /mnt/data/dev/xray-16/src/xrGame/ui/UIScriptWnd.cpp:22
    #17 0x55a834610a70 in CUIButton::OnClick() /mnt/data/dev/xray-16/src/xrUICore/Buttons/UIButton.cpp:98
    #18 0x55a83460c049 in CUI3tButton::OnClick() /mnt/data/dev/xray-16/src/xrUICore/Buttons/UI3tButton.cpp:24
    #19 0x55a834612837 in CUIButton::OnMouseAction(float, float, EUIMessages) /mnt/data/dev/xray-16/src/xrUICore/Buttons/UIButton.cpp:69
    #20 0x55a8346bb101 in CUIWindow::OnMouseAction(float, float, EUIMessages) /mnt/data/dev/xray-16/src/xrUICore/Windows/UIWindow.cpp:212
    #21 0x55a8346bb101 in CUIWindow::OnMouseAction(float, float, EUIMessages) /mnt/data/dev/xray-16/src/xrUICore/Windows/UIWindow.cpp:212
    #22 0x55a83239bee3 in CDialogHolder::IR_UIOnKeyboardRelease(int) /mnt/data/dev/xray-16/src/xrGame/UIDialogHolder.cpp:383
    #23 0x55a8319999b9 in CMainMenu::IR_OnKeyboardRelease(int) /mnt/data/dev/xray-16/src/xrGame/MainMenu.cpp:401
    #24 0x55a8319987a4 in CMainMenu::IR_OnMouseRelease(int) /mnt/data/dev/xray-16/src/xrGame/MainMenu.cpp:339
    #25 0x55a82ed3f11c in CInput::MouseUpdate() /mnt/data/dev/xray-16/src/xrEngine/xr_input.cpp:219
    #26 0x55a82ed45abb in CInput::OnFrame() /mnt/data/dev/xray-16/src/xrEngine/xr_input.cpp:775
    #27 0x55a82ed996ba in pureFrame::OnPure(pureFrame*) /mnt/data/dev/xray-16/src/xrEngine/pure.h:18
    #28 0x55a82ed996ba in MessageRegistry<pureFrame>::Process() /mnt/data/dev/xray-16/src/xrEngine/pure.h:101
    #29 0x55a82ed7a3f5 in CRenderDevice::FrameMove() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:484
    #30 0x55a82ed7aa83 in CRenderDevice::ProcessFrame() /mnt/data/dev/xray-16/src/xrEngine/device.cpp:270
    #31 0x55a82ed35b19 in CApplication::Run() /mnt/data/dev/xray-16/src/xrEngine/x_ray.cpp:433
    #32 0x55a82ec72875 in entry_point(char const*) /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:53
    #33 0x55a82ec72cfb in main /mnt/data/dev/xray-16/src/xr_3da/entry_point.cpp:109
    #34 0x7f49f4a27b8a  (/usr/lib/libc.so.6+0x27b8a) (BuildId: be49ccbe2324cfead397067d560a06640890a1f8)
    #35 0x7f49f4a27c4a in __libc_start_main (/usr/lib/libc.so.6+0x27c4a) (BuildId: be49ccbe2324cfead397067d560a06640890a1f8)
    #36 0x55a82ec726a4 in _start (/mnt/data/dev/xray-16/bin/x86_64/Debug/xr_3da+0xe7286a4) (BuildId: 7255d0e1dfa01aa2709ca2faa3ca34fe807fe3eb)
```