### PR TITLE
fix: PDA filters `QuestNpcs` and `PrimaryObjects` being swapped

### DIFF
--- a/src/xrGame/ui/UIMapFilters.cpp
+++ b/src/xrGame/ui/UIMapFilters.cpp
@@ -15,9 +15,9 @@ bool CUIMapFilters::Init(CUIXml& xml)
     constexpr std::tuple<eSpotsFilter, pcstr> filters[] =
     {
         { Treasures,      "filter_treasures" },
-        { QuestNpcs,      "filter_primary_objects" },
+        { QuestNpcs,      "filter_quest_npcs" },
         { SecondaryTasks, "filter_secondary_tasks" },
-        { PrimaryObjects, "filter_quest_npcs" },
+        { PrimaryObjects, "filter_primary_objects" },
     };
 
     for (const auto& [filter_id, filter_section] : filters)


### PR DESCRIPTION
Seems like this was introduced in the c291bccbafbab9cad8c599c6671d2998ad8f3c58 commit.

Fixes #2072