### PR TITLE
[FIX] Fix false-positive constant buffer unregister errors and noisy log.

### DIFF
--- a/src/Layers/xrRenderDX11/dx11ConstantBuffer.cpp
+++ b/src/Layers/xrRenderDX11/dx11ConstantBuffer.cpp
@@ -7,10 +7,12 @@ namespace xray::render::RENDER_NAMESPACE
 {
 dx11ConstantBuffer::~dx11ConstantBuffer()
 {
-    for (int id = 0; id < R__NUM_CONTEXTS; ++id)
+    if (dwFlags & xr_resource_flagged::RF_REGISTERED)
     {
-        RImplementation.Resources->_DeleteConstantBuffer(id, this);
+        VERIFY(m_context_id < R__NUM_CONTEXTS);
+        RImplementation.Resources->_DeleteConstantBuffer(m_context_id, this);
     }
+
     //	Flush();
     _RELEASE(m_pBuffer);
     xr_free(m_pBufferData);

--- a/src/Layers/xrRenderDX11/dx11ConstantBuffer.h
+++ b/src/Layers/xrRenderDX11/dx11ConstantBuffer.h
@@ -13,7 +13,11 @@ public:
 
     bool Similar(dx11ConstantBuffer& _in);
     ID3DBuffer* GetBuffer() { return m_pBuffer; }
+    pcstr GetBufferName() const { return m_strBufferName.c_str(); }
     void Flush(u32 context_id);
+
+    // Context registry the buffer belongs to
+    u32 m_context_id{ u32(-1) };
 
     //	Set copy data into constant buffer
     //	Plain buffer member

--- a/src/Layers/xrRenderDX11/dx11ResourceManager_Resources.cpp
+++ b/src/Layers/xrRenderDX11/dx11ResourceManager_Resources.cpp
@@ -174,6 +174,7 @@ dx11ConstantBuffer* CResourceManager::_CreateConstantBuffer(u32 context_id, ID3D
         }
     }
 
+    pTempBuffer->m_context_id = context_id;
     pTempBuffer->dwFlags |= xr_resource_flagged::RF_REGISTERED;
     v_constant_buffer[context_id].emplace_back(pTempBuffer);
     return pTempBuffer;
@@ -186,7 +187,8 @@ void CResourceManager::_DeleteConstantBuffer(u32 context_id, const dx11ConstantB
     if (reclaim(v_constant_buffer[context_id], pBuffer))
         return;
 #ifndef MASTER_GOLD
-    Msg("! ERROR: Failed to find compiled constant buffer");
+    Msg("! ERROR: Failed to find compiled constant buffer '%s' in context [%u]",
+        pBuffer->GetBufferName(), context_id);
 #endif
 }
 


### PR DESCRIPTION
### Notes

- Since the parallel render contexts refactor, `dx11ConstantBuffer` is registered in exactly one  per-context registry, but its destructor attempted to unregister from all `R__NUM_CONTEXTS`  registries. Every destroyed buffer produced guaranteed misses in the remaining registries, flooding the log with thousands of `! ERROR: Failed to find compiled constant buffer` lines on level unload and renderer teardown — all false positives. With the owning context tracked, the error can only fire on genuine registry corruption.
- Removes 6,680 false positive logs from log file that are appended on game shutdown.

### Changes

- Adds `m_context_id` to `dx11ConstantBuffer`, stamped by `CResourceManager::_CreateConstantBuffer` at registration time.
- Replaces the destructor's all-contexts unregister loop with a single targeted `_DeleteConstantBuffer(m_context_id, this)` call, guarded by `RF_REGISTERED` and a `VERIFY` on  the context id.
- Extends the failed-unregister error message with the buffer name and context id; adds a `GetBufferName()` accessor.

### Links

Introduced as side effect with https://github.com/OpenXRay/xray-16/pull/1331