### PR TITLE
[FIX] Normalize explosive hit direction

### DIFF
--- a/src/xrGame/Explosive.cpp
+++ b/src/xrGame/Explosive.cpp
@@ -696,11 +696,18 @@ void CExplosive::ExplodeWaveProcessObject(collide::rq_results& storage, CPhysics
         Fvector l_dir;
         l_dir.sub(l_goPos, m_vExplodePos);
 
-        float rmag = _sqrt(m_fUpThrowFactor * m_fUpThrowFactor + 1.f + 2.f * m_fUpThrowFactor * l_dir.y);
+        if (_valid(l_dir) && l_dir.square_magnitude() > EPS)
+            l_dir.normalize();
+        else
+            l_dir.set(0.f, 1.f, 0.f);
+
         l_dir.y += m_fUpThrowFactor;
-        // rmag -модуль l_dir после l_dir.y += m_fUpThrowFactor,
-        // модуль=_sqrt(l_dir^2+y^2+2.*(l_dir,y)),y=(0,m_fUpThrowFactor,0) (до этого модуль l_dir =1)
-        l_dir.mul(1.f / rmag); //перенормировка
+
+        if (_valid(l_dir) && l_dir.square_magnitude() > EPS)
+            l_dir.normalize();
+        else
+            l_dir.set(0.f, 1.f, 0.f);
+
         NET_Packet P;
         SHit HS;
         HS.GenHeader(GE_HIT, l_pGO->ID()); //		cast_game_object()->u_EventGen		(P,GE_HIT,l_pGO->ID());


### PR DESCRIPTION
### Notes

- Cause: explosion code applied its upward-bias formula to an unnormalized explosion-to-target vector, despite assuming a unit vector. A target sufficiently below an RGD-5/F1 explosion could produce a negative square-root input, resulting in a `NaN` direction and a debug `pvCompress` assertion.
- The upward impulse component is now consistent across target distances. This can make distant targets receive a more noticeable upward push.

### Changes

- Normalizes the radial explosion-to-target direction before applying `up_throw_factor`.
- Normalizes the final hit direction before serializing `SHit`.
- Uses an upward direction fallback for invalid, coincident, or cancelling vectors.

### Additional context

- Reproduced when had a lot of grenades thrown near Skadovsk (height variance here allows to reproduce such cases).
- Tested proposed normalization fix in a same place with 50+- grenades thrown with ~10 squads.