### PR TITLE
Fix PDA task icons: enable icons for additional tasks and restore texture rendering

### DIFF
--- a/src/xrGame/ui/UITaskWnd.cpp
+++ b/src/xrGame/ui/UITaskWnd.cpp
@@ -441,6 +441,7 @@ void CUITaskItem::InitTask(CGameTask* task)
     {
         if (task)
         {
+            S->TextureOn();
             S->InitTexture(task->m_icon_texture_name.c_str());
             S->SetStretchTexture(true);
             m_info["t_icon_over"]->Show(true);

--- a/src/xrGame/ui/map_hint.cpp
+++ b/src/xrGame/ui/map_hint.cpp
@@ -173,20 +173,31 @@ void CUIMapLocationHint::SetInfoTask(CGameTask* task)
     }
     else if (task->GetTaskType() == eTaskTypeAdditional)
     {
-        m_info["t_icon"]->Show(false);
-        float w = m_info["t_hint_text"]->GetWidth();
+        // Иконка побочного задания
+        m_info["t_icon"]->Show(true);
 
-        Fvector2 pos = m_info["t_caption"]->GetWndPos();
+        // Ширина рамки под описание задания (выравнивается по строке времени t_time)
+        float w = m_info["t_time"]->GetWidth();
+
+        // Расположение иконки побочного задания слева
+        Fvector2 pos = m_info["t_icon"]->GetWndPos();
         pos.x = m_posx_icon;
+        m_info["t_icon"]->SetWndPos(pos);
+
+        // Заголовок справа от иконки
+        pos = m_info["t_caption"]->GetWndPos();
+        pos.x = m_posx_caption;
         m_info["t_caption"]->SetWndPos(pos);
         m_info["t_caption"]->SetWidth(w);
 
+        // Время
         pos = m_info["t_time"]->GetWndPos();
-        pos.x = m_posx_icon;
+        pos.x = m_posx_caption;
         m_info["t_time"]->SetWndPos(pos);
 
+        // Сколько осталось времени
         pos = m_info["t_time_rem"]->GetWndPos();
-        pos.x = m_posx_icon;
+        pos.x = m_posx_caption;
         m_info["t_time_rem"]->SetWndPos(pos);
     }
 


### PR DESCRIPTION
Fix PDA task icons for additional tasks and after task switch

Closes #2086 

### Summary
- Enable icons for additional tasks
- Fix UIStatic texture not rendering after TextureOff()

### Result
- Icons always render correctly
- Layout consistent