### PR TITLE
GitHub Actions: switch utility workflows to ubuntu-slim image

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: on new pull request
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.opened == true || github.event.pull_request.reopened == true }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -5,27 +5,33 @@ on: [push, delete, workflow_dispatch]
 jobs:
   mirror:
     if: github.repository == 'OpenXRay/xray-16'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Bitbucket.org
-        uses: pixta-dev/repository-mirroring-action@v1.1.1
+        uses: Xottab-DUTY/git-mirror@v1.0.0
         with:
-          target_repo_url: git@bitbucket.org:OpenXRay/xray-16.git
-          ssh_private_key: ${{ secrets.RABOTYAGA_BITBUCKET_PRIVATE_SSH_KEY }}
+          target: git@bitbucket.org:OpenXRay/xray-16.git
+          password: ${{ secrets.RABOTYAGA_BITBUCKET_PRIVATE_SSH_KEY }}
+          push_args: "--tags --prune --force"
+          refspec: "refs/remotes/origin/*:refs/heads/*"
 
       - name: gitflic.ru
-        uses: pixta-dev/repository-mirroring-action@v1.1.1
+        uses: Xottab-DUTY/git-mirror@v1.0.0
         with:
-          target_repo_url: git@gitflic.ru:openxray/xray-16.git
-          ssh_private_key: ${{ secrets.GITFLIC_PRIVATE_SSH_KEY }}
+          target: git@gitflic.ru:openxray/xray-16.git
+          password: ${{ secrets.GITFLIC_PRIVATE_SSH_KEY }}
+          push_args: "--tags --prune --force"
+          refspec: "refs/remotes/origin/*:refs/heads/*"
 
       - name: abf.io
         continue-on-error: true
-        uses: pixta-dev/repository-mirroring-action@v1.1.1
+        uses: Xottab-DUTY/git-mirror@v1.0.0
         with:
-          target_repo_url: git@abf.io:openxray/xray-16.git
-          ssh_private_key: ${{ secrets.ABF_IO_PRIVATE_SSH_KEY }}
+          target: git@abf.io:openxray/xray-16.git
+          password: ${{ secrets.ABF_IO_PRIVATE_SSH_KEY }}
+          push_args: "--tags --prune --force"
+          refspec: "refs/remotes/origin/*:refs/heads/*"


### PR DESCRIPTION
I think `ubuntu-slim` should be slightly faster to start up because they are lightweight containers.
Another thing is unified file system, which could possibly be used to our advantage.

> Single-CPU GitHub-hosted runners are available in both public and private repositories. These runners — specified using the workflow label `ubuntu-slim` — offer a lower-cost option for running lightweight operations. This type of runner is optimized for automation tasks, issue operations and short-running jobs. They are not suitable for typical heavyweight CI/CD builds.
> `ubuntu-slim` runners execute Actions workflows in Ubuntu Linux, inside a container rather than a full VM instance. When the job begins, GitHub automatically provisions a new container for that job. All steps in the job execute in the container, allowing the steps in that job to share information using the runner's file system. When the job has finished, the container is automatically decommissioned. Each container provides hypervisor level 2 isolation.[^1]

[^1]:https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners