### PR TITLE
[FIX] Fix sound truncated / restarted from 0 after unpause.

### DIFF
--- a/src/xrSound/SoundRender_Emitter.cpp
+++ b/src/xrSound/SoundRender_Emitter.cpp
@@ -276,6 +276,13 @@ void CSoundRender_Emitter::dispatch_prefill()
     prefill_task.store(task, std::memory_order_release);
 }
 
+void CSoundRender_Emitter::discard_prefilled_blocks()
+{
+    wait_prefill();
+    current_block = 0;
+    filled_blocks = 0;
+}
+
 void CSoundRender_Emitter::wait_prefill() const
 {
     if (const auto task = prefill_task.load(std::memory_order_acquire))

--- a/src/xrSound/SoundRender_Emitter.h
+++ b/src/xrSound/SoundRender_Emitter.h
@@ -92,6 +92,7 @@ private:
 
     void fill_all_blocks();
     void dispatch_prefill();
+    void discard_prefilled_blocks();
 
     void wait_prefill() const;
 

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -113,6 +113,7 @@ void CSoundRender_Emitter::update(float fTime, float dt)
         if (iPaused)
         {
             stop_target();
+            discard_prefilled_blocks();
             m_current_state = stSimulating;
             fTimeStarted += dt;
             fTimeToStop += dt;
@@ -178,6 +179,7 @@ void CSoundRender_Emitter::update(float fTime, float dt)
         if (iPaused)
         {
             stop_target();
+            discard_prefilled_blocks();
             m_current_state = stSimulatingLooped;
             fTimeStarted += dt;
             fTimeToPropagade += dt;


### PR DESCRIPTION
### Notes

- The reset waits for any active prefill task before invalidating the queue, so resume refills PCM blocks from the recalculated playback cursor.
- Local testing confirms paused NPC speech resumes and completes correctly.

### Changes

- Adds `discard_prefilled_blocks()` for emitter-owned PCM prefetch state.
- Clears stale prefilled blocks after a target is stopped for pause.
- Applies the reset to both non-looped and looped paused emitters.

### Cause

- [b40433b19278aeb42bc3f20037e999d57bef44eb](https://github.com/OpenXRay/xray-16/commit/b40433b19278aeb42bc3f20037e999d57bef44eb) moved streaming and prefilled buffers into `CSoundRender_Emitter`. The pause path stops the target but left that emitter-owned queue valid.
- On resume, playback recalculated its cursor but could reuse already-filled blocks, replaying stale audio while the original stop deadline continued to run.
- [ace91982d73fd2d4d93662b88f6d80028a65f4a7](https://github.com/OpenXRay/xray-16/commit/ace91982d73fd2d4d93662b88f6d80028a65f4a7) made `stop_target()` close the Ogg handle and lazily reopen it during refilling, further coupling pause/resume correctness to invalidating the prefill queue.

### Additional context

- Reproduce by pausing an NPC voice line mid-playback, then resuming.
- Expected: the line resumes from its pause position and plays to completion.