### PR TITLE
[FIX] Corrected limbs shift calculation in IKLimb.

### DIFF
--- a/src/xrGame/IKLimbsController.cpp
+++ b/src/xrGame/IKLimbsController.cpp
@@ -94,7 +94,7 @@ float CIKLimbsController::LegLengthShiftLimit(float current_shift, const SCalcul
         if (cd[j].state.foot_step)
         {
             float s_down = cd[j].m_limb->ObjShiftDown(current_shift, cd[j]);
-            if (shift_down < s_down)
+            if (_valid(s_down) && shift_down < s_down)
                 shift_down = s_down;
         }
     return shift_down;
@@ -102,7 +102,16 @@ float CIKLimbsController::LegLengthShiftLimit(float current_shift, const SCalcul
 static const float static_shift_object_speed = .2f;
 float CIKLimbsController::StaticObjectShift(const SCalculateData cd[max_size])
 {
-    const float current_shift = _object_shift.shift();
+    float current_shift = _object_shift.shift();
+
+    if (!_valid(current_shift))
+    {
+#ifdef DEBUG
+        Msg("! IK: reset invalid object shift for %s", m_object->cName().c_str());
+#endif
+        _object_shift.reset();
+        current_shift = 0.f;
+    }
 
     u16 cnt = 0;
     float shift_up = 0;
@@ -111,7 +120,7 @@ float CIKLimbsController::StaticObjectShift(const SCalculateData cd[max_size])
         if (cd[j].state.foot_step)
         {
             float s_up = cd[j].cl_shift.y + current_shift;
-            if (0.f < s_up)
+            if (_valid(s_up) && 0.f < s_up)
             {
                 shift_up += s_up;
                 ++cnt;
@@ -127,7 +136,17 @@ float CIKLimbsController::StaticObjectShift(const SCalculateData cd[max_size])
         shift = -shift_down;
     else
         shift = shift_up;
-    VERIFY(_valid(shift));
+
+    if (!_valid(shift))
+    {
+#ifdef DEBUG
+        Msg("! IK: reset invalid object shift for %s", m_object->cName().c_str());
+#endif
+        _object_shift.reset();
+
+        return 0.f;
+    }
+
     _object_shift.set_taget(shift, _abs(current_shift - shift) / static_shift_object_speed);
     return shift;
 }

--- a/src/xrGame/ik/IKLimb.cpp
+++ b/src/xrGame/ik/IKLimb.cpp
@@ -946,7 +946,7 @@ float CIKLimb::ObjShiftDown(float current_shift, const SCalculateData& cd) const
     Fvector g;
     g.sub(m_foot.ref_bone_to_foot(m, cd.state.goal.get()).c, hip);
     float l = m_limb.Length();
-    return -g.y - _sqrt(l * l - g.x * g.x - g.z * g.z);
+    return -g.y - _sqrt(std::clamp(l * l - g.x * g.x - g.z * g.z, 0.f, l * l));
 }
 
 float CIKLimb::get_time_to_step_begin(const CBlend& B) const

--- a/src/xrGame/ik_object_shift.cpp
+++ b/src/xrGame/ik_object_shift.cpp
@@ -121,6 +121,17 @@ bool square_equation(float a, float b, float c, float& x0, float& x1) // returns
 float half_shift_restrict_up = 0.1f;
 float half_shift_restrict_down = 0.15f;
 
+void object_shift::reset()
+{
+    current = 0.f;
+    taget = 0.f;
+    taget_time = Device.fTimeGlobal;
+    current_time = Device.fTimeGlobal;
+    speed = 0.f;
+    accel = 0.f;
+    aaccel = 0.f;
+}
+
 void object_shift::set_taget(float taget_, float time)
 {
     if (b_freeze)

--- a/src/xrGame/ik_object_shift.h
+++ b/src/xrGame/ik_object_shift.h
@@ -16,6 +16,7 @@ class object_shift
 
 public:
     object_shift() = default;
+    void reset();
     void set_taget(float taget, float time);
     float shift() const;
     void freeze(bool v) { b_freeze = v; }


### PR DESCRIPTION
### Notes

- Treats an unreachable foot goal as a fully extended leg instead of allowing the square-root input to become negative.

### Changes

- Clamps the IK leg-reach radicand before calculating the downward shift.
- Ignores non-finite upward and downward limb-shift constraints.
- Resets invalid persistent `object_shift` state and returns a zero shift.
- Logs IK shift-state recovery in debug builds.

### Context

- Annoyed me since I compiled openxray first time.
- Verified with mixed build - skadovsk is good place to check it with ramps/stairs/doors etc.
- Removed `verify`, but added logs just in case. I think we can move it back to debug mode popup if anyone has preferences.