### PR TITLE
[FIX] Avoid multiplied hud release callback calls.

### DIFF
--- a/src/xrEngine/xr_object_list.cpp
+++ b/src/xrEngine/xr_object_list.cpp
@@ -322,7 +322,9 @@ void CObjectList::Update(bool bForce)
         {
             VERIFY(*(*it).m_ID == (it - m_relcase_callbacks.begin()));
             for (auto& dit : destroy_queue)
+            {
                 (*it).m_Callback(dit);
+            }
         }
 
         // Notify HUD once per destroyed object:

--- a/src/xrEngine/xr_object_list.cpp
+++ b/src/xrEngine/xr_object_list.cpp
@@ -322,10 +322,13 @@ void CObjectList::Update(bool bForce)
         {
             VERIFY(*(*it).m_ID == (it - m_relcase_callbacks.begin()));
             for (auto& dit : destroy_queue)
-            {
                 (*it).m_Callback(dit);
-                g_pGameLevel->pHUD->net_Relcase(dit);
-            }
+        }
+
+        // Notify HUD once per destroyed object:
+        for (auto& dit : destroy_queue)
+        {
+            g_pGameLevel->pHUD->net_Relcase(dit);
         }
 
         // Destroy


### PR DESCRIPTION
### Changes

- Hoists `g_pGameLevel->pHUD->net_Relcase(dit)` out of the relcase callbacks loop into its own loop over `destroy_queue` in `CObjectList::Update`.

### Notes

-  The HUD notification was nested inside the `m_relcase_callbacks` iteration in `CObjectList::Update`, so `pHUD->net_Relcase` executed `registered callbacks × destroyed objects` times. Profiling a regular Call of Pripyat session with Tracy showed 847,150 `CHUDManager::net_Relcase` calls for 1,747 destroyed objects (~485 registered relcase callbacks).
- The misplacement predates OpenXRay .
- `CHUDManager::net_Relcase` only drops cached references to the destroyed object (`HitMarker`, `m_pHUDTarget`), so moving it after the callbacks loop is order-independent.
- Edge-case behavior change: with zero registered relcase callbacks the HUD was previously never notified at all; it is now always notified once per destroyed object.
