### PR TITLE
[LUA] Add `eInventoryInfoRemoved` callback for inventory info updates.

### DIFF
--- a/src/xrGame/actor_communication.cpp
+++ b/src/xrGame/actor_communication.cpp
@@ -163,7 +163,14 @@ bool CActor::OnReceiveInfo(shared_str info_id) const
 
 void CActor::OnDisableInfo(shared_str info_id) const
 {
+    const bool wasPresent = HasInfo(info_id);
+
     CInventoryOwner::OnDisableInfo(info_id);
+
+    if (wasPresent)
+    {
+        callback(GameObject::eInventoryInfoRemoved)(lua_game_object(), info_id.c_str());
+    }
 
     if (!CurrentGameUI())
         return;

--- a/src/xrGame/game_object_space.h
+++ b/src/xrGame/game_object_space.h
@@ -81,6 +81,8 @@ enum ECallbackType : u32
     eControllerAttitudeChange,
 
     // X-Ray Extensions:
+    eInventoryInfoRemoved,
+
     eKeyPress   = 123,
     eKeyRelease = 124,
     eKeyHold    = 125,

--- a/src/xrGame/script_game_object_script.cpp
+++ b/src/xrGame/script_game_object_script.cpp
@@ -71,6 +71,7 @@ void CScriptGameObject::script_register(lua_State* luaState)
                 value("patrol_path_in_point", int(GameObject::ePatrolPathInPoint)),
                 value("inventory_pda", int(GameObject::eInventoryPda)),
                 value("inventory_info", int(GameObject::eInventoryInfo)),
+                value("inventory_info_removed", int(GameObject::eInventoryInfoRemoved)),
                 value("article_info", int(GameObject::eArticleInfo)),
                 value("task_state", int(GameObject::eTaskStateChange)),
                 value("map_location_added", int(GameObject::eMapLocationAdded)),


### PR DESCRIPTION
### Changes

- Add callback when actor infoportion is removed.

### Reason

- Useful for cache invalidation on lua side.
- Corresponding event for `eInventoryInfo`.