### PR TITLE
[FIX] Optimize spatial sector detection by skipping updates.

### DIFF
--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -830,7 +830,9 @@ void R_dsgraph_structure::build_subspace()
         for (u32 o_it = 0; o_it < lstRenderables.size(); o_it++)
         {
             ISpatial* spatial = lstRenderables[o_it];
-            if (o.is_main_pass)
+            // Re-detect the sector only when it was invalidated by a move (spatial_move). Static objects keep
+            // their cached sector and skip the 2 ray_query casts entirely - this is the bulk of per-frame rays.
+            if (o.is_main_pass && (spatial->GetSpatialData().type & STYPEFLAG_INVALIDSECTOR))
             {
                 const auto& entity_pos = spatial->spatial_sector_point();
                 const auto sector_id = detect_sector(entity_pos);

--- a/src/Layers/xrRender_R2/r2_R_calculate.cpp
+++ b/src/Layers/xrRender_R2/r2_R_calculate.cpp
@@ -114,8 +114,12 @@ void CRender::Calculate()
     g_pGamePersistent->SpatialSpace.q_sphere(spatial_lights, 0, STYPE_LIGHTSOURCE, Device.vCameraPosition, EPS_L);
     for (auto spatial : spatial_lights)
     {
-        const auto& entity_pos = spatial->spatial_sector_point();
-        spatial->spatial_updatesector(dsgraph_main.detect_sector(entity_pos));
+        if (spatial->GetSpatialData().type & STYPEFLAG_INVALIDSECTOR)
+        {
+            const auto& entity_pos = spatial->spatial_sector_point();
+            spatial->spatial_updatesector(dsgraph_main.detect_sector(entity_pos));
+        }
+
         const auto sector_id = spatial->GetSpatialData().sector_id;
         if (sector_id == IRender_Sector::INVALID_SECTOR_ID)
             continue; // disassociated from S/P structure

--- a/src/xrCDB/ISpatial.cpp
+++ b/src/xrCDB/ISpatial.cpp
@@ -100,8 +100,13 @@ void SpatialBase::spatial_move()
     ZoneScoped;
     if (spatial.node_ptr)
     {
-        //*** somehow it was determined that object has been moved
-        spatial.type |= STYPEFLAG_INVALIDSECTOR;
+        //*** invalidate the cached sector only on a meaningful move, so stationary/jittering
+        //*** objects don't force a per-frame sector raycast (see r__dsgraph_build sector detection)
+        //*** adopted from xray-monolith
+        if (last_sector_point.distance_to_sqr(spatial_sector_point()) > 1.f)
+        {
+            spatial.type |= STYPEFLAG_INVALIDSECTOR;
+        }
 
         //*** check if we are supposed to correct it's spatial location
         if (spatial_inside())
@@ -119,6 +124,7 @@ void SpatialBase::spatial_move()
 void SpatialBase::spatial_updatesector_internal(IRender_Sector::sector_id_t sector_id)
 {
     ZoneScoped;
+    last_sector_point = spatial_sector_point();
     spatial.type &= ~STYPEFLAG_INVALIDSECTOR;
     if (sector_id != IRender_Sector::INVALID_SECTOR_ID)
         spatial.sector_id = sector_id;

--- a/src/xrCDB/ISpatial.h
+++ b/src/xrCDB/ISpatial.h
@@ -137,6 +137,8 @@ public:
     SpatialData spatial;
 
 private:
+    // Point at which the sector was last (re)detected.
+    Fvector last_sector_point{};
     void spatial_updatesector_internal(IRender_Sector::sector_id_t sector_id);
 
 public:


### PR DESCRIPTION
### Changes

- Gates `detect_sector()` behind `STYPEFLAG_INVALIDSECTOR` in `R_dsgraph_structure::build_subspace()` (renderables) and `CRender::Calculate()` (near-camera lights); unmoved objects skip both ray casts.
- `SpatialBase::spatial_move()` raises `STYPEFLAG_INVALIDSECTOR` only when the object moved more than 1m from its last detection point.
- Adds `SpatialBase::last_sector_point`, recorded in `spatial_updatesector_internal()`, to drive the move threshold.

### Notes

- Bring back previous condition check + introduce [spatial move invalidation from xray-monilith](https://github.com/themrdemonized/xray-monolith/blob/78d398f055211b4243d78e297d33edd597bd8bde/src/xrCDB/ISpatial.cpp#L106C30-L106C58)
- **Root cause.** #1311 (`a8d9187`, "xrRender: `detectSector` moved into dsgraph") moved the sector raycast out of the flag-guarded `SpatialBase::spatial_updatesector_internal()` and into the callers in `R_dsgraph_structure::build_subspace()` and `CRender::Calculate()`, where it now runs before the `STYPEFLAG_INVALIDSECTOR` check. The guard still exists but only skips storing an already-computed result — so every visible renderable and every near-camera light issues 2 `CDB::COLLIDER::ray_query` casts on every main pass, even when its sector has not changed. Before #1311 the arg-less `spatial_updatesector()` bailed on the flag and never raycast for objects whose sector was still valid.
- **Fix.** Restores the `STYPEFLAG_INVALIDSECTOR` gate at both call sites, and raises the flag in `spatial_move()` only when the object moved a meaningful distance, so static world geometry and stationary lights reuse their cached sector.
- **Profiling (in-game level scene).** `CDB::COLLIDER::ray_query` drops from **~604 to ~129 calls/frame (−79%)**.
- **Behavioral tradeoff.** An object that moves less than 1 m² between frames reuses its cached render sector for that frame. Sectors are room-sized, so this is imperceptible and matches the pre-#1311 flag-gated behavior. The actor/view-entity shadow path in `build_subspace()` is intentionally left unconditional (single object, negligible cost, avoids any stale-sector risk on the player shadow).

### Links

Fixes issue introduced in https://github.com/OpenXRay/xray-16/pull/1311