### PR TITLE
ALife graph registry robustness (#2058)

### DIFF
--- a/src/xrGame/alife_graph_registry.cpp
+++ b/src/xrGame/alife_graph_registry.cpp
@@ -176,7 +176,27 @@ void CALifeGraphRegistry::add(CSE_ALifeDynamicObject* object, GameGraph::_GRAPH_
     if (!object->m_bOnline && object->used_ai_locations() /**&& object->interactive()**/)
     {
         VERIFY(ai().game_graph().valid_vertex_id(game_vertex_id));
-        m_objects[game_vertex_id].objects().add(object->ID, object);
+        OBJECT_REGISTRY& target = m_objects[game_vertex_id].objects();
+        const auto& target_map = target.objects();
+        const auto existing_at_target = target_map.find(object->ID);
+        const bool already_registered_here =
+            (existing_at_target != target_map.end() && existing_at_target->second == object);
+
+        if (!already_registered_here)
+        {
+            const GameGraph::_GRAPH_ID vertex_count = (GameGraph::_GRAPH_ID)m_objects.size();
+            for (GameGraph::_GRAPH_ID i = 0; i < vertex_count; ++i)
+            {
+                if (!ai().game_graph().valid_vertex_id(i))
+                    continue;
+                OBJECT_REGISTRY& reg = m_objects[i].objects();
+                const auto& om = reg.objects();
+                if (om.find(object->ID) == om.end())
+                    continue;
+                reg.remove(object->ID, true);
+            }
+            target.add(object->ID, object);
+        }
         object->m_tGraphID = game_vertex_id;
     }
     else if (!m_level && update)
@@ -191,6 +211,7 @@ void CALifeGraphRegistry::add(CSE_ALifeDynamicObject* object, GameGraph::_GRAPH_
 
 void CALifeGraphRegistry::remove(CSE_ALifeDynamicObject* object, GameGraph::_GRAPH_ID game_vertex_id, bool update)
 {
+    bool removed_from_graph = false;
     if (object->used_ai_locations() /**&& object->interactive()**/)
     {
 #ifdef DEBUG
@@ -200,8 +221,51 @@ void CALifeGraphRegistry::remove(CSE_ALifeDynamicObject* object, GameGraph::_GRA
                 game_vertex_id);
         }
 #endif
-        m_objects[game_vertex_id].objects().remove(object->ID);
+        if (ai().game_graph().valid_vertex_id(game_vertex_id))
+        {
+            OBJECT_REGISTRY& primary = m_objects[game_vertex_id].objects();
+            const auto& primary_map = primary.objects();
+            if (primary_map.find(object->ID) != primary_map.end())
+            {
+                primary.remove(object->ID);
+                removed_from_graph = true;
+            }
+        }
+        if (!removed_from_graph)
+        {
+            const GameGraph::_GRAPH_ID vertex_count = (GameGraph::_GRAPH_ID)m_objects.size();
+            for (GameGraph::_GRAPH_ID i = 0; i < vertex_count; ++i)
+            {
+                if (!ai().game_graph().valid_vertex_id(i))
+                    continue;
+                if (i == game_vertex_id)
+                    continue;
+                OBJECT_REGISTRY& reg = m_objects[i].objects();
+                const auto& om = reg.objects();
+                if (om.find(object->ID) == om.end())
+                    continue;
+                reg.remove(object->ID);
+                removed_from_graph = true;
+#ifndef MASTER_GOLD
+                Msg("! [ALife] graph registry: object [%s][%d] was at vertex %u, not at m_tGraphID %u — removed from "
+                    "actual vertex",
+                    object->name_replace(), object->ID, i, game_vertex_id);
+#endif
+                break;
+            }
+        }
+#ifndef MASTER_GOLD
+        if (!removed_from_graph)
+            Msg("! [ALife] graph registry: remove [%s][%d] — not in any vertex map (expected %u), continuing",
+                object->name_replace(), object->ID, game_vertex_id);
+#endif
     }
     if (update && m_level)
-        level().remove(object, ai().game_graph().vertex(game_vertex_id)->level_id() != level().level_id());
+    {
+        bool level_no_assert =
+            ai().game_graph().vertex(game_vertex_id)->level_id() != level().level_id();
+        if (object->used_ai_locations() && !removed_from_graph)
+            level_no_assert = true;
+        level().remove(object, level_no_assert);
+    }
 }

--- a/src/xrGame/ui/UIMapList.h
+++ b/src/xrGame/ui/UIMapList.h
@@ -76,6 +76,8 @@ private:
     {
         shared_str weather_name;
         shared_str weather_time;
+        Sw() = default;
+        Sw(const shared_str& wname, const shared_str& wtime) : weather_name(wname), weather_time(wtime) {}
     };
     xr_vector<Sw> m_mapWeather;
     xr_string m_command;


### PR DESCRIPTION
ALife graph registry (alife_graph_registry.cpp)
CoC ends up calling teleport_object from Lua in situations where the NPC is no longer in the graph cell that matches m_tGraphID. The engine then hit CSafeMapIterator::remove with “object not in registry” and died. I made remove look for the id on all graph vertices, and if it’s nowhere, skip the graph remove instead of asserting. Same situation could leave you with a strict level().remove on an empty level registry, so when the graph remove didn’t actually remove anything, the level remove is done with no_assert.

On disconnect I also saw the opposite: add blowing up with “already in registry” when se_monster’s on_unregister (or whatever runs during teardown) tried to register again while the object was still listed. add is now safe in that case: if the same pointer is already in the target vertex we no-op; otherwise we strip that id from every vertex once and then insert.

Refs #2058 (same class of CoC + ALife weirdness).

Key bindings for Lua (key_binding_registrator_script.cpp + key_binding_dik_lua.inl)
AXR’s axr_keybind does key_bindings["DIK_…"] for values coming from config. In OpenXRay those scan codes only lived on DIK_keys, so Lua died with no static 'DIK_NUMPADENTER' in class 'key_bindings'. I mirrored the same value(...) list onto key_bindings via a shared include so we don’t maintain two divergent copies. Also fixed the stray ) in DIK_KBDILLUMTOGGLE’s string while at it.